### PR TITLE
Add auto-sync workflow to keep dev aligned with main

### DIFF
--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -1,0 +1,22 @@
+name: Sync dev after main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Fast-forward dev to main
+        run: |
+          git checkout dev
+          git merge main
+          git push origin dev


### PR DESCRIPTION
Adds a GitHub Action that automatically fast-forwards `dev` to `main` after each merge. This keeps the development branch up to date without manual syncing.

## How it works
- Runs on every push to `main`
- Checks out `dev`
- Merges `main` into `dev` (fast-forward)
- Pushes the updated `dev` to origin

## Note
This workflow won't run until it's merged to `main` — it activates on the first push to main after merge.