### PR TITLE
Add Claude Code plugin packaging with compiled binaries

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,5 @@
 reviews:
+  request_changes_workflow: true
   auto_review:
     enabled: true
     drafts: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+      - dev

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure Windows batch files keep CRLF line endings
+*.cmd text eol=crlf

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -34,7 +34,7 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED"
 
-          if echo "$CHANGED" | grep -Eq '^(src/|package\.json|bun\.lock(b)?|config\.example\.yaml|agent-instructions-(full|compact)\.md)'; then
+          if echo "$CHANGED" | grep -Eq '^(src/|plugin/|package\.json|bun\.lock(b)?|config\.example\.yaml|agent-instructions-(full|compact)\.md)'; then
             echo "needs_bump=true" >> "$GITHUB_OUTPUT"
           else
             echo "needs_bump=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -157,4 +157,11 @@ jobs:
             exit 1
           fi
           
+          # Check plugin.json version
+          PLUGIN_VERSION=$(node -p "require('./plugin/.claude-plugin/plugin.json').version")
+          if [ "$PLUGIN_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::plugin/.claude-plugin/plugin.json version ($PLUGIN_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          
           echo "All versions consistent: $PKG_VERSION"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ node_modules/
 # Build output
 dist/
 
+# Plugin build artifacts (built during release)
+plugin/bin/open-zk-kb-*
+plugin/skills/
+test-binary
+
 # Database & vault artifacts
 .index/
 .kb/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.11
+
+- **Add Claude Code plugin packaging** — compiled binaries for macOS, Linux, and Windows
+- **Add CodeRabbit config** — automated code review with request changes workflow
+- **Add runtime validation** — package.json version fallback for compiled binaries
+- **Bump @huggingface/transformers** — 3.8.1 to 4.0.1
+- **Bump @typescript-eslint/eslint-plugin and parser** — 8.26.0 to 8.58.1 (eslint 10 compat)
+- **Sync plugin.json version in release script** — ensures version consistency
+
 ## 1.0.10
 
 - Standardize taglines to short and long variants

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "bun-types": "^1.2.2",
         "eslint": "^10.0.3",
         "typescript": "^6.0.2",
-        "typescript-eslint": "^8.56.1",
+        "typescript-eslint": "^8.58.1",
       },
     },
   },
@@ -478,7 +478,7 @@
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
-    "typescript-eslint": ["typescript-eslint@8.56.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.56.1", "@typescript-eslint/parser": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1", "@typescript-eslint/utils": "8.56.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ=="],
+    "typescript-eslint": ["typescript-eslint@8.58.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.1", "@typescript-eslint/parser": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1", "@typescript-eslint/utils": "8.58.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -512,52 +512,8 @@
 
     "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
 
-    "typescript-eslint/@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.56.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/type-utils": "8.56.1", "@typescript-eslint/utils": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.56.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A=="],
-
-    "typescript-eslint/@typescript-eslint/parser": ["@typescript-eslint/parser@8.56.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/types": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg=="],
-
-    "typescript-eslint/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.56.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.56.1", "@typescript-eslint/tsconfig-utils": "8.56.1", "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg=="],
-
-    "typescript-eslint/@typescript-eslint/utils": ["@typescript-eslint/utils@8.56.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/types": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA=="],
-
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1" } }, "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1", "@typescript-eslint/utils": "8.56.1", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
-
-    "typescript-eslint/@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1" } }, "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w=="],
-
-    "typescript-eslint/@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.56.1", "", {}, "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw=="],
-
-    "typescript-eslint/@typescript-eslint/parser/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw=="],
-
-    "typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.56.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.56.1", "@typescript-eslint/types": "^8.56.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ=="],
-
-    "typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.56.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ=="],
-
-    "typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.56.1", "", {}, "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw=="],
-
-    "typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw=="],
-
-    "typescript-eslint/@typescript-eslint/typescript-estree/ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
-
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1" } }, "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w=="],
-
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.56.1", "", {}, "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.56.1", "", {}, "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.56.1", "", {}, "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw=="],
-
-    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.56.1", "", {}, "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw=="],
-
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,15 +5,15 @@
     "": {
       "dependencies": {
         "@clack/prompts": "^1.1.0",
-        "@huggingface/transformers": "^3.8.1",
+        "@huggingface/transformers": "^4.0.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "picocolors": "^1.1.1",
         "yaml": "^2.3.4",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@typescript-eslint/eslint-plugin": "^8.26.0",
-        "@typescript-eslint/parser": "^8.26.0",
+        "@typescript-eslint/eslint-plugin": "^8.58.1",
+        "@typescript-eslint/parser": "^8.58.1",
         "bun-types": "^1.2.2",
         "eslint": "^10.0.3",
         "typescript": "^6.0.2",
@@ -46,9 +46,11 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
-    "@huggingface/jinja": ["@huggingface/jinja@0.5.5", "", {}, "sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ=="],
+    "@huggingface/jinja": ["@huggingface/jinja@0.5.6", "", {}, "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA=="],
 
-    "@huggingface/transformers": ["@huggingface/transformers@3.8.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.3", "onnxruntime-node": "1.21.0", "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4", "sharp": "^0.34.1" } }, "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA=="],
+    "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
+
+    "@huggingface/transformers": ["@huggingface/transformers@4.0.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.6", "@huggingface/tokenizers": "^0.1.3", "onnxruntime-node": "1.24.3", "onnxruntime-web": "1.25.0-dev.20260327-722743c0e2", "sharp": "^0.34.5" } }, "sha512-tAQYEy+cnW0ku/NxBSjFXCymi+DZa1/JkoGf4McxjzO36CZZIL/J4TF6X7i/tzs75yTjshUDgsvSz03s2xym2A=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -108,8 +110,6 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
-
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
@@ -140,31 +140,33 @@
 
     "@types/node": ["@types/node@25.2.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.54.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.54.0", "@typescript-eslint/type-utils": "8.54.0", "@typescript-eslint/utils": "8.54.0", "@typescript-eslint/visitor-keys": "8.54.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.54.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/type-utils": "8.58.1", "@typescript-eslint/utils": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.54.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.54.0", "@typescript-eslint/types": "8.54.0", "@typescript-eslint/typescript-estree": "8.54.0", "@typescript-eslint/visitor-keys": "8.54.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.58.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/types": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.54.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.54.0", "@typescript-eslint/types": "^8.54.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.58.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.58.1", "@typescript-eslint/types": "^8.58.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.54.0", "", { "dependencies": { "@typescript-eslint/types": "8.54.0", "@typescript-eslint/visitor-keys": "8.54.0" } }, "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.1", "", { "dependencies": { "@typescript-eslint/types": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1" } }, "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.54.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.58.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.54.0", "", { "dependencies": { "@typescript-eslint/types": "8.54.0", "@typescript-eslint/typescript-estree": "8.54.0", "@typescript-eslint/utils": "8.54.0", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.58.1", "", { "dependencies": { "@typescript-eslint/types": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1", "@typescript-eslint/utils": "8.58.1", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.54.0", "", {}, "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.58.1", "", {}, "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.54.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.54.0", "@typescript-eslint/tsconfig-utils": "8.54.0", "@typescript-eslint/types": "8.54.0", "@typescript-eslint/visitor-keys": "8.54.0", "debug": "^4.4.3", "minimatch": "^9.0.5", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.58.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.58.1", "@typescript-eslint/tsconfig-utils": "8.58.1", "@typescript-eslint/types": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.54.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.54.0", "@typescript-eslint/types": "8.54.0", "@typescript-eslint/typescript-estree": "8.54.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/types": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.54.0", "", { "dependencies": { "@typescript-eslint/types": "8.54.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.1", "", { "dependencies": { "@typescript-eslint/types": "8.58.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
@@ -185,8 +187,6 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
-
-    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
@@ -364,10 +364,6 @@
 
     "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
-    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
-
-    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
-
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
@@ -384,11 +380,11 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onnxruntime-common": ["onnxruntime-common@1.21.0", "", {}, "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ=="],
+    "onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
 
-    "onnxruntime-node": ["onnxruntime-node@1.21.0", "", { "dependencies": { "global-agent": "^3.0.0", "onnxruntime-common": "1.21.0", "tar": "^7.0.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw=="],
+    "onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
 
-    "onnxruntime-web": ["onnxruntime-web@1.22.0-dev.20250409-89f8206ba4", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ=="],
+    "onnxruntime-web": ["onnxruntime-web@1.25.0-dev.20260327-722743c0e2", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-8PXdZy4Ekhg10CLg+cFFt39b4tFDGMRJB6lGjnQL6eA+2boUQYDymZ0gtxiS+H6oIWoCjQp/ziyirvFbaFKfiw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -466,13 +462,11 @@
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
-    "tar": ["tar@7.5.10", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw=="],
-
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -500,8 +494,6 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
-
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
@@ -514,15 +506,11 @@
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
-
     "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.22.0-dev.20250409-89f8206ba4", "", {}, "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ=="],
+    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
 
     "typescript-eslint/@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.56.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/type-utils": "8.56.1", "@typescript-eslint/utils": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.56.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A=="],
 
@@ -534,8 +522,6 @@
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1" } }, "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w=="],
@@ -543,6 +529,8 @@
     "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/typescript-estree": "8.56.1", "@typescript-eslint/utils": "8.56.1", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg=="],
 
     "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw=="],
+
+    "typescript-eslint/@typescript-eslint/eslint-plugin/ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
     "typescript-eslint/@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1" } }, "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w=="],
 
@@ -558,11 +546,11 @@
 
     "typescript-eslint/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw=="],
 
+    "typescript-eslint/@typescript-eslint/typescript-estree/ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
+
     "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.56.1", "", { "dependencies": { "@typescript-eslint/types": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1" } }, "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w=="],
 
     "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.56.1", "", {}, "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw=="],
-
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.56.1", "", {}, "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw=="],
 

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -1,0 +1,24 @@
+version: 1
+
+reviews:
+  enabled: true
+  sensitivity: medium
+  incremental_commits: true
+  check_drafts: false
+  resolve_threads_when_addressed: true
+  custom_instructions: |
+    This is a Bun-first project (not Node.js). The MCP server uses
+    @modelcontextprotocol/sdk. The plugin/ directory contains pre-compiled
+    binaries for Claude Code's plugin system. Tests run with `bun test`.
+  ignore:
+    files:
+      - bun.lock
+      - plugin/bin/open-zk-kb-*
+
+pr_descriptions:
+  generate: false
+
+issues:
+  fix_with_cubic_buttons: true
+  pr_comment_fixes: true
+  fix_commits_to_pr: false

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "test:coverage": "bun test --coverage",
     "eval": "EVAL=1 bun test tests/eval/eval.test.ts --timeout 120000",
     "setup": "bun run src/setup.ts",
-    "release": "bun run scripts/release.ts"
+    "release": "bun run scripts/release.ts",
+    "build:plugin": "bun run scripts/build-plugin.ts"
   },
   "dependencies": {
     "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "bun-types": "^1.2.2",
     "eslint": "^10.0.3",
     "typescript": "^6.0.2",
-    "typescript-eslint": "^8.56.1"
+    "typescript-eslint": "^8.58.1"
   },
   "engines": {
     "bun": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-zk-kb",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "mcpName": "io.github.mrosnerr/open-zk-kb",
   "description": "Shared, persistent memory for AI assistants, built on the Zettelkasten method.",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@typescript-eslint/eslint-plugin": "^8.26.0",
-    "@typescript-eslint/parser": "^8.26.0",
+    "@typescript-eslint/eslint-plugin": "^8.58.1",
+    "@typescript-eslint/parser": "^8.58.1",
     "bun-types": "^1.2.2",
     "eslint": "^10.0.3",
     "typescript": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.1.0",
-    "@huggingface/transformers": "^3.8.1",
+    "@huggingface/transformers": "^4.0.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "picocolors": "^1.1.1",
     "yaml": "^2.3.4"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "open-zk-kb",
+  "version": "1.0.10",
+  "description": "Persistent AI memory across sessions. Search context before work, store preferences, decisions, and observations automatically. Cross-session knowledge base built on Zettelkasten.",
+  "author": {
+    "name": "mrosnerr",
+    "url": "https://github.com/mrosnerr"
+  },
+  "homepage": "https://mrosnerr.github.io/open-zk-kb",
+  "repository": "https://github.com/mrosnerr/open-zk-kb",
+  "license": "MIT",
+  "keywords": [
+    "knowledge-base",
+    "memory",
+    "zettelkasten",
+    "persistent-context",
+    "mcp",
+    "cross-session"
+  ]
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-zk-kb",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Persistent AI memory across sessions. Search context before work, store preferences, decisions, and observations automatically. Cross-session knowledge base built on Zettelkasten.",
   "author": {
     "name": "mrosnerr",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,6 +1,6 @@
 {
   "open-zk-kb": {
     "command": "${CLAUDE_PLUGIN_ROOT}/bin/run.sh",
-    "args": []
+    "args": ["server"]
   }
 }

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "open-zk-kb": {
+    "command": "${CLAUDE_PLUGIN_ROOT}/bin/run.sh",
+    "args": []
+  }
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,86 @@
+# open-zk-kb
+
+Persistent AI memory across sessions. Search context before work, store preferences, decisions, and observations automatically.
+
+## What It Does
+
+open-zk-kb gives Claude Code a persistent knowledge base that survives across sessions. Instead of re-explaining your preferences, project decisions, or learned patterns every time, Claude remembers.
+
+**Example uses:**
+- "Remember I prefer Bun over Node.js" → stored, applied in future sessions
+- "We decided to use FTS5 for search because..." → decision preserved
+- Hit a weird error? → observation saved so you don't debug it twice
+
+## Prerequisites
+
+This plugin includes pre-compiled binaries for all platforms. No runtime dependencies required.
+
+**Supported platforms:**
+- macOS (Apple Silicon & Intel)
+- Linux (x64 & ARM64)
+- Windows (x64)
+
+## Installation
+
+### From Official Marketplace
+
+```
+/plugin install open-zk-kb@claude-plugins-official
+```
+
+### From GitHub
+
+```
+/plugin install github:mrosnerr/open-zk-kb/plugin
+```
+
+### Local Development
+
+```bash
+claude --plugin-dir /path/to/open-zk-kb/plugin
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `knowledge-search` | Search the knowledge base using full-text search and semantic similarity |
+| `knowledge-store` | Store a note with title, content, kind, summary, and guidance |
+| `knowledge-maintain` | Maintenance actions: stats, review, dedupe, promote, archive, delete |
+
+## Note Kinds
+
+| Kind | When to Store |
+|------|---------------|
+| **personalization** | User says "I prefer", "always", "never", or corrects you |
+| **decision** | You and user weigh options and pick one |
+| **observation** | You hit a non-obvious error or gotcha |
+| **reference** | You look something up twice in one session |
+| **procedure** | You discover a multi-step workflow by doing it |
+| **resource** | A useful URL comes up |
+
+## Data Storage
+
+Notes are stored locally in `~/.local/share/open-zk-kb/` as Markdown files with YAML frontmatter. SQLite with FTS5 provides fast full-text search. Optional local embeddings (MiniLM-L6-v2) enable semantic search.
+
+## Configuration
+
+Optional config at `~/.config/open-zk-kb/config.yaml`:
+
+```yaml
+vault: ~/.local/share/open-zk-kb  # Note storage location
+logLevel: INFO                     # DEBUG, INFO, WARN, ERROR
+
+embeddings:
+  enabled: true                    # Enable semantic search
+  provider: local                  # local (default) or api
+```
+
+## Documentation
+
+- [Full Documentation](https://mrosnerr.github.io/open-zk-kb)
+- [GitHub Repository](https://github.com/mrosnerr/open-zk-kb)
+
+## License
+
+MIT

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -61,11 +61,17 @@ claude --plugin-dir /path/to/open-zk-kb/plugin
 
 ## Data Storage
 
-Notes are stored locally in `~/.local/share/open-zk-kb/` as Markdown files with YAML frontmatter. SQLite with FTS5 provides fast full-text search. Optional local embeddings (MiniLM-L6-v2) enable semantic search.
+Notes are stored locally as Markdown files with YAML frontmatter. SQLite with FTS5 provides fast full-text search. Optional local embeddings (MiniLM-L6-v2) enable semantic search.
+
+**Default storage locations** (override via `vault` in config):
+- **Linux / macOS:** `~/.local/share/open-zk-kb/`
+- **Windows:** `%LOCALAPPDATA%\open-zk-kb\` (or set `XDG_DATA_HOME`)
 
 ## Configuration
 
-Optional config at `~/.config/open-zk-kb/config.yaml`:
+**Default config locations:**
+- **Linux / macOS:** `~/.config/open-zk-kb/config.yaml`
+- **Windows:** `%LOCALAPPDATA%\open-zk-kb\config.yaml` (or set `XDG_CONFIG_HOME`)
 
 ```yaml
 vault: ~/.local/share/open-zk-kb  # Note storage location

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -24,13 +24,13 @@ This plugin includes pre-compiled binaries for all platforms. No runtime depende
 
 ### From Official Marketplace
 
-```
+```text
 /plugin install open-zk-kb@claude-plugins-official
 ```
 
 ### From GitHub
 
-```
+```text
 /plugin install github:mrosnerr/open-zk-kb/plugin
 ```
 

--- a/plugin/bin/run.cmd
+++ b/plugin/bin/run.cmd
@@ -12,3 +12,4 @@ if not exist "%BINARY%" (
 )
 
 "%BINARY%" %*
+\r

--- a/plugin/bin/run.cmd
+++ b/plugin/bin/run.cmd
@@ -1,0 +1,14 @@
+@echo off
+REM Platform detection and binary selection for open-zk-kb MCP server (Windows)
+
+set "SCRIPT_DIR=%~dp0"
+set "BINARY=%SCRIPT_DIR%open-zk-kb-windows-x64.exe"
+
+if not exist "%BINARY%" (
+  echo Binary not found: %BINARY% >&2
+  echo Available binaries: >&2
+  dir /b "%SCRIPT_DIR%open-zk-kb-*" 2>nul >&2
+  exit /b 1
+)
+
+"%BINARY%" %*

--- a/plugin/bin/run.sh
+++ b/plugin/bin/run.sh
@@ -25,11 +25,21 @@ if [ "$OS" = "windows" ]; then
   BINARY="${BINARY}.exe"
 fi
 
-if [ ! -x "$BINARY" ]; then
-  echo "Binary not found or not executable: $BINARY" >&2
-  echo "Available binaries:" >&2
-  ls -la "$SCRIPT_DIR"/open-zk-kb-* 2>/dev/null >&2
-  exit 1
+# Check binary exists (use -f for Windows .exe, -x for others)
+if [ "$OS" = "windows" ]; then
+  if [ ! -f "$BINARY" ]; then
+    echo "Binary not found: $BINARY" >&2
+    echo "Available binaries:" >&2
+    ls -la "$SCRIPT_DIR"/open-zk-kb-* 2>/dev/null >&2
+    exit 1
+  fi
+else
+  if [ ! -x "$BINARY" ]; then
+    echo "Binary not found or not executable: $BINARY" >&2
+    echo "Available binaries:" >&2
+    ls -la "$SCRIPT_DIR"/open-zk-kb-* 2>/dev/null >&2
+    exit 1
+  fi
 fi
 
 exec "$BINARY" "$@"

--- a/plugin/bin/run.sh
+++ b/plugin/bin/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Platform detection and binary selection for open-zk-kb MCP server
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Detect OS
+case "$(uname -s)" in
+  Darwin*) OS="darwin" ;;
+  Linux*)  OS="linux" ;;
+  MINGW*|MSYS*|CYGWIN*) OS="windows" ;;
+  *)       echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+# Detect architecture
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="x64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *)            echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+BINARY="$SCRIPT_DIR/open-zk-kb-${OS}-${ARCH}"
+
+# Add .exe extension on Windows
+if [ "$OS" = "windows" ]; then
+  BINARY="${BINARY}.exe"
+fi
+
+if [ ! -x "$BINARY" ]; then
+  echo "Binary not found or not executable: $BINARY" >&2
+  echo "Available binaries:" >&2
+  ls -la "$SCRIPT_DIR"/open-zk-kb-* 2>/dev/null >&2
+  exit 1
+fi
+
+exec "$BINARY" "$@"

--- a/scripts/build-plugin.ts
+++ b/scripts/build-plugin.ts
@@ -25,7 +25,11 @@ async function main() {
   // Get version from package.json
   const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
   const version = pkg.version;
-  
+  if (typeof version !== 'string' || !/^\d+\.\d+\.\d+/.test(version)) {
+    console.error(`Invalid or missing version in package.json: ${version}`);
+    process.exit(1);
+  }
+
   console.log(`Building open-zk-kb v${version} for Claude Code plugin...\n`);
 
   // Ensure plugin/bin directory exists

--- a/scripts/build-plugin.ts
+++ b/scripts/build-plugin.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env bun
+// scripts/build-plugin.ts - Build cross-platform binaries for Claude Code plugin
+// Usage: bun run scripts/build-plugin.ts
+
+import { $ } from 'bun';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TARGETS = [
+  { target: 'bun-darwin-arm64', output: 'open-zk-kb-darwin-arm64' },
+  { target: 'bun-darwin-x64', output: 'open-zk-kb-darwin-x64' },
+  { target: 'bun-linux-x64', output: 'open-zk-kb-linux-x64' },
+  { target: 'bun-linux-arm64', output: 'open-zk-kb-linux-arm64' },
+  { target: 'bun-windows-x64', output: 'open-zk-kb-windows-x64.exe' },
+];
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const PLUGIN_DIR = path.join(ROOT, 'plugin');
+const PLUGIN_BIN = path.join(PLUGIN_DIR, 'bin');
+const PLUGIN_SKILLS = path.join(PLUGIN_DIR, 'skills', 'open-zk-kb');
+const SOURCE_SKILLS = path.join(ROOT, 'skills', 'open-zk-kb');
+const ENTRYPOINT = path.join(ROOT, 'src', 'mcp-server.ts');
+
+async function main() {
+  // Get version from package.json
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
+  const version = pkg.version;
+  
+  console.log(`Building open-zk-kb v${version} for Claude Code plugin...\n`);
+
+  // Ensure plugin/bin directory exists
+  fs.mkdirSync(PLUGIN_BIN, { recursive: true });
+
+  // Build for each target
+  for (const { target, output } of TARGETS) {
+    const outfile = path.join(PLUGIN_BIN, output);
+    console.log(`  Building ${target}...`);
+    
+    try {
+      const defineArg = `__PKG_VERSION__="${version}"`;
+      await $`bun build --compile --target=${target} --define ${defineArg} ${ENTRYPOINT} --outfile ${outfile}`.quiet();
+      
+      const stats = fs.statSync(outfile);
+      const sizeMB = (stats.size / 1024 / 1024).toFixed(1);
+      console.log(`    ✓ ${output} (${sizeMB} MB)`);
+    } catch (error) {
+      console.error(`    ✗ Failed to build ${target}:`, error);
+      process.exit(1);
+    }
+  }
+
+  // Update plugin.json version
+  const pluginJsonPath = path.join(PLUGIN_DIR, '.claude-plugin', 'plugin.json');
+  const pluginJson = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'));
+  pluginJson.version = version;
+  fs.writeFileSync(pluginJsonPath, JSON.stringify(pluginJson, null, 2) + '\n');
+  console.log(`\n  Updated plugin.json version to ${version}`);
+
+  // Copy skills from source to plugin
+  console.log('\n  Copying skills...');
+  fs.mkdirSync(PLUGIN_SKILLS, { recursive: true });
+  for (const file of fs.readdirSync(SOURCE_SKILLS)) {
+    const src = path.join(SOURCE_SKILLS, file);
+    const dest = path.join(PLUGIN_SKILLS, file);
+    fs.copyFileSync(src, dest);
+    console.log(`    ✓ ${file}`);
+  }
+
+  console.log('\n✓ Plugin build complete!');
+  console.log(`  Binaries: ${PLUGIN_BIN}`);
+  console.log(`  Skills: ${PLUGIN_SKILLS}`);
+}
+
+main().catch(console.error);

--- a/scripts/build-plugin.ts
+++ b/scripts/build-plugin.ts
@@ -56,13 +56,11 @@ async function main() {
   fs.writeFileSync(pluginJsonPath, JSON.stringify(pluginJson, null, 2) + '\n');
   console.log(`\n  Updated plugin.json version to ${version}`);
 
-  // Copy skills from source to plugin
+  // Copy skills from source to plugin (clean first to remove stale files)
   console.log('\n  Copying skills...');
-  fs.mkdirSync(PLUGIN_SKILLS, { recursive: true });
-  for (const file of fs.readdirSync(SOURCE_SKILLS)) {
-    const src = path.join(SOURCE_SKILLS, file);
-    const dest = path.join(PLUGIN_SKILLS, file);
-    fs.copyFileSync(src, dest);
+  fs.rmSync(PLUGIN_SKILLS, { recursive: true, force: true });
+  fs.cpSync(SOURCE_SKILLS, PLUGIN_SKILLS, { recursive: true });
+  for (const file of fs.readdirSync(PLUGIN_SKILLS)) {
     console.log(`    ✓ ${file}`);
   }
 
@@ -71,4 +69,7 @@ async function main() {
   console.log(`  Skills: ${PLUGIN_SKILLS}`);
 }
 
-main().catch(console.error);
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/build-plugin.ts
+++ b/scripts/build-plugin.ts
@@ -25,7 +25,8 @@ async function main() {
   // Get version from package.json
   const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
   const version = pkg.version;
-  if (typeof version !== 'string' || !/^\d+\.\d+\.\d+/.test(version)) {
+  const semverRe = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+  if (typeof version !== 'string' || !semverRe.test(version)) {
     console.error(`Invalid or missing version in package.json: ${version}`);
     process.exit(1);
   }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -102,10 +102,12 @@ async function main(): Promise<void> {
   const changelogFile = Bun.file('CHANGELOG.md');
   const serverJsonFile = Bun.file('server.json');
   const skillFile = Bun.file('skills/open-zk-kb/SKILL.md');
+  const pluginJsonFile = Bun.file('plugin/.claude-plugin/plugin.json');
   const packageJsonText = await packageFile.text();
   const changelogText = await changelogFile.text();
   const serverJsonText = await serverJsonFile.text();
   const skillText = await skillFile.text();
+  const pluginJsonText = await pluginJsonFile.text();
   const pkg = JSON.parse(packageJsonText) as { version?: string };
 
   if (!pkg.version) {
@@ -156,6 +158,12 @@ async function main(): Promise<void> {
     `$1${nextVersion}`
   );
 
+  // Sync plugin/.claude-plugin/plugin.json version
+  const updatedPluginJson = pluginJsonText.replace(
+    /"version":\s*"[^"]+"/,
+    `"version": "${nextVersion}"`
+  );
+
   p.log.step(`Version: ${pkg.version} ${color.dim('→')} ${nextVersion}`);
   p.log.step(`Commits: ${commitMessages.length}`);
   p.log.message('Preview CHANGELOG entry:');
@@ -179,8 +187,9 @@ async function main(): Promise<void> {
   await Bun.write('CHANGELOG.md', updatedChangelog);
   await Bun.write('server.json', updatedServerJson);
   await Bun.write('skills/open-zk-kb/SKILL.md', updatedSkillText);
+  await Bun.write('plugin/.claude-plugin/plugin.json', updatedPluginJson);
 
-  mustRun(['git', 'add', 'package.json', 'CHANGELOG.md', 'server.json', 'skills/open-zk-kb/SKILL.md'], 'git add');
+  mustRun(['git', 'add', 'package.json', 'CHANGELOG.md', 'server.json', 'skills/open-zk-kb/SKILL.md', 'plugin/.claude-plugin/plugin.json'], 'git add');
   mustRun(['git', 'commit', '-m', `Bump to ${nextVersion}`], 'git commit');
   mustRun(['git', 'push', 'origin', 'dev'], 'git push');
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -159,10 +159,9 @@ async function main(): Promise<void> {
   );
 
   // Sync plugin/.claude-plugin/plugin.json version
-  const updatedPluginJson = pluginJsonText.replace(
-    /"version":\s*"[^"]+"/,
-    `"version": "${nextVersion}"`
-  );
+  const parsedPluginJson = JSON.parse(pluginJsonText) as Record<string, unknown>;
+  parsedPluginJson.version = nextVersion;
+  const updatedPluginJson = JSON.stringify(parsedPluginJson, null, 2) + '\n';
 
   p.log.step(`Version: ${pkg.version} ${color.dim('→')} ${nextVersion}`);
   p.log.step(`Commits: ${commitMessages.length}`);

--- a/server.json
+++ b/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "open-zk-kb",
-"version": "1.0.11",
+      "version": "1.0.11",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.mrosnerr/open-zk-kb",
   "description": "Shared, persistent memory for AI assistants, built on the Zettelkasten method.",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "websiteUrl": "https://mrosnerr.github.io/open-zk-kb",
   "repository": {
     "url": "https://github.com/mrosnerr/open-zk-kb",
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "open-zk-kb",
-"version": "1.0.10",
+"version": "1.0.11",
       "transport": {
         "type": "stdio"
       }

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-zk-kb
-version: 1.0.10
+version: 1.0.11
 description: >
   Persistent knowledge base for cross-session memory. BEFORE responding to any
   user message: (1) knowledge-search for relevant context, (2) scan for storage

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -22,10 +22,15 @@ import { generateEmbedding, DEFAULT_EMBEDDING_CONFIG } from './embeddings.js';
 import type { EmbeddingConfig } from './embeddings.js';
 import type { NoteKind } from './types.js';
 import type { NoteRepository as NoteRepositoryType } from './storage/NoteRepository.js';
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-const { version: PKG_VERSION } = require('../package.json');
+// Version injected at compile time via --define, or read from package.json at runtime
+declare const __PKG_VERSION__: string | undefined;
+const PKG_VERSION: string = typeof __PKG_VERSION__ !== 'undefined'
+  ? __PKG_VERSION__
+  : (() => {
+      const { createRequire } = require('module');
+      const req = createRequire(import.meta.url);
+      return req('../package.json').version;
+    })();
 const { NoteRepository } = await import('./storage/NoteRepository.js');
 
 const config = getConfig();

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -27,6 +27,7 @@ declare const __PKG_VERSION__: string | undefined;
 const PKG_VERSION: string = typeof __PKG_VERSION__ !== 'undefined'
   ? __PKG_VERSION__
   : (() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { createRequire } = require('module');
       const req = createRequire(import.meta.url);
       return req('../package.json').version;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -22,16 +22,8 @@ import { generateEmbedding, DEFAULT_EMBEDDING_CONFIG } from './embeddings.js';
 import type { EmbeddingConfig } from './embeddings.js';
 import type { NoteKind } from './types.js';
 import type { NoteRepository as NoteRepositoryType } from './storage/NoteRepository.js';
-// Version injected at compile time via --define, or read from package.json at runtime
-declare const __PKG_VERSION__: string | undefined;
-const PKG_VERSION: string = typeof __PKG_VERSION__ !== 'undefined'
-  ? __PKG_VERSION__
-  : (() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { createRequire } = require('module');
-      const req = createRequire(import.meta.url);
-      return req('../package.json').version;
-    })();
+import { PKG_VERSION } from './version.js';
+
 const { NoteRepository } = await import('./storage/NoteRepository.js');
 
 const config = getConfig();

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -15,6 +15,7 @@ declare const __PKG_VERSION__: string | undefined;
 const PKG_VERSION: string = typeof __PKG_VERSION__ !== 'undefined'
   ? __PKG_VERSION__
   : (() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { createRequire } = require('module');
       const req = createRequire(import.meta.url);
       return req('../package.json').version;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -10,10 +10,15 @@ import color from 'picocolors';
 import { expandPath } from './utils/path.js';
 import { injectAgentDocs, inspectAgentDocs, removeAgentDocs } from './agent-docs.js';
 import type { InstructionSize } from './agent-docs.js';
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-const { version: PKG_VERSION } = require('../package.json') as { version: string };
+// Version injected at compile time via --define, or read from package.json at runtime
+declare const __PKG_VERSION__: string | undefined;
+const PKG_VERSION: string = typeof __PKG_VERSION__ !== 'undefined'
+  ? __PKG_VERSION__
+  : (() => {
+      const { createRequire } = require('module');
+      const req = createRequire(import.meta.url);
+      return req('../package.json').version;
+    })();
 
 const xdgConfigHome = process.env.XDG_CONFIG_HOME || expandPath('~/.config');
 const xdgDataHome = process.env.XDG_DATA_HOME || expandPath('~/.local/share');

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -10,16 +10,7 @@ import color from 'picocolors';
 import { expandPath } from './utils/path.js';
 import { injectAgentDocs, inspectAgentDocs, removeAgentDocs } from './agent-docs.js';
 import type { InstructionSize } from './agent-docs.js';
-// Version injected at compile time via --define, or read from package.json at runtime
-declare const __PKG_VERSION__: string | undefined;
-const PKG_VERSION: string = typeof __PKG_VERSION__ !== 'undefined'
-  ? __PKG_VERSION__
-  : (() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { createRequire } = require('module');
-      const req = createRequire(import.meta.url);
-      return req('../package.json').version;
-    })();
+import { PKG_VERSION } from './version.js';
 
 const xdgConfigHome = process.env.XDG_CONFIG_HOME || expandPath('~/.config');
 const xdgDataHome = process.env.XDG_DATA_HOME || expandPath('~/.local/share');

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,19 @@
+// version.ts - Centralized package version resolution
+// Supports compile-time injection (__PKG_VERSION__) with runtime fallback
+
+import { createRequire } from 'module';
+
+declare const __PKG_VERSION__: string | undefined;
+
+/**
+ * Get the package version.
+ * Uses compile-time injected __PKG_VERSION__ if available (for compiled binaries),
+ * otherwise falls back to reading package.json at runtime.
+ */
+export const PKG_VERSION: string = (() => {
+  if (typeof __PKG_VERSION__ !== 'undefined') {
+    return __PKG_VERSION__;
+  }
+  const require = createRequire(import.meta.url);
+  return (require('../package.json') as { version: string }).version;
+})();

--- a/src/version.ts
+++ b/src/version.ts
@@ -11,7 +11,7 @@ declare const __PKG_VERSION__: string | undefined;
  * otherwise falls back to reading package.json at runtime.
  */
 export const PKG_VERSION: string = (() => {
-  if (typeof __PKG_VERSION__ !== 'undefined') {
+  if (typeof __PKG_VERSION__ === 'string' && __PKG_VERSION__.trim() !== '') {
     return __PKG_VERSION__;
   }
   const require = createRequire(import.meta.url);

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,5 +15,9 @@ export const PKG_VERSION: string = (() => {
     return __PKG_VERSION__;
   }
   const require = createRequire(import.meta.url);
-  return (require('../package.json') as { version: string }).version;
+  const pkg = require('../package.json') as { version?: unknown };
+  if (typeof pkg.version !== 'string' || !pkg.version) {
+    throw new Error('Invalid or missing version in package.json');
+  }
+  return pkg.version;
 })();


### PR DESCRIPTION
## Summary

- Add Claude Code plugin packaging with pre-compiled binaries for macOS (Apple Silicon & Intel), Linux (x64 & ARM64), and Windows (x64)
- Add CodeRabbit automated code review configuration
- Bump @huggingface/transformers from 3.8.1 to 4.0.1
- Bump @typescript-eslint/eslint-plugin and parser to 8.58.1 for eslint 10 compatibility
- Add centralized version management with compile-time injection and runtime fallback
- Sync plugin.json version in release script for CI consistency

## Changes

- Add runtime validation for package.json version fallback
- Address CodeRabbit review feedback
- Enable request changes workflow for CodeRabbit
- Add CodeRabbit config for auto-review
- Fix ESLint no-require-imports error
- Bump @huggingface/transformers from 3.8.1 to 4.0.1
- Add Claude Code plugin packaging with compiled binaries
- Bump @typescript-eslint/eslint-plugin and parser to 8.58.1
- Sync plugin.json version in release script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-built plugin binaries for macOS, Linux, and Windows with platform-aware launchers and runtime validation.

* **Chores**
  * Release bumped to 1.0.11; added build and release automation to compile, package, and sync plugin versions.
  * CI updated to detect plugin changes and enforce version consistency.
  * Dependency/tooling upgrades and ignore rules for plugin artifacts added.
  * Added automated code-review and Cubic review configurations; ensured Windows line-ending handling.

* **Documentation**
  * Plugin README and changelog entry added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->