### PR TITLE
Add MCP Registry publishing to CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,3 +89,14 @@ jobs:
             --notes "**Install:** \`bunx open-zk-kb@$VERSION\`
           **npm:** https://www.npmjs.com/package/open-zk-kb/v/$VERSION" \
             $PRERELEASE_FLAG
+
+      - name: Install mcp-publisher
+        if: steps.version-check.outputs.skip == 'false'
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+
+      - name: Publish to MCP Registry
+        if: steps.version-check.outputs.skip == 'false'
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish


### PR DESCRIPTION
## Summary

- Automatically publishes to MCP Registry after npm publish
- Uses GitHub OIDC authentication (no secrets needed)
- Only runs when a new version is published

## How It Works

1. npm publish completes
2. GitHub Release created
3. `mcp-publisher login github-oidc` authenticates via OIDC
4. `mcp-publisher publish` registers/updates on MCP Registry

## Auth

Uses `io.github.mrosnerr/open-zk-kb` namespace with GitHub OIDC — the `id-token: write` permission was already present.