### PR TITLE
Remove flaky npm upgrade step from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,9 +25,6 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@11
-
       - name: Check if version already published
         id: version-check
         run: |


### PR DESCRIPTION
GitHub Actions Node 22 already includes npm with provenance support. The upgrade step has been failing with MODULE_NOT_FOUND errors.