### PR TITLE
Use Node 24 for npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Check if version already published


### PR DESCRIPTION
npm trusted publishing requires npm v11.5.1+. Node 22 ships with npm v10, causing 404 errors. Node 24 ships with npm v11.