### PR TITLE
Add Claude Code plugin packaging with compiled binaries

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -34,7 +34,7 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED"
 
-          if echo "$CHANGED" | grep -Eq '^(src/|package\.json|bun\.lock(b)?|config\.example\.yaml|agent-instructions-(full|compact)\.md)'; then
+          if echo "$CHANGED" | grep -Eq '^(src/|plugin/|package\.json|bun\.lock(b)?|config\.example\.yaml|agent-instructions-(full|compact)\.md)'; then
             echo "needs_bump=true" >> "$GITHUB_OUTPUT"
           else
             echo "needs_bump=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -157,4 +157,11 @@ jobs:
             exit 1
           fi
           
+          # Check plugin.json version
+          PLUGIN_VERSION=$(node -p "require('./plugin/.claude-plugin/plugin.json').version")
+          if [ "$PLUGIN_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::plugin/.claude-plugin/plugin.json version ($PLUGIN_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          
           echo "All versions consistent: $PKG_VERSION"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ node_modules/
 # Build output
 dist/
 
+# Plugin build artifacts (built during release)
+plugin/bin/open-zk-kb-*
+plugin/skills/
+test-binary
+
 # Database & vault artifacts
 .index/
 .kb/

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "test:coverage": "bun test --coverage",
     "eval": "EVAL=1 bun test tests/eval/eval.test.ts --timeout 120000",
     "setup": "bun run src/setup.ts",
-    "release": "bun run scripts/release.ts"
+    "release": "bun run scripts/release.ts",
+    "build:plugin": "bun run scripts/build-plugin.ts"
   },
   "dependencies": {
     "@clack/prompts": "^1.1.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "open-zk-kb",
+  "version": "1.0.10",
+  "description": "Persistent AI memory across sessions. Search context before work, store preferences, decisions, and observations automatically. Cross-session knowledge base built on Zettelkasten.",
+  "author": {
+    "name": "mrosnerr",
+    "url": "https://github.com/mrosnerr"
+  },
+  "homepage": "https://mrosnerr.github.io/open-zk-kb",
+  "repository": "https://github.com/mrosnerr/open-zk-kb",
+  "license": "MIT",
+  "keywords": [
+    "knowledge-base",
+    "memory",
+    "zettelkasten",
+    "persistent-context",
+    "mcp",
+    "cross-session"
+  ]
+}

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "open-zk-kb": {
+    "command": "${CLAUDE_PLUGIN_ROOT}/bin/run.sh",
+    "args": []
+  }
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,86 @@
+# open-zk-kb
+
+Persistent AI memory across sessions. Search context before work, store preferences, decisions, and observations automatically.
+
+## What It Does
+
+open-zk-kb gives Claude Code a persistent knowledge base that survives across sessions. Instead of re-explaining your preferences, project decisions, or learned patterns every time, Claude remembers.
+
+**Example uses:**
+- "Remember I prefer Bun over Node.js" → stored, applied in future sessions
+- "We decided to use FTS5 for search because..." → decision preserved
+- Hit a weird error? → observation saved so you don't debug it twice
+
+## Prerequisites
+
+This plugin includes pre-compiled binaries for all platforms. No runtime dependencies required.
+
+**Supported platforms:**
+- macOS (Apple Silicon & Intel)
+- Linux (x64 & ARM64)
+- Windows (x64)
+
+## Installation
+
+### From Official Marketplace
+
+```
+/plugin install open-zk-kb@claude-plugins-official
+```
+
+### From GitHub
+
+```
+/plugin install github:mrosnerr/open-zk-kb/plugin
+```
+
+### Local Development
+
+```bash
+claude --plugin-dir /path/to/open-zk-kb/plugin
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `knowledge-search` | Search the knowledge base using full-text search and semantic similarity |
+| `knowledge-store` | Store a note with title, content, kind, summary, and guidance |
+| `knowledge-maintain` | Maintenance actions: stats, review, dedupe, promote, archive, delete |
+
+## Note Kinds
+
+| Kind | When to Store |
+|------|---------------|
+| **personalization** | User says "I prefer", "always", "never", or corrects you |
+| **decision** | You and user weigh options and pick one |
+| **observation** | You hit a non-obvious error or gotcha |
+| **reference** | You look something up twice in one session |
+| **procedure** | You discover a multi-step workflow by doing it |
+| **resource** | A useful URL comes up |
+
+## Data Storage
+
+Notes are stored locally in `~/.local/share/open-zk-kb/` as Markdown files with YAML frontmatter. SQLite with FTS5 provides fast full-text search. Optional local embeddings (MiniLM-L6-v2) enable semantic search.
+
+## Configuration
+
+Optional config at `~/.config/open-zk-kb/config.yaml`:
+
+```yaml
+vault: ~/.local/share/open-zk-kb  # Note storage location
+logLevel: INFO                     # DEBUG, INFO, WARN, ERROR
+
+embeddings:
+  enabled: true                    # Enable semantic search
+  provider: local                  # local (default) or api
+```
+
+## Documentation
+
+- [Full Documentation](https://mrosnerr.github.io/open-zk-kb)
+- [GitHub Repository](https://github.com/mrosnerr/open-zk-kb)
+
+## License
+
+MIT

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -24,13 +24,13 @@ This plugin includes pre-compiled binaries for all platforms. No runtime depende
 
 ### From Official Marketplace
 
-```
+```text
 /plugin install open-zk-kb@claude-plugins-official
 ```
 
 ### From GitHub
 
-```
+```text
 /plugin install github:mrosnerr/open-zk-kb/plugin
 ```
 

--- a/plugin/bin/run.sh
+++ b/plugin/bin/run.sh
@@ -25,11 +25,21 @@ if [ "$OS" = "windows" ]; then
   BINARY="${BINARY}.exe"
 fi
 
-if [ ! -x "$BINARY" ]; then
-  echo "Binary not found or not executable: $BINARY" >&2
-  echo "Available binaries:" >&2
-  ls -la "$SCRIPT_DIR"/open-zk-kb-* 2>/dev/null >&2
-  exit 1
+# Check binary exists (use -f for Windows .exe, -x for others)
+if [ "$OS" = "windows" ]; then
+  if [ ! -f "$BINARY" ]; then
+    echo "Binary not found: $BINARY" >&2
+    echo "Available binaries:" >&2
+    ls -la "$SCRIPT_DIR"/open-zk-kb-* 2>/dev/null >&2
+    exit 1
+  fi
+else
+  if [ ! -x "$BINARY" ]; then
+    echo "Binary not found or not executable: $BINARY" >&2
+    echo "Available binaries:" >&2
+    ls -la "$SCRIPT_DIR"/open-zk-kb-* 2>/dev/null >&2
+    exit 1
+  fi
 fi
 
 exec "$BINARY" "$@"

--- a/plugin/bin/run.sh
+++ b/plugin/bin/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Platform detection and binary selection for open-zk-kb MCP server
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Detect OS
+case "$(uname -s)" in
+  Darwin*) OS="darwin" ;;
+  Linux*)  OS="linux" ;;
+  MINGW*|MSYS*|CYGWIN*) OS="windows" ;;
+  *)       echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+# Detect architecture
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="x64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *)            echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+BINARY="$SCRIPT_DIR/open-zk-kb-${OS}-${ARCH}"
+
+# Add .exe extension on Windows
+if [ "$OS" = "windows" ]; then
+  BINARY="${BINARY}.exe"
+fi
+
+if [ ! -x "$BINARY" ]; then
+  echo "Binary not found or not executable: $BINARY" >&2
+  echo "Available binaries:" >&2
+  ls -la "$SCRIPT_DIR"/open-zk-kb-* 2>/dev/null >&2
+  exit 1
+fi
+
+exec "$BINARY" "$@"

--- a/scripts/build-plugin.ts
+++ b/scripts/build-plugin.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env bun
+// scripts/build-plugin.ts - Build cross-platform binaries for Claude Code plugin
+// Usage: bun run scripts/build-plugin.ts
+
+import { $ } from 'bun';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TARGETS = [
+  { target: 'bun-darwin-arm64', output: 'open-zk-kb-darwin-arm64' },
+  { target: 'bun-darwin-x64', output: 'open-zk-kb-darwin-x64' },
+  { target: 'bun-linux-x64', output: 'open-zk-kb-linux-x64' },
+  { target: 'bun-linux-arm64', output: 'open-zk-kb-linux-arm64' },
+  { target: 'bun-windows-x64', output: 'open-zk-kb-windows-x64.exe' },
+];
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const PLUGIN_DIR = path.join(ROOT, 'plugin');
+const PLUGIN_BIN = path.join(PLUGIN_DIR, 'bin');
+const PLUGIN_SKILLS = path.join(PLUGIN_DIR, 'skills', 'open-zk-kb');
+const SOURCE_SKILLS = path.join(ROOT, 'skills', 'open-zk-kb');
+const ENTRYPOINT = path.join(ROOT, 'src', 'mcp-server.ts');
+
+async function main() {
+  // Get version from package.json
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
+  const version = pkg.version;
+  
+  console.log(`Building open-zk-kb v${version} for Claude Code plugin...\n`);
+
+  // Ensure plugin/bin directory exists
+  fs.mkdirSync(PLUGIN_BIN, { recursive: true });
+
+  // Build for each target
+  for (const { target, output } of TARGETS) {
+    const outfile = path.join(PLUGIN_BIN, output);
+    console.log(`  Building ${target}...`);
+    
+    try {
+      const defineArg = `__PKG_VERSION__="${version}"`;
+      await $`bun build --compile --target=${target} --define ${defineArg} ${ENTRYPOINT} --outfile ${outfile}`.quiet();
+      
+      const stats = fs.statSync(outfile);
+      const sizeMB = (stats.size / 1024 / 1024).toFixed(1);
+      console.log(`    ✓ ${output} (${sizeMB} MB)`);
+    } catch (error) {
+      console.error(`    ✗ Failed to build ${target}:`, error);
+      process.exit(1);
+    }
+  }
+
+  // Update plugin.json version
+  const pluginJsonPath = path.join(PLUGIN_DIR, '.claude-plugin', 'plugin.json');
+  const pluginJson = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'));
+  pluginJson.version = version;
+  fs.writeFileSync(pluginJsonPath, JSON.stringify(pluginJson, null, 2) + '\n');
+  console.log(`\n  Updated plugin.json version to ${version}`);
+
+  // Copy skills from source to plugin
+  console.log('\n  Copying skills...');
+  fs.mkdirSync(PLUGIN_SKILLS, { recursive: true });
+  for (const file of fs.readdirSync(SOURCE_SKILLS)) {
+    const src = path.join(SOURCE_SKILLS, file);
+    const dest = path.join(PLUGIN_SKILLS, file);
+    fs.copyFileSync(src, dest);
+    console.log(`    ✓ ${file}`);
+  }
+
+  console.log('\n✓ Plugin build complete!');
+  console.log(`  Binaries: ${PLUGIN_BIN}`);
+  console.log(`  Skills: ${PLUGIN_SKILLS}`);
+}
+
+main().catch(console.error);

--- a/scripts/build-plugin.ts
+++ b/scripts/build-plugin.ts
@@ -56,13 +56,11 @@ async function main() {
   fs.writeFileSync(pluginJsonPath, JSON.stringify(pluginJson, null, 2) + '\n');
   console.log(`\n  Updated plugin.json version to ${version}`);
 
-  // Copy skills from source to plugin
+  // Copy skills from source to plugin (clean first to remove stale files)
   console.log('\n  Copying skills...');
-  fs.mkdirSync(PLUGIN_SKILLS, { recursive: true });
-  for (const file of fs.readdirSync(SOURCE_SKILLS)) {
-    const src = path.join(SOURCE_SKILLS, file);
-    const dest = path.join(PLUGIN_SKILLS, file);
-    fs.copyFileSync(src, dest);
+  fs.rmSync(PLUGIN_SKILLS, { recursive: true, force: true });
+  fs.cpSync(SOURCE_SKILLS, PLUGIN_SKILLS, { recursive: true });
+  for (const file of fs.readdirSync(PLUGIN_SKILLS)) {
     console.log(`    ✓ ${file}`);
   }
 
@@ -71,4 +69,7 @@ async function main() {
   console.log(`  Skills: ${PLUGIN_SKILLS}`);
 }
 
-main().catch(console.error);
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -22,10 +22,15 @@ import { generateEmbedding, DEFAULT_EMBEDDING_CONFIG } from './embeddings.js';
 import type { EmbeddingConfig } from './embeddings.js';
 import type { NoteKind } from './types.js';
 import type { NoteRepository as NoteRepositoryType } from './storage/NoteRepository.js';
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-const { version: PKG_VERSION } = require('../package.json');
+// Version injected at compile time via --define, or read from package.json at runtime
+declare const __PKG_VERSION__: string | undefined;
+const PKG_VERSION: string = typeof __PKG_VERSION__ !== 'undefined'
+  ? __PKG_VERSION__
+  : (() => {
+      const { createRequire } = require('module');
+      const req = createRequire(import.meta.url);
+      return req('../package.json').version;
+    })();
 const { NoteRepository } = await import('./storage/NoteRepository.js');
 
 const config = getConfig();

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -27,6 +27,7 @@ declare const __PKG_VERSION__: string | undefined;
 const PKG_VERSION: string = typeof __PKG_VERSION__ !== 'undefined'
   ? __PKG_VERSION__
   : (() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { createRequire } = require('module');
       const req = createRequire(import.meta.url);
       return req('../package.json').version;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -22,16 +22,8 @@ import { generateEmbedding, DEFAULT_EMBEDDING_CONFIG } from './embeddings.js';
 import type { EmbeddingConfig } from './embeddings.js';
 import type { NoteKind } from './types.js';
 import type { NoteRepository as NoteRepositoryType } from './storage/NoteRepository.js';
-// Version injected at compile time via --define, or read from package.json at runtime
-declare const __PKG_VERSION__: string | undefined;
-const PKG_VERSION: string = typeof __PKG_VERSION__ !== 'undefined'
-  ? __PKG_VERSION__
-  : (() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { createRequire } = require('module');
-      const req = createRequire(import.meta.url);
-      return req('../package.json').version;
-    })();
+import { PKG_VERSION } from './version.js';
+
 const { NoteRepository } = await import('./storage/NoteRepository.js');
 
 const config = getConfig();

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -15,6 +15,7 @@ declare const __PKG_VERSION__: string | undefined;
 const PKG_VERSION: string = typeof __PKG_VERSION__ !== 'undefined'
   ? __PKG_VERSION__
   : (() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { createRequire } = require('module');
       const req = createRequire(import.meta.url);
       return req('../package.json').version;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -10,10 +10,15 @@ import color from 'picocolors';
 import { expandPath } from './utils/path.js';
 import { injectAgentDocs, inspectAgentDocs, removeAgentDocs } from './agent-docs.js';
 import type { InstructionSize } from './agent-docs.js';
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-const { version: PKG_VERSION } = require('../package.json') as { version: string };
+// Version injected at compile time via --define, or read from package.json at runtime
+declare const __PKG_VERSION__: string | undefined;
+const PKG_VERSION: string = typeof __PKG_VERSION__ !== 'undefined'
+  ? __PKG_VERSION__
+  : (() => {
+      const { createRequire } = require('module');
+      const req = createRequire(import.meta.url);
+      return req('../package.json').version;
+    })();
 
 const xdgConfigHome = process.env.XDG_CONFIG_HOME || expandPath('~/.config');
 const xdgDataHome = process.env.XDG_DATA_HOME || expandPath('~/.local/share');

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -10,16 +10,7 @@ import color from 'picocolors';
 import { expandPath } from './utils/path.js';
 import { injectAgentDocs, inspectAgentDocs, removeAgentDocs } from './agent-docs.js';
 import type { InstructionSize } from './agent-docs.js';
-// Version injected at compile time via --define, or read from package.json at runtime
-declare const __PKG_VERSION__: string | undefined;
-const PKG_VERSION: string = typeof __PKG_VERSION__ !== 'undefined'
-  ? __PKG_VERSION__
-  : (() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { createRequire } = require('module');
-      const req = createRequire(import.meta.url);
-      return req('../package.json').version;
-    })();
+import { PKG_VERSION } from './version.js';
 
 const xdgConfigHome = process.env.XDG_CONFIG_HOME || expandPath('~/.config');
 const xdgDataHome = process.env.XDG_DATA_HOME || expandPath('~/.local/share');

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,19 @@
+// version.ts - Centralized package version resolution
+// Supports compile-time injection (__PKG_VERSION__) with runtime fallback
+
+import { createRequire } from 'module';
+
+declare const __PKG_VERSION__: string | undefined;
+
+/**
+ * Get the package version.
+ * Uses compile-time injected __PKG_VERSION__ if available (for compiled binaries),
+ * otherwise falls back to reading package.json at runtime.
+ */
+export const PKG_VERSION: string = (() => {
+  if (typeof __PKG_VERSION__ !== 'undefined') {
+    return __PKG_VERSION__;
+  }
+  const require = createRequire(import.meta.url);
+  return (require('../package.json') as { version: string }).version;
+})();

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,5 +15,9 @@ export const PKG_VERSION: string = (() => {
     return __PKG_VERSION__;
   }
   const require = createRequire(import.meta.url);
-  return (require('../package.json') as { version: string }).version;
+  const pkg = require('../package.json') as { version?: unknown };
+  if (typeof pkg.version !== 'string' || !pkg.version) {
+    throw new Error('Invalid or missing version in package.json');
+  }
+  return pkg.version;
 })();


### PR DESCRIPTION
## Summary

Adds Claude Code plugin support with pre-compiled binaries for all major platforms. Users can install without needing Bun runtime.

## Changes

- **Plugin structure** (`plugin/`)
  - `.claude-plugin/plugin.json` — manifest with metadata
  - `.mcp.json` — MCP server config pointing to platform wrapper
  - `bin/run.sh` — detects OS/arch and runs correct binary
  - `README.md` — setup instructions
  - `skills/` — copied from `skills/` at build time

- **Build script** (`scripts/build-plugin.ts`)
  - Cross-compiles for 5 targets: darwin-arm64, darwin-x64, linux-x64, linux-arm64, windows-x64
  - Injects version via `--define` at compile time
  - Copies skills to plugin directory
  - Updates plugin.json version

- **Source changes**
  - `src/mcp-server.ts`, `src/setup.ts` — support compile-time version injection
  - `.github/workflows/version-check.yml` — verify plugin.json version consistency
  - `.gitignore` — exclude compiled binaries and copied skills

## Installation

```bash
# Direct from GitHub
/plugin install github:mrosnerr/open-zk-kb/plugin

# After official marketplace approval
/plugin install open-zk-kb@claude-plugins-official
```

## Binary Sizes

| Platform | Size |
|----------|------|
| darwin-arm64 | 60.6 MB |
| darwin-x64 | 65.1 MB |
| linux-arm64 | 95.5 MB |
| linux-x64 | 100.8 MB |
| windows-x64 | 112.0 MB |

## Testing

- [x] `claude plugin validate ./plugin` passes
- [x] `claude --plugin-dir ./plugin` loads correctly
- [x] All MCP tools work (knowledge-search, knowledge-store, knowledge-maintain)
- [x] Skills load correctly

## Next Steps

1. Merge this PR
2. Submit to official marketplace via https://clau.de/plugin-directory-submission
3. Consider adding `bun run build:plugin` to release CI workflow

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the open-zk-kb plugin providing persistent cross-session AI memory with search, store, and maintenance tools.

* **Documentation**
  * Added a comprehensive plugin README with usage, note kinds, storage, configuration, and examples.

* **Chores**
  * Added plugin build tooling, cross-platform launcher, npm script, ignore rules, MCP tooling entry, and CI checks that enforce manifest/package version consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->