### PR TITLE
Require descriptive titles for release PRs

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,7 +13,22 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
+            const baseBranch = context.payload.pull_request.base.ref;
+            const headBranch = context.payload.pull_request.head.ref;
             const errors = [];
+
+            // Release PRs (dev→main) must have descriptive titles, not generic version bumps
+            if (baseBranch === 'main' && headBranch === 'dev') {
+              if (/^Bump (to |version )?\d+\.\d+\.\d+/i.test(title.trim())) {
+                errors.push('Release PR title must describe changes, not just "Bump to X.Y.Z" — this becomes the commit message on main');
+              }
+              if (/^Release:/i.test(title.trim())) {
+                errors.push('Release PR title must describe changes, not just "Release: ..." — this becomes the commit message on main');
+              }
+              if (/^Merge \w+ into (main|dev)$/i.test(title.trim())) {
+                errors.push('Release PR title must describe changes, not just "Merge X into Y" — this becomes the commit message on main');
+              }
+            }
 
             if (title !== title.trimStart()) {
               errors.push('Title must not start with whitespace');

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -184,7 +184,11 @@ async function main(): Promise<void> {
   mustRun(['git', 'commit', '-m', `Bump to ${nextVersion}`], 'git commit');
   mustRun(['git', 'push', 'origin', 'dev'], 'git push');
 
-  const prTitle = `Bump to ${nextVersion}`;
+  // Generate descriptive PR title from commits (CI rejects generic "Bump to X.Y.Z")
+  const prTitle = commitMessages.length === 1
+    ? commitMessages[0]  // Single commit: use its message
+    : commitMessages[0]; // Multiple commits: use the first (most recent) as summary
+  
   const prBody = buildPrBody(nextVersion, commitMessages);
   if (existingPr) {
     mustRun(['gh', 'pr', 'edit', String(existingPr.number), '--title', prTitle, '--body', prBody], 'gh pr edit');


### PR DESCRIPTION
## Summary

- CI now rejects dev→main PRs with generic "Bump to X.Y.Z" titles
- Release script now uses first commit message as PR title instead of version bump

## Why

Squash merges use PR title as the commit message on main. Generic "Bump to 1.0.3" titles make browsing file history meaningless.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/pr-title.yml` | Fail release PRs with "Bump to X.Y.Z" titles |
| `scripts/release.ts` | Use first commit message as PR title |