### PR TITLE
Fix prerelease publish tag and bin permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,11 @@ jobs:
         run: |
           LOCAL_VERSION=$(node -p "require('./package.json').version")
           echo "local_version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+          if echo "$LOCAL_VERSION" | grep -qE '(alpha|beta|rc)'; then
+            echo "tag=beta" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
           PUBLISHED=$(npm view open-zk-kb@"$LOCAL_VERSION" version 2>/dev/null || echo "")
           if [ "$PUBLISHED" = "$LOCAL_VERSION" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -58,9 +63,13 @@ jobs:
         if: steps.version-check.outputs.skip == 'false'
         run: bun test
 
+      - name: Prepare bin scripts
+        if: steps.version-check.outputs.skip == 'false'
+        run: chmod +x dist/setup.js dist/mcp-server.js
+
       - name: Publish
         if: steps.version-check.outputs.skip == 'false'
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag ${{ steps.version-check.outputs.tag }}
 
       - name: Create GitHub Release
         if: steps.version-check.outputs.skip == 'false'
@@ -71,8 +80,12 @@ jobs:
           TAG="v$VERSION"
           git tag "$TAG"
           git push origin "$TAG"
+          PRERELEASE_FLAG=""
+          if [ "${{ steps.version-check.outputs.tag }}" != "latest" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
           gh release create "$TAG" \
             --title "$TAG" \
             --notes "**Install:** \`bunx open-zk-kb@$VERSION\`
           **npm:** https://www.npmjs.com/package/open-zk-kb/v/$VERSION" \
-            --latest
+            $PRERELEASE_FLAG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,16 @@
 # Changelog
 
-## 0.1.0-beta.3
+## 0.1.0-beta.4
 
 - Fix npm trusted publishing (requires npm >= 11.5.1 for OIDC token exchange)
+- Fix prerelease publish requiring `--tag beta` on npm latest
 - Bun runtime guards on MCP server and installer
 - Installer writes `bunx` commands for npm installs
 - Dev → main branch workflow with auto-publish
 
-## 0.1.0-beta.2
+## 0.1.0-beta.2 / beta.3
 
-(Failed publish — provenance signed but npm OIDC exchange required npm >= 11.5.1)
+(Failed publishes — OIDC token exchange required npm >= 11.5.1, prerelease required --tag)
 
 ## 0.1.0-beta.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-zk-kb",
-  "version": "0.1.0-beta.3",
+  "version": "0.1.0-beta.4",
   "description": "MCP server for persistent Zettelkasten-based knowledge management",
   "type": "module",
   "main": "dist/mcp-server.js",


### PR DESCRIPTION
## Summary

- Add `--tag beta` for prerelease versions (npm latest requires explicit tag)
- Add `chmod +x` for bin scripts (npm latest stricter about executable bit)
- Dynamic tag detection: `beta` for alpha/beta/rc versions, `latest` for stable
- Mark prerelease GitHub releases with `--prerelease` flag
- Bump to 0.1.0-beta.4

## Root Cause

npm latest (>= 11.5.1) requires `--tag` when publishing prerelease versions. Previous attempt failed with: `You must specify a tag using --tag when publishing a prerelease version.`