### PR TITLE
Fix npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,9 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Check if version already published
         id: version-check
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.0-beta.3
+
+- Fix npm trusted publishing (requires npm >= 11.5.1 for OIDC token exchange)
+- Bun runtime guards on MCP server and installer
+- Installer writes `bunx` commands for npm installs
+- Dev → main branch workflow with auto-publish
+
+## 0.1.0-beta.2
+
+(Failed publish — provenance signed but npm OIDC exchange required npm >= 11.5.1)
+
 ## 0.1.0-beta.1
 
 Initial beta release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-zk-kb",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "description": "MCP server for persistent Zettelkasten-based knowledge management",
   "type": "module",
   "main": "dist/mcp-server.js",


### PR DESCRIPTION
## Summary

- Upgrade npm to latest in publish workflow (OIDC token exchange requires npm >= 11.5.1)
- Bump to 0.1.0-beta.3

## Root Cause

Node 22 ships with npm ~10.x which signs provenance but fails the OIDC token exchange, resulting in a 404 on `npm publish`. Adding `npm install -g npm@latest` before publish resolves this.

## Changes

- `.github/workflows/publish.yml`: Add `npm install -g npm@latest` step
- `package.json`: Bump version to 0.1.0-beta.3
- `CHANGELOG.md`: Add beta.3 and beta.2 entries