### PR TITLE
Pin npm version in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Check if version already published
         id: version-check


### PR DESCRIPTION
Fixes flaky `npm install -g npm@latest` failures in GitHub Actions.