### PR TITLE
Shorten server.json description for MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.mrosnerr/open-zk-kb",
-  "description": "Zettelkasten-style knowledge base for AI coding assistants. Stores decisions, preferences, patterns, and context as linked Markdown notes with full-text and semantic search.",
+  "description": "Zettelkasten knowledge base for AI assistants with full-text and semantic search.",
   "version": "1.0.4",
   "websiteUrl": "https://mrosnerr.github.io/open-zk-kb",
   "repository": {


### PR DESCRIPTION
MCP Registry has a 100 character limit on description. Previous was 172 chars.