### PR TITLE
Standardize taglines to short and long variants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools. TypeScript/Bun, SQLite FTS5, Markdown files with YAML frontmatter. Entry point: `mcp-server.ts` (MCP stdio).
+Shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools — so context persists across sessions and clients. TypeScript/Bun, SQLite FTS5, Markdown files with YAML frontmatter. Entry point: `mcp-server.ts` (MCP stdio).
 
 ## Structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.10
+
+- Standardize taglines to short and long variants
+- Remove coding-specific terminology from taglines
+
 ## 1.0.9
 
 - Update taglines to emphasize Zettelkasten method and shared KB

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## System Overview
 
-open-zk-kb is shared, persistent memory for AI assistants, built on the Zettelkasten method and implemented as a Model Context Protocol (MCP) server. One knowledge base for all your tools — any MCP-compatible client (OpenCode, Claude Code, Cursor, Windsurf, Zed) can interact with the same atomic, linked notes.
+Shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools — so context persists across sessions and clients. Implemented as a Model Context Protocol (MCP) server, any MCP-compatible client (OpenCode, Claude Code, Cursor, Windsurf, Zed) can interact with the same atomic, linked notes.
 
 Knowledge capture is driven by the calling agent's instructions (e.g., a Claude Code skill, `AGENTS.md`, or global rules), which guide the model to use the `knowledge-store` tool when relevant information is encountered.
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Shared, persistent memory for AI assistants, built on the Zettelkasten method
 
-open-zk-kb is shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools — it stores atomic notes (decisions, preferences, patterns, procedures, context) as linked Markdown files with wiki-links, full-text search (SQLite FTS5), and local semantic embeddings.
+Shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools — so context persists across sessions and clients. Stores atomic notes (decisions, preferences, patterns, procedures, context) as linked Markdown files with wiki-links, full-text search (SQLite FTS5), and local semantic embeddings.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-zk-kb",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "mcpName": "io.github.mrosnerr/open-zk-kb",
   "description": "Shared, persistent memory for AI assistants, built on the Zettelkasten method.",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "open-zk-kb",
   "version": "1.0.9",
   "mcpName": "io.github.mrosnerr/open-zk-kb",
-  "description": "Shared, persistent memory for AI assistants, built on the Zettelkasten method — one knowledge base for all your tools",
+  "description": "Shared, persistent memory for AI assistants, built on the Zettelkasten method.",
   "type": "module",
   "main": "dist/mcp-server.js",
   "types": "dist/mcp-server.d.ts",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.mrosnerr/open-zk-kb",
   "description": "Shared, persistent memory for AI assistants, built on the Zettelkasten method.",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "websiteUrl": "https://mrosnerr.github.io/open-zk-kb",
   "repository": {
     "url": "https://github.com/mrosnerr/open-zk-kb",
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "open-zk-kb",
-"version": "1.0.9",
+"version": "1.0.10",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.mrosnerr/open-zk-kb",
-  "description": "Shared, persistent memory for AI assistants, built on the Zettelkasten method — one knowledge base for all your tools.",
+  "description": "Shared, persistent memory for AI assistants, built on the Zettelkasten method.",
   "version": "1.0.9",
   "websiteUrl": "https://mrosnerr.github.io/open-zk-kb",
   "repository": {

--- a/site/index.md
+++ b/site/index.md
@@ -5,7 +5,7 @@ title: open-zk-kb
 
 # Shared, persistent memory for AI assistants
 
-Your AI assistant forgets everything between sessions. open-zk-kb fixes that — one Zettelkasten-based knowledge base for all your tools, so context persists across sessions and clients.
+Shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools — so context persists across sessions and clients.
 
 It gives your assistant a **structured, searchable knowledge base** it queries automatically — so your preferences, decisions, and context persist across every conversation.
 

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-zk-kb
-version: 1.0.9
+version: 1.0.10
 description: >
   Persistent knowledge base for cross-session memory. BEFORE responding to any
   user message: (1) knowledge-search for relevant context, (2) scan for storage


### PR DESCRIPTION
## Summary

Standardizes all project taglines to two canonical versions:

**Short (78 chars):**
> Shared, persistent memory for AI assistants, built on the Zettelkasten method.

**Long:**
> Shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools — so context persists across sessions and clients.

## Changes

| File | Variant |
|------|---------|
| `server.json` | Short (MCP Registry 100-char limit) |
| `package.json` | Short |
| `llms.txt` blockquote | Short |
| `src/types.ts` | Short |
| `CONTRIBUTING.md` | Short |
| `README.md` | Long |
| `AGENTS.md` | Long + tech stack |
| `docs/architecture.md` | Long + MCP context |
| `site/index.md` | Long |
| `llms.txt` paragraph | Long + tech details |

Also fixes MCP Registry publish failure (422 validation error from 121-char description).