### PR TITLE
Add model-aware capability detection via agent self-report

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -89,6 +89,7 @@ const storeSchema = z.object({
   project: z.string().optional().describe('Project scope — auto-adds project:<name> tag'),
   client: z.string().optional().describe('Client identifier (e.g. claude-code, opencode). Auto-detected from content when omitted.'),
   related: z.array(z.string()).optional().describe('IDs of related notes to link via wikilinks'),
+  model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
 });
 
 server.registerTool(
@@ -110,6 +111,7 @@ server.registerTool(
         project: args.project,
         client: args.client,
         related: args.related,
+        model: args.model,
       }, getOrCreateRepo(), getEmbeddingConfig());
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
@@ -151,6 +153,7 @@ const searchSchema = z.object({
   client: z.string().optional().describe('Your client name — excludes notes scoped to other clients'),
   tags: z.array(z.string()).optional().describe('Filter by tags (all must match)'),
   limit: z.number().optional().describe('Max results (default 10)'),
+  model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
 });
 
 server.registerTool(
@@ -176,6 +179,7 @@ server.registerTool(
         client: args.client,
         tags: args.tags,
         limit: args.limit,
+        model: args.model,
       }, getOrCreateRepo(), queryEmbedding);
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
@@ -200,6 +204,7 @@ const maintainSchema = z.object({
   days: z.number().optional().describe('Days threshold for review (default: from lifecycle.reviewAfterDays config)'),
   limit: z.number().optional().describe('Max notes to show (default: 3 for review)'),
   dryRun: z.boolean().optional().describe('Preview changes without applying'),
+  model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
 });
 
 server.registerTool(
@@ -217,6 +222,7 @@ server.registerTool(
         days: args.days,
         limit: args.limit,
         dryRun: args.dryRun,
+        model: args.model,
       }, getOrCreateRepo(), config, getEmbeddingConfig(), PKG_VERSION);
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {

--- a/src/model-capabilities.ts
+++ b/src/model-capabilities.ts
@@ -7,7 +7,7 @@
 export type CapabilityTier = 'high' | 'medium' | 'low';
 
 // ---- Model family patterns ----
-// Ordered: high-tier checked first, then low-tier. Everything else = medium.
+// Ordered: low-tier checked first (mini/nano/flash override high-tier bases). Everything else = medium.
 
 const HIGH_TIER_PATTERNS: RegExp[] = [
   /\bopus\b/i,
@@ -26,7 +26,6 @@ const LOW_TIER_PATTERNS: RegExp[] = [
   /\bflash\b/i,
   /\bnano\b/i,
   /\bgpt-?3\.?5\b/i,
-  /\bgpt-?4o-mini\b/i,
   /\bgemma\b/i,
   /\bphi-/i,
   /\bqwen.*\b[0-3]b\b/i,  // ≤3B parameter models

--- a/src/model-capabilities.ts
+++ b/src/model-capabilities.ts
@@ -43,12 +43,14 @@ export function classifyModel(model: string | undefined): CapabilityTier {
 
   const normalized = model.trim();
 
-  for (const pattern of HIGH_TIER_PATTERNS) {
-    if (pattern.test(normalized)) return 'high';
-  }
-
+  // Low-tier checked first: "mini"/"nano"/"flash" suffixes override high-tier bases
+  // (e.g., gpt-5-mini → low, not high)
   for (const pattern of LOW_TIER_PATTERNS) {
     if (pattern.test(normalized)) return 'low';
+  }
+
+  for (const pattern of HIGH_TIER_PATTERNS) {
+    if (pattern.test(normalized)) return 'high';
   }
 
   return 'medium';

--- a/src/model-capabilities.ts
+++ b/src/model-capabilities.ts
@@ -1,0 +1,57 @@
+// model-capabilities.ts - Model capability detection via agent self-report
+//
+// Classifies calling models into capability tiers based on self-reported model
+// identifiers. Gates response richness — richer output for capable models,
+// conservative output for weaker ones or when model is unknown.
+
+export type CapabilityTier = 'high' | 'medium' | 'low';
+
+// ---- Model family patterns ----
+// Ordered: high-tier checked first, then low-tier. Everything else = medium.
+
+const HIGH_TIER_PATTERNS: RegExp[] = [
+  /\bopus\b/i,
+  /\bgpt-?5\b/i,
+  /\bo[34]-/i,             // o3-*, o4-* reasoning models
+  /\bgemini[- ]?2\.?5[- ]?pro\b/i,
+  /\bgemini[- ]?ultra\b/i,
+  /\bdeepseek[- ]?r1\b/i,
+  /\bkimi[- ]?k2/i,        // kimi-k2, kimi-k2.5
+  /\bglm[- ]?5\b/i,
+];
+
+const LOW_TIER_PATTERNS: RegExp[] = [
+  /\bhaiku\b/i,
+  /\bmini\b/i,
+  /\bflash\b/i,
+  /\bnano\b/i,
+  /\bgpt-?3\.?5\b/i,
+  /\bgpt-?4o-mini\b/i,
+  /\bgemma\b/i,
+  /\bphi-/i,
+  /\bqwen.*\b[0-3]b\b/i,  // ≤3B parameter models
+  /\bllama.*\b[0-8]b\b/i, // ≤8B parameter models
+];
+
+/**
+ * Classify a model identifier into a capability tier.
+ * @param model Self-reported model identifier (e.g., 'claude-opus-4', 'gpt-4o-mini').
+ * @returns 'high', 'medium', or 'low'. Returns 'medium' when model is undefined.
+ */
+export function classifyModel(model: string | undefined): CapabilityTier {
+  if (!model || model.trim() === '') return 'medium';
+
+  const normalized = model.trim();
+
+  for (const pattern of HIGH_TIER_PATTERNS) {
+    if (pattern.test(normalized)) return 'high';
+  }
+
+  for (const pattern of LOW_TIER_PATTERNS) {
+    if (pattern.test(normalized)) return 'low';
+  }
+
+  return 'medium';
+}
+
+export const MODEL_HINT = '\n\n💡 Pass the `model` parameter (e.g., model="claude-opus-4") to enable richer responses including related note suggestions.';

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -22,6 +22,7 @@ import { getAgentDocsTargets } from './agent-docs-targets.js';
 import { injectAgentDocs, inspectAgentDocs } from './agent-docs.js';
 import { detectClient, isVisibleToClient, getClientTags, clientTag, isKnownClient } from './client-heuristics.js';
 import { getInstalledInstructionVersions } from './instruction-versions.js';
+import { MODEL_HINT } from './model-capabilities.js';
 
 // ---- Constants ----
 
@@ -81,6 +82,7 @@ export interface StoreArgs {
   project?: string;
   client?: string;
   related?: string[];
+  model?: string;
 }
 
 export interface SearchArgs {
@@ -91,6 +93,7 @@ export interface SearchArgs {
   client?: string;
   tags?: string[];
   limit?: number;
+  model?: string;
 }
 
 export interface MaintainArgs {
@@ -100,6 +103,7 @@ export interface MaintainArgs {
   days?: number;
   limit?: number;
   dryRun?: boolean;
+  model?: string;
 }
 
 function describeAgentDocsStatus(status: ReturnType<typeof inspectAgentDocs>['status']): string {
@@ -189,6 +193,10 @@ export function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConf
 
   if (args.client && !isKnownClient(args.client)) {
     output += `\n\n⚠ Unrecognized client "${args.client}". Known clients: opencode, claude-code, cursor, windsurf, zed.`;
+  }
+
+  if (!args.model) {
+    output += MODEL_HINT;
   }
 
   return output;

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -22,7 +22,7 @@ import { getAgentDocsTargets } from './agent-docs-targets.js';
 import { injectAgentDocs, inspectAgentDocs } from './agent-docs.js';
 import { detectClient, isVisibleToClient, getClientTags, clientTag, isKnownClient } from './client-heuristics.js';
 import { getInstalledInstructionVersions } from './instruction-versions.js';
-import { MODEL_HINT } from './model-capabilities.js';
+import { classifyModel, MODEL_HINT } from './model-capabilities.js';
 
 // ---- Constants ----
 
@@ -195,8 +195,11 @@ export function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConf
     output += `\n\n⚠ Unrecognized client "${args.client}". Known clients: opencode, claude-code, cursor, windsurf, zed.`;
   }
 
+  const tier = classifyModel(args.model);
   if (!args.model) {
     output += MODEL_HINT;
+  } else if (tier === 'high') {
+    output += `\n\nCapability: ${tier}`;
   }
 
   return output;

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -1402,7 +1402,97 @@ describe('MCP Tool: knowledge-maintain scope-audit', () => {
     const output = await handleMaintain(
       { action: 'scope-audit', dryRun: true }, ctx.engine, ctx.config,
     );
-    expect(output).toContain('client:vscode: 1 ⚠ unrecognized');
+     expect(output).toContain('client:vscode: 1 ⚠ unrecognized');
     expect(output).not.toContain('client:opencode: 1 ⚠');
+  });
+});
+
+describe('MCP Tool: knowledge-store (model capability)', () => {
+  let ctx: TestContext;
+
+  beforeEach(() => { ctx = createTestHarness(); });
+  afterEach(() => { cleanupTestHarness(ctx); });
+
+  it('should append model hint when model param is absent', async () => {
+    const output = await handleStore({
+      title: 'No Model',
+      content: 'Test content',
+      kind: 'observation',
+      summary: 'Test',
+      guidance: 'Test',
+    }, ctx.engine);
+
+    expect(output).toContain('💡');
+    expect(output).toContain('model');
+  });
+
+  it('should not append model hint when model param is provided', async () => {
+    const output = await handleStore({
+      title: 'With Model',
+      content: 'Test content',
+      kind: 'observation',
+      summary: 'Test',
+      guidance: 'Test',
+      model: 'claude-sonnet-4',
+    }, ctx.engine);
+
+    expect(output).not.toContain('💡');
+  });
+
+  it('should show capability tier for high-tier models', async () => {
+    const output = await handleStore({
+      title: 'High Tier',
+      content: 'Test content',
+      kind: 'observation',
+      summary: 'Test',
+      guidance: 'Test',
+      model: 'claude-opus-4',
+    }, ctx.engine);
+
+    expect(output).toContain('Capability: high');
+  });
+
+  it('should not show capability tier for medium-tier models', async () => {
+    const output = await handleStore({
+      title: 'Medium Tier',
+      content: 'Test content',
+      kind: 'observation',
+      summary: 'Test',
+      guidance: 'Test',
+      model: 'claude-sonnet-4',
+    }, ctx.engine);
+
+    expect(output).not.toContain('Capability:');
+  });
+
+  it('should not show capability tier for low-tier models', async () => {
+    const output = await handleStore({
+      title: 'Low Tier',
+      content: 'Test content',
+      kind: 'observation',
+      summary: 'Test',
+      guidance: 'Test',
+      model: 'claude-haiku',
+    }, ctx.engine);
+
+    expect(output).not.toContain('Capability:');
+  });
+
+  it('should still store the note correctly regardless of model param', async () => {
+    const output = await handleStore({
+      title: 'Model Store Test',
+      content: 'Important knowledge',
+      kind: 'reference',
+      summary: 'Test storage with model',
+      guidance: 'Test guidance',
+      model: 'gpt-4o-mini',
+    }, ctx.engine);
+
+    expect(output).toContain('Knowledge stored (created)');
+    expect(output).toContain('Kind: reference');
+
+    const notes = ctx.engine.search('Important knowledge');
+    expect(notes.length).toBe(1);
+    expect(notes[0].title).toBe('Model Store Test');
   });
 });

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -10,8 +10,8 @@ describe('classifyModel', () => {
       'gpt-5',
       'gpt-5.4',
       'openai/gpt-5',
-      'o3-mini',
-      'o4-mini',
+      'o3-pro',
+      'o4-preview',
       'gemini-2.5-pro',
       'gemini-25-pro',
       'gemini-ultra',
@@ -35,6 +35,9 @@ describe('classifyModel', () => {
       'gpt-4o-mini',
       'gpt-3.5-turbo',
       'gpt-35-turbo',
+      'gpt-5-mini',
+      'o3-mini',
+      'o4-mini',
       'gemini-flash',
       'gemini-nano',
       'gemma-2b',
@@ -114,6 +117,21 @@ describe('classifyModel', () => {
     it('trims leading/trailing whitespace', () => {
       expect(classifyModel('  claude-opus-4  ')).toBe('high');
     });
+  });
+
+  describe('tier collision: low suffix overrides high base', () => {
+    const collisionModels: Array<[string, 'low']> = [
+      ['gpt-5-mini', 'low'],
+      ['gpt-5-nano', 'low'],
+      ['o3-mini', 'low'],
+      ['o4-mini', 'low'],
+    ];
+
+    for (const [model, expected] of collisionModels) {
+      it(`classifies "${model}" as ${expected} (low suffix wins)`, () => {
+        expect(classifyModel(model)).toBe(expected);
+      });
+    }
   });
 });
 

--- a/tests/model-capabilities.test.ts
+++ b/tests/model-capabilities.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'bun:test';
+import { classifyModel, MODEL_HINT } from '../src/model-capabilities.js';
+
+describe('classifyModel', () => {
+  describe('high tier', () => {
+    const highModels = [
+      'claude-opus-4',
+      'claude-opus-4-6',
+      'anthropic/claude-opus-4-6',
+      'gpt-5',
+      'gpt-5.4',
+      'openai/gpt-5',
+      'o3-mini',
+      'o4-mini',
+      'gemini-2.5-pro',
+      'gemini-25-pro',
+      'gemini-ultra',
+      'deepseek-r1',
+      'kimi-k2',
+      'kimi-k2.5',
+      'glm-5',
+    ];
+
+    for (const model of highModels) {
+      it(`classifies "${model}" as high`, () => {
+        expect(classifyModel(model)).toBe('high');
+      });
+    }
+  });
+
+  describe('low tier', () => {
+    const lowModels = [
+      'claude-haiku',
+      'claude-3-haiku',
+      'gpt-4o-mini',
+      'gpt-3.5-turbo',
+      'gpt-35-turbo',
+      'gemini-flash',
+      'gemini-nano',
+      'gemma-2b',
+      'phi-3',
+      'phi-4-mini',
+      'qwen-2b',
+      'llama-3-8b',
+      'llama-8b',
+    ];
+
+    for (const model of lowModels) {
+      it(`classifies "${model}" as low`, () => {
+        expect(classifyModel(model)).toBe('low');
+      });
+    }
+  });
+
+  describe('medium tier (default)', () => {
+    const mediumModels = [
+      'claude-sonnet-4',
+      'claude-3.5-sonnet',
+      'gpt-4o',
+      'gpt-4-turbo',
+      'gemini-pro',
+      'gemini-2.0-pro',
+      'mistral-large',
+      'command-r-plus',
+      'unknown-model-xyz',
+    ];
+
+    for (const model of mediumModels) {
+      it(`classifies "${model}" as medium`, () => {
+        expect(classifyModel(model)).toBe('medium');
+      });
+    }
+  });
+
+  describe('undefined/empty input', () => {
+    it('returns medium for undefined', () => {
+      expect(classifyModel(undefined)).toBe('medium');
+    });
+
+    it('returns medium for empty string', () => {
+      expect(classifyModel('')).toBe('medium');
+    });
+
+    it('returns medium for whitespace-only', () => {
+      expect(classifyModel('   ')).toBe('medium');
+    });
+  });
+
+  describe('provider-prefixed models', () => {
+    it('handles anthropic/ prefix', () => {
+      expect(classifyModel('anthropic/claude-opus-4')).toBe('high');
+    });
+
+    it('handles openai/ prefix', () => {
+      expect(classifyModel('openai/gpt-5.4')).toBe('high');
+    });
+
+    it('handles github-copilot/ prefix', () => {
+      expect(classifyModel('github-copilot/claude-haiku')).toBe('low');
+    });
+  });
+
+  describe('case insensitivity', () => {
+    it('handles uppercase', () => {
+      expect(classifyModel('Claude-OPUS-4')).toBe('high');
+    });
+
+    it('handles mixed case', () => {
+      expect(classifyModel('GPT-4o-Mini')).toBe('low');
+    });
+  });
+
+  describe('whitespace handling', () => {
+    it('trims leading/trailing whitespace', () => {
+      expect(classifyModel('  claude-opus-4  ')).toBe('high');
+    });
+  });
+});
+
+describe('MODEL_HINT', () => {
+  it('is a non-empty string', () => {
+    expect(MODEL_HINT.length).toBeGreaterThan(0);
+  });
+
+  it('mentions the model parameter', () => {
+    expect(MODEL_HINT).toContain('model');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds optional `model` parameter to all 3 MCP tools (`knowledge-store`, `knowledge-search`, `knowledge-maintain`)
- Introduces `classifyModel()` in new `src/model-capabilities.ts` — deterministic string-matching classification into `high`/`medium`/`low` capability tiers
- Appends a soft hint to `knowledge-store` responses when `model` is not provided, nudging agents to self-report
- Infrastructure for gating response richness in future features (#76, #77, #78, #79, #80)

## Non-Breaking

- `model` parameter is optional on all tools — existing callers unaffected
- All 433 existing tests pass without modification
- 48 new tests for model classification (high/medium/low tiers, edge cases, provider prefixes, case insensitivity)

Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tools now accept an optional model parameter to enable richer, context-aware responses
  * Model capability detection automatically optimizes outputs based on the selected model
  * Helpful guidance prompts appear when model information isn't provided to improve user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->