### PR TITLE
Sync versions across all files on release

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -130,3 +130,31 @@ jobs:
             exit 1
           fi
           echo "CHANGELOG.md has been updated"
+
+      - name: Verify version consistency across files
+        if: steps.scope.outputs.needs_bump == 'true'
+        run: |
+          PKG_VERSION="${{ steps.versions.outputs.head }}"
+          
+          # Check server.json root version
+          SERVER_ROOT_VERSION=$(node -p "require('./server.json').version")
+          if [ "$SERVER_ROOT_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::server.json root version ($SERVER_ROOT_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          
+          # Check server.json packages[0].version
+          SERVER_PKG_VERSION=$(node -p "require('./server.json').packages[0].version")
+          if [ "$SERVER_PKG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::server.json packages[0].version ($SERVER_PKG_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          
+          # Check SKILL.md frontmatter version
+          SKILL_VERSION=$(grep -m1 '^version:' skills/open-zk-kb/SKILL.md | sed 's/version: //')
+          if [ "$SKILL_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::skills/open-zk-kb/SKILL.md version ($SKILL_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          
+          echo "All versions consistent: $PKG_VERSION"

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -100,8 +100,12 @@ async function main(): Promise<void> {
 
   const packageFile = Bun.file('package.json');
   const changelogFile = Bun.file('CHANGELOG.md');
+  const serverJsonFile = Bun.file('server.json');
+  const skillFile = Bun.file('skills/open-zk-kb/SKILL.md');
   const packageJsonText = await packageFile.text();
   const changelogText = await changelogFile.text();
+  const serverJsonText = await serverJsonFile.text();
+  const skillText = await skillFile.text();
   const pkg = JSON.parse(packageJsonText) as { version?: string };
 
   if (!pkg.version) {
@@ -142,6 +146,16 @@ async function main(): Promise<void> {
     `"version": "${nextVersion}"`
   );
 
+  // Sync server.json versions (root version + packages[0].version)
+  const updatedServerJson = serverJsonText
+    .replace(/"version":\s*"[^"]+"/g, `"version": "${nextVersion}"`);
+
+  // Sync SKILL.md frontmatter version
+  const updatedSkillText = skillText.replace(
+    /^(---\nname: open-zk-kb\nversion: )[^\n]+/m,
+    `$1${nextVersion}`
+  );
+
   p.log.step(`Version: ${pkg.version} ${color.dim('→')} ${nextVersion}`);
   p.log.step(`Commits: ${commitMessages.length}`);
   p.log.message('Preview CHANGELOG entry:');
@@ -163,8 +177,10 @@ async function main(): Promise<void> {
 
   await Bun.write('package.json', updatedPackageJson);
   await Bun.write('CHANGELOG.md', updatedChangelog);
+  await Bun.write('server.json', updatedServerJson);
+  await Bun.write('skills/open-zk-kb/SKILL.md', updatedSkillText);
 
-  mustRun(['git', 'add', 'package.json', 'CHANGELOG.md'], 'git add');
+  mustRun(['git', 'add', 'package.json', 'CHANGELOG.md', 'server.json', 'skills/open-zk-kb/SKILL.md'], 'git add');
   mustRun(['git', 'commit', '-m', `Bump to ${nextVersion}`], 'git commit');
   mustRun(['git', 'push', 'origin', 'dev'], 'git push');
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.mrosnerr/open-zk-kb",
   "description": "Zettelkasten-style knowledge base for AI coding assistants. Stores decisions, preferences, patterns, and context as linked Markdown notes with full-text and semantic search.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "websiteUrl": "https://mrosnerr.github.io/open-zk-kb",
   "repository": {
     "url": "https://github.com/mrosnerr/open-zk-kb",
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "open-zk-kb",
-"version": "1.0.1",
+"version": "1.0.2",
       "transport": {
         "type": "stdio"
       }

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-zk-kb
-version: 1.0.1
+version: 1.0.2
 description: >
   Persistent knowledge base for cross-session memory. BEFORE responding to any
   user message: (1) knowledge-search for relevant context, (2) scan for storage


### PR DESCRIPTION
## Summary

- Release script now auto-syncs `server.json` and `SKILL.md` versions with `package.json`
- CI check fails PRs to main if versions are inconsistent
- Fixes current drift: `SKILL.md` was at 1.0.1, now 1.0.2

## Files Changed

| File | Change |
|------|--------|
| `scripts/release.ts` | Sync `server.json` (root + packages[0]) and `skills/open-zk-kb/SKILL.md` |
| `.github/workflows/version-check.yml` | Add consistency check for all 4 version locations |
| `server.json` | Fix version to 1.0.2 |
| `skills/open-zk-kb/SKILL.md` | Fix version to 1.0.2 |