### PR TITLE
Add knowledge-ingest tool for URL content extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,14 @@ Supported clients: **OpenCode**, **Claude Code**, **Cursor**, **Windsurf**, **Ze
 
 ## How It Works
 
-Your AI assistant gets three MCP tools:
+Your AI assistant gets four MCP tools:
 
 | Tool | What it does |
 |------|-------------|
 | `knowledge-search` | Search the knowledge base before starting work |
 | `knowledge-store` | Save decisions, preferences, procedures, and insights |
 | `knowledge-maintain` | Review, promote, archive, and rebuild notes |
+| `knowledge-ingest` | Extract article content from URLs or HTML into structured markdown |
 
 The installer injects instructions that guide the AI to **proactively search** for relevant context before starting work and **store valuable knowledge** as it discovers it. No plugin required — the AI drives everything through tool calls.
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,11 +7,15 @@
         "@clack/prompts": "^1.1.0",
         "@huggingface/transformers": "^4.0.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
+        "@mozilla/readability": "^0.6.0",
+        "linkedom": "^0.18.12",
         "picocolors": "^1.1.1",
+        "turndown": "^7.2.4",
         "yaml": "^2.3.4",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/turndown": "^5.0.6",
         "@typescript-eslint/eslint-plugin": "^8.58.1",
         "@typescript-eslint/parser": "^8.58.1",
         "bun-types": "^1.2.2",
@@ -110,7 +114,11 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg=="],
+
+    "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -139,6 +147,8 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@25.2.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg=="],
+
+    "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/type-utils": "8.58.1", "@typescript-eslint/utils": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ=="],
 
@@ -176,6 +186,8 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
     "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
@@ -200,6 +212,12 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
@@ -214,11 +232,21 @@
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -308,6 +336,10 @@
 
     "hono": ["hono@4.11.9", "", {}, "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ=="],
 
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
@@ -346,6 +378,8 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
+    "linkedom": ["linkedom@0.18.12", "", { "dependencies": { "css-select": "^5.1.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.0.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q=="],
+
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
@@ -369,6 +403,8 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -470,6 +506,8 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
@@ -479,6 +517,8 @@
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "typescript-eslint": ["typescript-eslint@8.58.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.1", "@typescript-eslint/parser": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1", "@typescript-eslint/utils": "8.58.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg=="],
+
+    "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -507,6 +547,8 @@
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -69,17 +69,7 @@ Extract article content as clean markdown from a URL or pre-fetched HTML. Return
 
 ### Usage patterns
 
-**Direct URL ingestion** — when you have a URL and no other web tools:
-```json
-{ "url": "https://example.com/blog/article" }
-```
-
-**Pre-fetched HTML** — when you already got the page via Playwright, Exa, or another tool:
-```json
-{ "html": "<html><body><article>...</article></body></html>" }
-```
-
-**HTML with URL context** — for correct relative link resolution:
+**Preferred: Pre-fetched HTML** — use your web tools (Playwright, Exa, web_fetch) to fetch first, then pass the HTML for extraction. This handles JavaScript-rendered pages, bot-protected sites, and authenticated content:
 ```json
 {
   "url": "https://example.com/blog/article",
@@ -87,12 +77,35 @@ Extract article content as clean markdown from a URL or pre-fetched HTML. Return
 }
 ```
 
+**HTML only** — when you have HTML but no source URL:
+```json
+{ "html": "<html><body><article>...</article></body></html>" }
+```
+
+**Fallback: Direct URL** — when no web tools are available. The built-in fetcher is basic — see limitations below:
+```json
+{ "url": "https://example.com/blog/article" }
+```
+
+### Built-in fetcher limitations
+
+The `url`-only path uses a basic HTTP client. It **cannot** handle:
+
+- JavaScript-rendered pages (SPAs, React, Vue, Next.js client-side)
+- Bot-protected sites (CloudFlare, Akamai, CAPTCHAs)
+- Authenticated or paywalled content
+- Cookie consent modals
+- Lazy-loaded or infinite-scroll content
+
+For these cases, fetch the page with a browser-capable tool and pass the `html` parameter.
+
 ### Workflow
 
 The intended workflow is a two-step pipeline:
 
-1. `knowledge-ingest` → extract and review content
-2. `knowledge-store` → save as a knowledge base note
+1. *(If you have web tools)* Fetch with Playwright/Exa/web_fetch → pass to `knowledge-ingest(html: ...)`
+2. `knowledge-ingest` → extract and review content
+3. `knowledge-store` → save as a knowledge base note
 
 The tool extracts content but does **not** create notes automatically. This keeps summarization and note structuring at the agent layer.
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-open-zk-kb exposes three MCP tools. Your AI assistant calls these automatically based on injected instructions — you rarely need to invoke them manually.
+open-zk-kb exposes four MCP tools. Your AI assistant calls these automatically based on injected instructions — you rarely need to invoke them manually.
 
 ## knowledge-store
 
@@ -42,6 +42,59 @@ Store knowledge in the persistent knowledge base. One concept per note.
   "project": "open-zk-kb"
 }
 ```
+
+---
+
+## knowledge-ingest
+
+Extract article content as clean markdown from a URL or pre-fetched HTML. Returns title, content, word count, and metadata. Deterministic — no LLM dependency.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | string | No* | URL to fetch and extract content from. Must be `http://` or `https://` |
+| `html` | string | No* | Raw HTML to extract from. Use when you already fetched the page via another tool |
+
+\* At least one of `url` or `html` must be provided. When both are provided, `html` is used for extraction and `url` is used for resolving relative links.
+
+### What happens
+
+1. **If `url` only** — fetches the page with SSRF protection (private IP blocking, redirect validation, streaming size limits), then extracts
+2. **If `html` only** — extracts directly from provided HTML (no network request)
+3. **If both** — extracts from `html`, uses `url` for relative link resolution
+4. Extracts article content using Mozilla Readability (same engine as Firefox Reader View)
+5. Converts to clean markdown (headings, lists, links preserved; images, iframes, nav stripped)
+6. Returns structured metadata: title, word count, byline, excerpt, site name
+
+### Usage patterns
+
+**Direct URL ingestion** — when you have a URL and no other web tools:
+```json
+{ "url": "https://example.com/blog/article" }
+```
+
+**Pre-fetched HTML** — when you already got the page via Playwright, Exa, or another tool:
+```json
+{ "html": "<html><body><article>...</article></body></html>" }
+```
+
+**HTML with URL context** — for correct relative link resolution:
+```json
+{
+  "url": "https://example.com/blog/article",
+  "html": "<html>...</html>"
+}
+```
+
+### Workflow
+
+The intended workflow is a two-step pipeline:
+
+1. `knowledge-ingest` → extract and review content
+2. `knowledge-store` → save as a knowledge base note
+
+The tool extracts content but does **not** create notes automatically. This keeps summarization and note structuring at the agent layer.
 
 ---
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -60,8 +60,8 @@ Extract article content as clean markdown from a URL or pre-fetched HTML. Return
 
 ### What happens
 
-1. **If `url` only** — fetches the page with SSRF protection (private IP blocking, redirect validation, streaming size limits), then extracts
-2. **If `html` only** — extracts directly from provided HTML (no network request)
+1. **If `url` only** — fetches the page with SSRF protection (literal private IP/hostname pattern blocking, redirect validation, streaming size limits), then extracts
+2. **If `html` only** — extracts directly from provided HTML (no network request). Pass `url` alongside `html` when possible — without it, relative links cannot be resolved
 3. **If both** — extracts from `html`, uses `url` for relative link resolution
 4. Extracts article content using Mozilla Readability (same engine as Firefox Reader View)
 5. Converts to clean markdown (headings, lists, links preserved; images, iframes, nav stripped)
@@ -98,6 +98,13 @@ The `url`-only path uses a basic HTTP client. It **cannot** handle:
 - Lazy-loaded or infinite-scroll content
 
 For these cases, fetch the page with a browser-capable tool and pass the `html` parameter.
+
+### Security notes
+
+- **SSRF protection** blocks literal private/reserved IP addresses and hostname patterns (localhost, 10.x, 172.16-31.x, 192.168.x, 169.254.x, IPv6 loopback/link-local/unique-local, IPv4-mapped IPv6). Redirect hops are validated individually.
+- **Known limitation**: hostnames that DNS-resolve to private IPs are **not** blocked — the check operates on hostname text, not resolved addresses. This is acceptable for a locally-run MCP tool but means a domain like `evil.com → 127.0.0.1` would bypass the guard.
+- **Extracted links** are filtered to exclude private/reserved IP targets before being shown in output.
+- **URL credentials** (userinfo) are stripped from extracted links.
 
 ### Workflow
 

--- a/package.json
+++ b/package.json
@@ -56,11 +56,15 @@
     "@clack/prompts": "^1.1.0",
     "@huggingface/transformers": "^4.0.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
+    "@mozilla/readability": "^0.6.0",
+    "linkedom": "^0.18.12",
     "picocolors": "^1.1.1",
+    "turndown": "^7.2.4",
     "yaml": "^2.3.4"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/turndown": "^5.0.6",
     "@typescript-eslint/eslint-plugin": "^8.58.1",
     "@typescript-eslint/parser": "^8.58.1",
     "bun-types": "^1.2.2",

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -52,13 +52,16 @@ Notes exceeding the target will trigger a soft warning — heed it and split if 
 - Before ending a session: review for uncaptured preferences, decisions, gotchas, or workflows.
 
 ### Ingesting URLs
-When a useful URL comes up, use `knowledge-ingest` to extract clean article content, then store via `knowledge-store`:
+When a useful URL comes up, extract its content via `knowledge-ingest`, then store via `knowledge-store`.
 
-1. `knowledge-ingest(url: "...")` → returns extracted title, content, metadata
-2. Review the extracted content and summarize the key takeaway
+**If you have a web tool** (Playwright, Exa, web_fetch, dev-browser — check your available tools):
+1. Fetch the page with your web tool (handles JS rendering, bot protection, auth)
+2. `knowledge-ingest(html: "<fetched html>", url: "<source url>")` → extracts title, content, metadata
 3. `knowledge-store(kind: "resource", ...)` with your summary
 
-If you already fetched HTML via another tool (e.g. Playwright, web_fetch), pass it directly: `knowledge-ingest(html: "...")`.
+**If you have no web tools** (fallback only):
+1. `knowledge-ingest(url: "...")` → basic fetch + extract (no JS rendering, may fail on protected sites)
+2. `knowledge-store(kind: "resource", ...)` with your summary
 
 ### Maintenance
 - `knowledge-maintain stats` — KB health | `knowledge-maintain review` — stale notes

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -51,6 +51,15 @@ Notes exceeding the target will trigger a soft warning — heed it and split if 
 - At natural breakpoints (complex debug, architecture choice, topic change): ask *"Anything worth saving?"*
 - Before ending a session: review for uncaptured preferences, decisions, gotchas, or workflows.
 
+### Ingesting URLs
+When a useful URL comes up, use `knowledge-ingest` to extract clean article content, then store via `knowledge-store`:
+
+1. `knowledge-ingest(url: "...")` → returns extracted title, content, metadata
+2. Review the extracted content and summarize the key takeaway
+3. `knowledge-store(kind: "resource", ...)` with your summary
+
+If you already fetched HTML via another tool (e.g. Playwright, web_fetch), pass it directly: `knowledge-ingest(html: "...")`.
+
 ### Maintenance
 - `knowledge-maintain stats` — KB health | `knowledge-maintain review` — stale notes
 

--- a/src/content-splitter.ts
+++ b/src/content-splitter.ts
@@ -1,7 +1,4 @@
-// content-splitter.ts — Standalone content processing utilities.
-//
-// Splits markdown into sections by heading boundaries and extracts links.
-// No dependency on ingest, store, or any MCP tool — reusable across the codebase.
+import { isPrivateOrReservedHost } from './url-extractor.js';
 
 export interface ContentSection {
   heading: string;
@@ -22,15 +19,19 @@ const TRACKING_PARAMS = new Set([
   'ref', '_ga', '_gl', 'mc_cid', 'mc_eid',
 ]);
 
-function countWords(text: string): number {
+export function countWords(text: string): number {
   return text.split(/\s+/).filter(Boolean).length;
 }
 
-function canonicalizeUrl(raw: string): string | null {
+export function canonicalizeUrl(raw: string): string | null {
   try {
     const url = new URL(raw);
     if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
 
+    if (isPrivateOrReservedHost(url.hostname)) return null;
+
+    url.username = '';
+    url.password = '';
     for (const param of [...url.searchParams.keys()]) {
       if (TRACKING_PARAMS.has(param.toLowerCase())) {
         url.searchParams.delete(param);
@@ -125,8 +126,9 @@ export function extractLinks(markdown: string, sourceUrl?: string): ContentLink[
       const anchor = match[1].trim();
       const rawUrl = match[2].trim();
 
+      const absolute = rawUrl.startsWith('http://') || rawUrl.startsWith('https://');
       const canonical = canonicalizeUrl(
-        rawUrl.startsWith('http') ? rawUrl : sourceUrl ? new URL(rawUrl, sourceUrl).href : rawUrl,
+        absolute ? rawUrl : sourceUrl ? new URL(rawUrl, sourceUrl).href : rawUrl,
       );
       if (!canonical) continue;
       if (seen.has(canonical)) continue;

--- a/src/content-splitter.ts
+++ b/src/content-splitter.ts
@@ -1,0 +1,140 @@
+// content-splitter.ts — Standalone content processing utilities.
+//
+// Splits markdown into sections by heading boundaries and extracts links.
+// No dependency on ingest, store, or any MCP tool — reusable across the codebase.
+
+export interface ContentSection {
+  heading: string;
+  depth: number;
+  content: string;
+  wordCount: number;
+}
+
+export interface ContentLink {
+  url: string;
+  anchor: string;
+  section: string;
+}
+
+const TRACKING_PARAMS = new Set([
+  'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content',
+  'fbclid', 'gclid', 'gclsrc', 'dclid', 'msclkid',
+  'ref', '_ga', '_gl', 'mc_cid', 'mc_eid',
+]);
+
+function countWords(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+function canonicalizeUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+
+    for (const param of [...url.searchParams.keys()]) {
+      if (TRACKING_PARAMS.has(param.toLowerCase())) {
+        url.searchParams.delete(param);
+      }
+    }
+    url.hash = '';
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+export function splitSections(markdown: string): ContentSection[] {
+  if (!markdown || markdown.trim().length === 0) return [];
+
+  const lines = markdown.split('\n');
+  const sections: ContentSection[] = [];
+  let currentHeading = '';
+  let currentDepth = 0;
+  let currentLines: string[] = [];
+  let inFencedBlock = false;
+
+  function flush() {
+    const content = currentLines.join('\n').trim();
+    if (content.length > 0) {
+      sections.push({
+        heading: currentHeading,
+        depth: currentDepth,
+        content,
+        wordCount: countWords(content),
+      });
+    }
+  }
+
+  for (const line of lines) {
+    if (/^(`{3,}|~{3,})/.test(line)) {
+      inFencedBlock = !inFencedBlock;
+      currentLines.push(line);
+      continue;
+    }
+
+    if (inFencedBlock) {
+      currentLines.push(line);
+      continue;
+    }
+
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)/);
+    if (headingMatch) {
+      const depth = headingMatch[1].length;
+      if (depth >= 2 && depth <= 3) {
+        flush();
+        currentHeading = headingMatch[2].trim();
+        currentDepth = depth;
+        currentLines = [];
+        continue;
+      }
+    }
+
+    currentLines.push(line);
+  }
+
+  flush();
+  return sections;
+}
+
+const MARKDOWN_LINK_RE = /\[([^\]]*)\]\(([^)]+)\)/g;
+
+export function extractLinks(markdown: string, sourceUrl?: string): ContentLink[] {
+  if (!markdown) return [];
+
+  const lines = markdown.split('\n');
+  const seen = new Set<string>();
+  const links: ContentLink[] = [];
+  let currentSection = '';
+  let inFencedBlock = false;
+
+  for (const line of lines) {
+    if (/^(`{3,}|~{3,})/.test(line)) {
+      inFencedBlock = !inFencedBlock;
+      continue;
+    }
+    if (inFencedBlock) continue;
+
+    const headingMatch = line.match(/^#{2,3}\s+(.+)/);
+    if (headingMatch) {
+      currentSection = headingMatch[1].trim();
+    }
+
+    let match;
+    MARKDOWN_LINK_RE.lastIndex = 0;
+    while ((match = MARKDOWN_LINK_RE.exec(line)) !== null) {
+      const anchor = match[1].trim();
+      const rawUrl = match[2].trim();
+
+      const canonical = canonicalizeUrl(
+        rawUrl.startsWith('http') ? rawUrl : sourceUrl ? new URL(rawUrl, sourceUrl).href : rawUrl,
+      );
+      if (!canonical) continue;
+      if (seen.has(canonical)) continue;
+      seen.add(canonical);
+
+      links.push({ url: canonical, anchor, section: currentSection });
+    }
+  }
+
+  return links;
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -130,10 +130,13 @@ server.registerTool(
 // ---- knowledge-ingest ----
 
 const ingestSchema = z.object({
-  url: z.string().url().optional().describe('URL to fetch and extract. Fallback only — the built-in fetcher cannot handle JavaScript-rendered pages, bot protection, or authenticated content. If you have a web tool (Playwright, Exa, web_fetch), fetch with that and pass html instead.'),
+  url: z.string().url()
+    .refine(u => { try { const p = new URL(u); return p.protocol === 'http:' || p.protocol === 'https:'; } catch { return false; } }, { message: 'URL must use http:// or https://' })
+    .optional()
+    .describe('URL to fetch and extract. Fallback only — the built-in fetcher cannot handle JavaScript-rendered pages, bot protection, or authenticated content. If you have a web tool (Playwright, Exa, web_fetch), fetch with that and pass html instead. When passing html, also pass url for relative link resolution.'),
   html: z.string().optional().describe('Preferred — raw HTML to extract content from. Pass HTML you already fetched via Playwright, Exa, web_fetch, or any browser/web tool for best results.'),
   model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
-});
+}).refine(d => d.url || d.html, { message: 'At least one of url or html must be provided' });
 
 server.registerTool(
   'knowledge-ingest',

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -130,20 +130,22 @@ server.registerTool(
 // ---- knowledge-ingest ----
 
 const ingestSchema = z.object({
-  url: z.string().url().describe('URL to extract content from. Must be http:// or https://.'),
+  url: z.string().url().optional().describe('URL to fetch and extract content from. Provide url, html, or both (url used for link resolution when html is provided).'),
+  html: z.string().optional().describe('Raw HTML to extract content from. Use when you already fetched the page via another tool (e.g. Playwright, Exa, web_fetch).'),
   model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
 });
 
 server.registerTool(
   'knowledge-ingest',
   {
-    description: 'Fetch a URL and extract its article content as clean markdown. Returns title, content, word count, and metadata. Use the extracted content to create notes via knowledge-store.',
+    description: 'Extract article content as clean markdown from a URL or raw HTML. Returns title, content, word count, and metadata. Accepts a url (fetches and extracts), html (extracts from pre-fetched content), or both. Use the extracted content to create notes via knowledge-store.',
     inputSchema: ingestSchema as unknown as AnySchema,
   },
   async (args: z.infer<typeof ingestSchema>) => {
     try {
       const result = await handleIngest({
         url: args.url,
+        html: args.html,
         model: args.model,
       });
       return { content: [{ type: 'text' as const, text: result }] };

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18,7 +18,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { getConfig, getEmbeddingsConfig } from './config.js';
 import { logToFile } from './logger.js';
-import { handleStore, handleSearch, handleMaintain } from './tool-handlers.js';
+import { handleStore, handleSearch, handleMaintain, handleIngest } from './tool-handlers.js';
 import { generateEmbedding, DEFAULT_EMBEDDING_CONFIG } from './embeddings.js';
 import type { EmbeddingConfig } from './embeddings.js';
 import type { NoteKind } from './types.js';
@@ -117,6 +117,39 @@ server.registerTool(
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-store failed', {
+        error: error instanceof Error ? error.message : String(error),
+      }, config);
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+        isError: true,
+      };
+    }
+  },
+);
+
+// ---- knowledge-ingest ----
+
+const ingestSchema = z.object({
+  url: z.string().describe('URL to extract content from. Must be http:// or https://.'),
+  model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
+});
+
+server.registerTool(
+  'knowledge-ingest',
+  {
+    description: 'Fetch a URL and extract its article content as clean markdown. Returns title, content, word count, and metadata. Use the extracted content to create notes via knowledge-store.',
+    inputSchema: ingestSchema as unknown as AnySchema,
+  },
+  async (args: z.infer<typeof ingestSchema>) => {
+    try {
+      const result = await handleIngest({
+        url: args.url,
+        model: args.model,
+      });
+      return { content: [{ type: 'text' as const, text: result }] };
+    } catch (error) {
+      logToFile('ERROR', 'knowledge-ingest failed', {
+        url: args.url,
         error: error instanceof Error ? error.message : String(error),
       }, config);
       return {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -130,7 +130,7 @@ server.registerTool(
 // ---- knowledge-ingest ----
 
 const ingestSchema = z.object({
-  url: z.string().describe('URL to extract content from. Must be http:// or https://.'),
+  url: z.string().url().describe('URL to extract content from. Must be http:// or https://.'),
   model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
 });
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -130,15 +130,15 @@ server.registerTool(
 // ---- knowledge-ingest ----
 
 const ingestSchema = z.object({
-  url: z.string().url().optional().describe('URL to fetch and extract content from. Provide url, html, or both (url used for link resolution when html is provided).'),
-  html: z.string().optional().describe('Raw HTML to extract content from. Use when you already fetched the page via another tool (e.g. Playwright, Exa, web_fetch).'),
+  url: z.string().url().optional().describe('URL to fetch and extract. Fallback only — the built-in fetcher cannot handle JavaScript-rendered pages, bot protection, or authenticated content. If you have a web tool (Playwright, Exa, web_fetch), fetch with that and pass html instead.'),
+  html: z.string().optional().describe('Preferred — raw HTML to extract content from. Pass HTML you already fetched via Playwright, Exa, web_fetch, or any browser/web tool for best results.'),
   model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
 });
 
 server.registerTool(
   'knowledge-ingest',
   {
-    description: 'Extract article content as clean markdown from a URL or raw HTML. Returns title, content, word count, and metadata. Accepts a url (fetches and extracts), html (extracts from pre-fetched content), or both. Use the extracted content to create notes via knowledge-store.',
+    description: 'Extract article content as clean markdown. Returns title, content, word count, and metadata. PREFER passing html from your own web tools (Playwright, Exa, web_fetch) — the built-in url fetcher is a basic fallback that cannot render JavaScript or bypass bot protection. Use the extracted content to create notes via knowledge-store.',
     inputSchema: ingestSchema as unknown as AnySchema,
   },
   async (args: z.infer<typeof ingestSchema>) => {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -147,7 +147,7 @@ server.registerTool(
         url: args.url,
         html: args.html,
         model: args.model,
-      });
+      }, getOrCreateRepo());
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-ingest failed', {

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -839,6 +839,19 @@ export class NoteRepository {
     }));
   }
 
+  findByUrl(url: string): Array<{ id: string; title: string }> {
+    try {
+      const parsed = new URL(url);
+      const hostPath = parsed.hostname + parsed.pathname.replace(/\/$/, '');
+      const stmt = this.db.prepare(
+        "SELECT id, title FROM notes WHERE content LIKE ? AND status != 'archived' LIMIT 5"
+      );
+      return stmt.all(`%${hostPath}%`) as Array<{ id: string; title: string }>;
+    } catch {
+      return [];
+    }
+  }
+
   /**
    * Get the most frequently accessed notes, prioritizing permanent notes.
    */

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -842,9 +842,10 @@ export class NoteRepository {
   findByUrl(url: string): Array<{ id: string; title: string }> {
     try {
       const parsed = new URL(url);
-      const hostPath = parsed.hostname + parsed.pathname.replace(/\/$/, '');
+      const hostPath = (parsed.hostname + parsed.pathname.replace(/\/$/, ''))
+        .replace(/[\\%_]/g, ch => '\\' + ch);
       const stmt = this.db.prepare(
-        "SELECT id, title FROM notes WHERE content LIKE ? AND status != 'archived' LIMIT 5"
+        "SELECT id, title FROM notes WHERE content LIKE ? ESCAPE '\\' AND status != 'archived' LIMIT 5"
       );
       return stmt.all(`%${hostPath}%`) as Array<{ id: string; title: string }>;
     } catch {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -113,16 +113,25 @@ export interface IngestArgs {
   model?: string;
 }
 
+function sanitizeMetadata(value: string): string {
+  return value.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
 export async function handleIngest(args: IngestArgs): Promise<string> {
   const result: ExtractionResult = await extractFromUrl(args.url);
 
+  const title = sanitizeMetadata(result.title);
+  const byline = result.byline ? sanitizeMetadata(result.byline) : null;
+  const siteName = result.siteName ? sanitizeMetadata(result.siteName) : null;
+  const excerpt = result.excerpt ? sanitizeMetadata(result.excerpt) : null;
+
   let output = `## Extracted Content\n\n`;
-  output += `**Title:** ${result.title}\n`;
+  output += `**Title:** ${title}\n`;
   output += `**URL:** ${result.url}\n`;
   output += `**Words:** ${result.wordCount}\n`;
-  if (result.byline) output += `**Author:** ${result.byline}\n`;
-  if (result.siteName) output += `**Site:** ${result.siteName}\n`;
-  if (result.excerpt) output += `**Excerpt:** ${result.excerpt}\n`;
+  if (byline) output += `**Author:** ${byline}\n`;
+  if (siteName) output += `**Site:** ${siteName}\n`;
+  if (excerpt) output += `**Excerpt:** ${excerpt}\n`;
   output += `**Extracted:** ${result.extractedAt}\n`;
   output += `\n---\n\n${result.content}`;
 

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -119,7 +119,7 @@ function sanitizeMetadata(value: string): string {
   return value.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
-export async function handleIngest(args: IngestArgs): Promise<string> {
+export async function handleIngest(args: IngestArgs, repo?: NoteRepository): Promise<string> {
   let result: ExtractionResult;
   if (args.html) {
     const sourceUrl = args.url || 'about:blank';
@@ -173,6 +173,19 @@ export async function handleIngest(args: IngestArgs): Promise<string> {
     }
     if (links.length > 10) {
       output += `- ...and ${links.length - 10} more\n`;
+    }
+  }
+
+  const sourceUrl = result.url !== 'about:blank' ? result.url : args.url;
+  if (repo && sourceUrl) {
+    const existing = repo.findByUrl(sourceUrl);
+    if (existing.length > 0) {
+      output += '\n## Existing KB Coverage\n';
+      output += `⚠️ ${existing.length} note(s) already reference this URL:\n`;
+      for (const note of existing) {
+        output += `- ${note.title} [${note.id}]\n`;
+      }
+      output += 'Review before creating duplicates.\n';
     }
   }
 

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -25,7 +25,7 @@ import { getInstalledInstructionVersions } from './instruction-versions.js';
 import { classifyModel, MODEL_HINT } from './model-capabilities.js';
 import { extractFromUrl, extractArticle } from './url-extractor.js';
 import type { ExtractionResult } from './url-extractor.js';
-import { splitSections, extractLinks } from './content-splitter.js';
+import { splitSections, extractLinks, countWords } from './content-splitter.js';
 
 // ---- Constants ----
 
@@ -43,10 +43,6 @@ export const KIND_WORD_GUIDELINES: Record<NoteKind, { target: number; warn: numb
 export const ABSOLUTE_WARN_THRESHOLD = 300;
 
 // ---- Helper functions ----
-
-function countWords(text: string): number {
-  return text.split(/\s+/).filter(Boolean).length;
-}
 
 function atomicityWarning(kind: NoteKind, wordCount: number): string | null {
   const guide = KIND_WORD_GUIDELINES[kind];
@@ -119,9 +115,14 @@ function sanitizeMetadata(value: string): string {
   return value.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
+const MAX_HTML_BYTES = 5 * 1024 * 1024; // 5MB
+
 export async function handleIngest(args: IngestArgs, repo?: NoteRepository): Promise<string> {
   let result: ExtractionResult;
   if (args.html) {
+    if (Buffer.byteLength(args.html, 'utf8') > MAX_HTML_BYTES) {
+      throw new Error(`HTML content too large: exceeds ${MAX_HTML_BYTES} byte limit`);
+    }
     const sourceUrl = args.url || 'about:blank';
     const article = extractArticle(args.html, sourceUrl);
     if (!article) {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -23,7 +23,7 @@ import { injectAgentDocs, inspectAgentDocs } from './agent-docs.js';
 import { detectClient, isVisibleToClient, getClientTags, clientTag, isKnownClient } from './client-heuristics.js';
 import { getInstalledInstructionVersions } from './instruction-versions.js';
 import { classifyModel, MODEL_HINT } from './model-capabilities.js';
-import { extractFromUrl } from './url-extractor.js';
+import { extractFromUrl, extractArticle } from './url-extractor.js';
 import type { ExtractionResult } from './url-extractor.js';
 
 // ---- Constants ----
@@ -109,7 +109,8 @@ export interface MaintainArgs {
 }
 
 export interface IngestArgs {
-  url: string;
+  url?: string;
+  html?: string;
   model?: string;
 }
 
@@ -118,7 +119,19 @@ function sanitizeMetadata(value: string): string {
 }
 
 export async function handleIngest(args: IngestArgs): Promise<string> {
-  const result: ExtractionResult = await extractFromUrl(args.url);
+  let result: ExtractionResult;
+  if (args.html) {
+    const sourceUrl = args.url || 'about:blank';
+    const article = extractArticle(args.html, sourceUrl);
+    if (!article) {
+      throw new Error('Could not extract article content from provided HTML. The content may not contain enough readable text.');
+    }
+    result = article;
+  } else if (args.url) {
+    result = await extractFromUrl(args.url);
+  } else {
+    throw new Error('Either url or html must be provided');
+  }
 
   const title = sanitizeMetadata(result.title);
   const byline = result.byline ? sanitizeMetadata(result.byline) : null;

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -25,6 +25,7 @@ import { getInstalledInstructionVersions } from './instruction-versions.js';
 import { classifyModel, MODEL_HINT } from './model-capabilities.js';
 import { extractFromUrl, extractArticle } from './url-extractor.js';
 import type { ExtractionResult } from './url-extractor.js';
+import { splitSections, extractLinks } from './content-splitter.js';
 
 // ---- Constants ----
 
@@ -138,15 +139,51 @@ export async function handleIngest(args: IngestArgs): Promise<string> {
   const siteName = result.siteName ? sanitizeMetadata(result.siteName) : null;
   const excerpt = result.excerpt ? sanitizeMetadata(result.excerpt) : null;
 
+  const sections = splitSections(result.content);
+  const links = extractLinks(result.content, result.url !== 'about:blank' ? result.url : undefined);
+
   let output = `## Extracted Content\n\n`;
   output += `**Title:** ${title}\n`;
   output += `**URL:** ${result.url}\n`;
-  output += `**Words:** ${result.wordCount}\n`;
-  if (byline) output += `**Author:** ${byline}\n`;
-  if (siteName) output += `**Site:** ${siteName}\n`;
+  output += `**Words:** ${result.wordCount}`;
+  if (byline) output += `  |  **Author:** ${byline}`;
+  if (siteName) output += `  |  **Site:** ${siteName}`;
+  output += '\n';
   if (excerpt) output += `**Excerpt:** ${excerpt}\n`;
   output += `**Extracted:** ${result.extractedAt}\n`;
-  output += `\n---\n\n${result.content}`;
+
+  if (sections.length > 1) {
+    output += `**Sections:** ${sections.length}\n`;
+    output += '\n---\n';
+    for (const section of sections) {
+      const flag = section.wordCount > 200 ? ' — exceeds 200w note target' : '';
+      const heading = section.heading || '(preamble)';
+      output += `\n### § ${heading} (${section.wordCount} words${flag})\n\n`;
+      output += section.content + '\n';
+    }
+  } else {
+    output += `\n---\n\n${result.content}`;
+  }
+
+  if (links.length > 0) {
+    output += '\n---\n\n## Links Found (' + links.length + ')\n';
+    for (const link of links.slice(0, 10)) {
+      const sectionNote = link.section ? ` — § ${link.section}` : '';
+      output += `- [${link.anchor}](${link.url})${sectionNote}\n`;
+    }
+    if (links.length > 10) {
+      output += `- ...and ${links.length - 10} more\n`;
+    }
+  }
+
+  output += '\n## Next Steps\n';
+  output += 'Review each section. For each worth saving, call knowledge-store with title, content, kind, summary, guidance.\n';
+  if (sections.some(s => s.wordCount > 200)) {
+    output += 'Sections over ~200 words may need splitting into separate atomic notes.\n';
+  }
+  if (links.length > 0) {
+    output += `${links.length} link(s) found. Follow at most 1-2 per ingest. Do not follow links from followed articles.\n`;
+  }
 
   if (!args.model) {
     output += MODEL_HINT;

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -23,6 +23,8 @@ import { injectAgentDocs, inspectAgentDocs } from './agent-docs.js';
 import { detectClient, isVisibleToClient, getClientTags, clientTag, isKnownClient } from './client-heuristics.js';
 import { getInstalledInstructionVersions } from './instruction-versions.js';
 import { classifyModel, MODEL_HINT } from './model-capabilities.js';
+import { extractFromUrl } from './url-extractor.js';
+import type { ExtractionResult } from './url-extractor.js';
 
 // ---- Constants ----
 
@@ -104,6 +106,31 @@ export interface MaintainArgs {
   limit?: number;
   dryRun?: boolean;
   model?: string;
+}
+
+export interface IngestArgs {
+  url: string;
+  model?: string;
+}
+
+export async function handleIngest(args: IngestArgs): Promise<string> {
+  const result: ExtractionResult = await extractFromUrl(args.url);
+
+  let output = `## Extracted Content\n\n`;
+  output += `**Title:** ${result.title}\n`;
+  output += `**URL:** ${result.url}\n`;
+  output += `**Words:** ${result.wordCount}\n`;
+  if (result.byline) output += `**Author:** ${result.byline}\n`;
+  if (result.siteName) output += `**Site:** ${result.siteName}\n`;
+  if (result.excerpt) output += `**Excerpt:** ${result.excerpt}\n`;
+  output += `**Extracted:** ${result.extractedAt}\n`;
+  output += `\n---\n\n${result.content}`;
+
+  if (!args.model) {
+    output += MODEL_HINT;
+  }
+
+  return output;
 }
 
 function describeAgentDocsStatus(status: ReturnType<typeof inspectAgentDocs>['status']): string {

--- a/src/url-extractor.ts
+++ b/src/url-extractor.ts
@@ -78,6 +78,15 @@ export function isPrivateOrReservedHost(hostname: string): boolean {
     if (ipv6 === '::1') return true;                                    // loopback
     if (ipv6.startsWith('fc') || ipv6.startsWith('fd')) return true;    // fc00::/7 unique local
     if (ipv6.startsWith('fe80')) return true;                           // fe80::/10 link-local
+
+    // IPv4-mapped (::ffff:H:H) and IPv4-compatible (::H:H) — extract embedded IPv4 and re-check
+    const mappedMatch = ipv6.match(/^::(?:ffff:)?([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (mappedMatch) {
+      const high = parseInt(mappedMatch[1], 16);
+      const low = parseInt(mappedMatch[2], 16);
+      const ipv4 = `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+      return isPrivateOrReservedHost(ipv4);
+    }
   }
 
   return false;

--- a/src/url-extractor.ts
+++ b/src/url-extractor.ts
@@ -26,6 +26,8 @@ export interface ExtractOptions {
 
 const DEFAULT_TIMEOUT_MS = 15000;
 const DEFAULT_MAX_CONTENT_LENGTH = 5 * 1024 * 1024; // 5MB HTML limit
+const MAX_REDIRECTS = 5;
+const MIN_READABLE_CHARS = 50;
 const USER_AGENT = 'open-zk-kb/1.0 (knowledge-ingest)';
 
 const turndown = new TurndownService({
@@ -36,6 +38,7 @@ const turndown = new TurndownService({
 
 turndown.remove(['img', 'iframe', 'video', 'audio', 'picture', 'figure', 'svg']);
 
+/** Checks whether a URL string has a valid http/https scheme. */
 export function isValidUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
@@ -45,6 +48,98 @@ export function isValidUrl(url: string): boolean {
   }
 }
 
+/**
+ * Returns true if the hostname resolves to a private, loopback, link-local,
+ * or otherwise reserved IP range. Used to block SSRF via redirect chains.
+ */
+export function isPrivateOrReservedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+
+  // Loopback hostnames
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+
+  // IPv4 ranges
+  const ipv4Match = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4Match) {
+    const [, aStr, bStr] = ipv4Match;
+    const a = Number(aStr);
+    const b = Number(bStr);
+    if (a === 127) return true;                        // 127.0.0.0/8  loopback
+    if (a === 10) return true;                         // 10.0.0.0/8   private
+    if (a === 172 && b >= 16 && b <= 31) return true;  // 172.16.0.0/12 private
+    if (a === 192 && b === 168) return true;            // 192.168.0.0/16 private
+    if (a === 169 && b === 254) return true;            // 169.254.0.0/16 link-local / cloud metadata
+    if (a === 0) return true;                          // 0.0.0.0/8
+  }
+
+  // IPv6 bracket notation (as it appears in URL hostnames)
+  if (host.startsWith('[') && host.endsWith(']')) {
+    const ipv6 = host.slice(1, -1).toLowerCase();
+    if (ipv6 === '::1') return true;                                    // loopback
+    if (ipv6.startsWith('fc') || ipv6.startsWith('fd')) return true;    // fc00::/7 unique local
+    if (ipv6.startsWith('fe80')) return true;                           // fe80::/10 link-local
+  }
+
+  return false;
+}
+
+/**
+ * Validates a URL for safe fetching: scheme must be http/https and
+ * hostname must not resolve to a private/reserved range.
+ */
+function validateFetchTarget(url: string): void {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Blocked URL: unsupported protocol ${parsed.protocol}`);
+  }
+  if (isPrivateOrReservedHost(parsed.hostname)) {
+    throw new Error(`Blocked URL: hostname ${parsed.hostname} resolves to a private/reserved range`);
+  }
+}
+
+/**
+ * Reads a response body as text using streaming byte-counting.
+ * Aborts as soon as accumulated bytes exceed maxLength — never buffers the
+ * full body before enforcing the limit.
+ */
+async function readBodyWithLimit(response: Response, maxLength: number): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    // Fallback for environments where body is not a ReadableStream
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > maxLength) {
+      throw new Error(`Content too large: exceeded ${maxLength} bytes`);
+    }
+    return text;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxLength) {
+        throw new Error(`Content too large: exceeded ${maxLength} bytes`);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const combined = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(combined);
+}
+
+/** Fetches HTML from a URL with SSRF protection, redirect validation, and streaming size limits. */
 export async function fetchHtml(url: string, options: ExtractOptions = {}): Promise<string> {
   const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxLength = options.maxContentLength ?? DEFAULT_MAX_CONTENT_LENGTH;
@@ -53,32 +148,47 @@ export async function fetchHtml(url: string, options: ExtractOptions = {}): Prom
   const timer = setTimeout(() => controller.abort(), timeout);
 
   try {
-    const response = await fetch(url, {
-      signal: controller.signal,
-      headers: { 'User-Agent': USER_AGENT },
-      redirect: 'follow',
-    });
+    let currentUrl = url;
+    let redirectCount = 0;
 
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    while (true) {
+      validateFetchTarget(currentUrl);
+
+      const response = await fetch(currentUrl, {
+        signal: controller.signal,
+        headers: { 'User-Agent': USER_AGENT },
+        redirect: 'manual',
+      });
+
+      if (response.status >= 300 && response.status < 400) {
+        redirectCount++;
+        if (redirectCount > MAX_REDIRECTS) {
+          throw new Error(`Too many redirects (max ${MAX_REDIRECTS})`);
+        }
+        const location = response.headers.get('location');
+        if (!location) {
+          throw new Error(`Redirect ${response.status} without Location header`);
+        }
+        currentUrl = new URL(location, currentUrl).href;
+        continue;
+      }
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const contentType = response.headers.get('content-type') || '';
+      if (!contentType.includes('text/html') && !contentType.includes('text/plain') && !contentType.includes('application/xhtml')) {
+        throw new Error(`Unsupported content type: ${contentType}`);
+      }
+
+      const contentLength = response.headers.get('content-length');
+      if (contentLength && parseInt(contentLength, 10) > maxLength) {
+        throw new Error(`Content too large: ${contentLength} bytes (max ${maxLength})`);
+      }
+
+      return await readBodyWithLimit(response, maxLength);
     }
-
-    const contentType = response.headers.get('content-type') || '';
-    if (!contentType.includes('text/html') && !contentType.includes('text/plain') && !contentType.includes('application/xhtml')) {
-      throw new Error(`Unsupported content type: ${contentType}`);
-    }
-
-    const contentLength = response.headers.get('content-length');
-    if (contentLength && parseInt(contentLength, 10) > maxLength) {
-      throw new Error(`Content too large: ${contentLength} bytes (max ${maxLength})`);
-    }
-
-    const html = await response.text();
-    if (html.length > maxLength) {
-      throw new Error(`Content too large: ${html.length} bytes (max ${maxLength})`);
-    }
-
-    return html;
   } finally {
     clearTimeout(timer);
   }
@@ -95,7 +205,7 @@ export function extractArticle(html: string, url: string): ExtractionResult | nu
   const reader = new Readability(document);
   const article = reader.parse();
 
-  if (!article || !article.textContent || article.textContent.trim().length < 50) {
+  if (!article || !article.textContent || article.textContent.trim().length < MIN_READABLE_CHARS) {
     return null;
   }
 

--- a/src/url-extractor.ts
+++ b/src/url-extractor.ts
@@ -59,7 +59,7 @@ export function isValidUrl(url: string): boolean {
  * or otherwise reserved IP pattern. Does not perform DNS resolution.
  */
 export function isPrivateOrReservedHost(hostname: string): boolean {
-  const host = hostname.toLowerCase();
+  const host = hostname.toLowerCase().replace(/\.$/, '');
 
   // Loopback hostnames
   if (host === 'localhost' || host.endsWith('.localhost')) return true;
@@ -256,14 +256,17 @@ export async function extractFromUrl(url: string, options: ExtractOptions = {}):
   }
 
   const { html, finalUrl } = await fetchHtml(url, options);
-  const result = extractArticle(html, finalUrl);
+  const safeFinalUrl = new URL(finalUrl);
+  safeFinalUrl.username = '';
+  safeFinalUrl.password = '';
+  const result = extractArticle(html, safeFinalUrl.href);
 
   if (!result) {
     throw new Error(`Could not extract article content from ${url}. The page may not contain enough readable content.`);
   }
 
   logToFile('DEBUG', 'URL extraction complete', {
-    url: finalUrl,
+    url: safeFinalUrl.href,
     title: result.title,
     wordCount: result.wordCount,
   });

--- a/src/url-extractor.ts
+++ b/src/url-extractor.ts
@@ -11,12 +11,18 @@ import { logToFile } from './logger.js';
 export interface ExtractionResult {
   title: string;
   content: string;
+  textContent: string;
   url: string;
   extractedAt: string;
   wordCount: number;
   byline: string | null;
   excerpt: string | null;
   siteName: string | null;
+}
+
+export interface FetchResult {
+  html: string;
+  finalUrl: string;
 }
 
 export interface ExtractOptions {
@@ -49,8 +55,8 @@ export function isValidUrl(url: string): boolean {
 }
 
 /**
- * Returns true if the hostname resolves to a private, loopback, link-local,
- * or otherwise reserved IP range. Used to block SSRF via redirect chains.
+ * Returns true if the hostname matches a private, loopback, link-local,
+ * or otherwise reserved IP pattern. Does not perform DNS resolution.
  */
 export function isPrivateOrReservedHost(hostname: string): boolean {
   const host = hostname.toLowerCase();
@@ -77,7 +83,8 @@ export function isPrivateOrReservedHost(hostname: string): boolean {
     const ipv6 = host.slice(1, -1).toLowerCase();
     if (ipv6 === '::1') return true;                                    // loopback
     if (ipv6.startsWith('fc') || ipv6.startsWith('fd')) return true;    // fc00::/7 unique local
-    if (ipv6.startsWith('fe80')) return true;                           // fe80::/10 link-local
+    const fe = parseInt(ipv6.slice(0, 4), 16);
+    if ((fe & 0xffc0) === 0xfe80) return true;                            // fe80::/10 link-local (fe80-febf)
 
     // IPv4-mapped (::ffff:H:H) and IPv4-compatible (::H:H) — extract embedded IPv4 and re-check
     const mappedMatch = ipv6.match(/^::(?:ffff:)?([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
@@ -102,7 +109,7 @@ function validateFetchTarget(url: string): void {
     throw new Error(`Blocked URL: unsupported protocol ${parsed.protocol}`);
   }
   if (isPrivateOrReservedHost(parsed.hostname)) {
-    throw new Error(`Blocked URL: hostname ${parsed.hostname} resolves to a private/reserved range`);
+    throw new Error(`Blocked URL: hostname ${parsed.hostname} matches a private/reserved range`);
   }
 }
 
@@ -148,8 +155,7 @@ async function readBodyWithLimit(response: Response, maxLength: number): Promise
   return new TextDecoder().decode(combined);
 }
 
-/** Fetches HTML from a URL with SSRF protection, redirect validation, and streaming size limits. */
-export async function fetchHtml(url: string, options: ExtractOptions = {}): Promise<string> {
+export async function fetchHtml(url: string, options: ExtractOptions = {}): Promise<FetchResult> {
   const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxLength = options.maxContentLength ?? DEFAULT_MAX_CONTENT_LENGTH;
 
@@ -196,7 +202,8 @@ export async function fetchHtml(url: string, options: ExtractOptions = {}): Prom
         throw new Error(`Content too large: ${contentLength} bytes (max ${maxLength})`);
       }
 
-      return await readBodyWithLimit(response, maxLength);
+      const html = await readBodyWithLimit(response, maxLength);
+      return { html, finalUrl: currentUrl };
     }
   } finally {
     clearTimeout(timer);
@@ -208,8 +215,11 @@ export function extractArticle(html: string, url: string): ExtractionResult | nu
 
   const { document } = parseHTML(html);
 
-  // Set documentURI for Readability's relative URL resolution
-  Object.defineProperty(document, 'documentURI', { value: url, writable: false });
+  try {
+    Object.defineProperty(document, 'documentURI', { value: url, configurable: true, writable: false });
+  } catch {
+    // linkedom may define documentURI as non-configurable; fall through
+  }
 
   const reader = new Readability(document);
   const article = reader.parse();
@@ -219,11 +229,18 @@ export function extractArticle(html: string, url: string): ExtractionResult | nu
   }
 
   const markdown = turndown.turndown(article.content);
-  const wordCount = markdown.split(/\s+/).filter(Boolean).length;
+  const textContent = article.textContent;
+  const wordCount = textContent.split(/\s+/).filter(Boolean).length;
+
+  let title = article.title;
+  if (!title) {
+    try { title = new URL(url).hostname || 'Untitled'; } catch { title = 'Untitled'; }
+  }
 
   return {
-    title: article.title || new URL(url).hostname,
+    title,
     content: markdown,
+    textContent,
     url,
     extractedAt: new Date().toISOString(),
     wordCount,
@@ -238,15 +255,15 @@ export async function extractFromUrl(url: string, options: ExtractOptions = {}):
     throw new Error(`Invalid URL: ${url}`);
   }
 
-  const html = await fetchHtml(url, options);
-  const result = extractArticle(html, url);
+  const { html, finalUrl } = await fetchHtml(url, options);
+  const result = extractArticle(html, finalUrl);
 
   if (!result) {
     throw new Error(`Could not extract article content from ${url}. The page may not contain enough readable content.`);
   }
 
   logToFile('DEBUG', 'URL extraction complete', {
-    url,
+    url: finalUrl,
     title: result.title,
     wordCount: result.wordCount,
   });

--- a/src/url-extractor.ts
+++ b/src/url-extractor.ts
@@ -1,0 +1,136 @@
+// url-extractor.ts - Deterministic URL content extraction
+//
+// Fetches a URL, extracts article content using Readability, converts to markdown.
+// No LLM dependency — pure server-side extraction.
+
+import { parseHTML } from 'linkedom';
+import { Readability } from '@mozilla/readability';
+import TurndownService from 'turndown';
+import { logToFile } from './logger.js';
+
+export interface ExtractionResult {
+  title: string;
+  content: string;
+  url: string;
+  extractedAt: string;
+  wordCount: number;
+  byline: string | null;
+  excerpt: string | null;
+  siteName: string | null;
+}
+
+export interface ExtractOptions {
+  timeoutMs?: number;
+  maxContentLength?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 15000;
+const DEFAULT_MAX_CONTENT_LENGTH = 5 * 1024 * 1024; // 5MB HTML limit
+const USER_AGENT = 'open-zk-kb/1.0 (knowledge-ingest)';
+
+const turndown = new TurndownService({
+  headingStyle: 'atx',
+  codeBlockStyle: 'fenced',
+  bulletListMarker: '-',
+});
+
+turndown.remove(['img', 'iframe', 'video', 'audio', 'picture', 'figure', 'svg']);
+
+export function isValidUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export async function fetchHtml(url: string, options: ExtractOptions = {}): Promise<string> {
+  const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxLength = options.maxContentLength ?? DEFAULT_MAX_CONTENT_LENGTH;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { 'User-Agent': USER_AGENT },
+      redirect: 'follow',
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('text/html') && !contentType.includes('text/plain') && !contentType.includes('application/xhtml')) {
+      throw new Error(`Unsupported content type: ${contentType}`);
+    }
+
+    const contentLength = response.headers.get('content-length');
+    if (contentLength && parseInt(contentLength, 10) > maxLength) {
+      throw new Error(`Content too large: ${contentLength} bytes (max ${maxLength})`);
+    }
+
+    const html = await response.text();
+    if (html.length > maxLength) {
+      throw new Error(`Content too large: ${html.length} bytes (max ${maxLength})`);
+    }
+
+    return html;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function extractArticle(html: string, url: string): ExtractionResult | null {
+  if (!html || html.trim().length === 0) return null;
+
+  const { document } = parseHTML(html);
+
+  // Set documentURI for Readability's relative URL resolution
+  Object.defineProperty(document, 'documentURI', { value: url, writable: false });
+
+  const reader = new Readability(document);
+  const article = reader.parse();
+
+  if (!article || !article.textContent || article.textContent.trim().length < 50) {
+    return null;
+  }
+
+  const markdown = turndown.turndown(article.content);
+  const wordCount = markdown.split(/\s+/).filter(Boolean).length;
+
+  return {
+    title: article.title || new URL(url).hostname,
+    content: markdown,
+    url,
+    extractedAt: new Date().toISOString(),
+    wordCount,
+    byline: article.byline || null,
+    excerpt: article.excerpt || null,
+    siteName: article.siteName || null,
+  };
+}
+
+export async function extractFromUrl(url: string, options: ExtractOptions = {}): Promise<ExtractionResult> {
+  if (!isValidUrl(url)) {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+
+  const html = await fetchHtml(url, options);
+  const result = extractArticle(html, url);
+
+  if (!result) {
+    throw new Error(`Could not extract article content from ${url}. The page may not contain enough readable content.`);
+  }
+
+  logToFile('DEBUG', 'URL extraction complete', {
+    url,
+    title: result.title,
+    wordCount: result.wordCount,
+  });
+
+  return result;
+}

--- a/tests/content-splitter.test.ts
+++ b/tests/content-splitter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { splitSections, extractLinks } from '../src/content-splitter.js';
+import { splitSections, extractLinks, canonicalizeUrl, countWords } from '../src/content-splitter.js';
 
 describe('splitSections', () => {
   it('splits on h2 boundaries', () => {
@@ -186,5 +186,89 @@ describe('extractLinks', () => {
     const links = extractLinks(md);
     expect(links).toHaveLength(1);
     expect(links[0].anchor).toBe('');
+  });
+
+  it('filters out links targeting private IPs', () => {
+    const md = `
+[public](https://example.com)
+[private](http://192.168.1.1/admin)
+[metadata](http://169.254.169.254/latest)
+[localhost](http://localhost:3000/api)
+[also public](https://other.com)
+`;
+    const links = extractLinks(md);
+    expect(links).toHaveLength(2);
+    expect(links[0].url).toContain('example.com');
+    expect(links[1].url).toContain('other.com');
+  });
+
+  it('filters out IPv6 private links', () => {
+    const md = '[loopback](http://[::1]:8080/secret)';
+    const links = extractLinks(md);
+    expect(links).toHaveLength(0);
+  });
+
+  it('strips URL credentials from extracted links', () => {
+    const md = '[creds](https://user:pass@example.com/page)';
+    const links = extractLinks(md);
+    expect(links).toHaveLength(1);
+    expect(links[0].url).not.toContain('user');
+    expect(links[0].url).not.toContain('pass');
+    expect(links[0].url).toContain('example.com/page');
+  });
+
+  it('uses strict http:// or https:// prefix for absolute detection', () => {
+    const md = '[x](httpfoo://example.com/bad)';
+    const links = extractLinks(md);
+    expect(links).toHaveLength(0);
+  });
+
+  it('resolves relative links only when sourceUrl provided', () => {
+    const md = '[relative](/docs/api)';
+    const links = extractLinks(md, 'https://example.com/page');
+    expect(links).toHaveLength(1);
+    expect(links[0].url).toBe('https://example.com/docs/api');
+  });
+});
+
+describe('canonicalizeUrl', () => {
+  it('strips credentials from URLs', () => {
+    const result = canonicalizeUrl('https://admin:secret@example.com/path');
+    expect(result).not.toBeNull();
+    expect(result).not.toContain('admin');
+    expect(result).not.toContain('secret');
+    expect(result).toContain('example.com/path');
+  });
+
+  it('returns null for private IP URLs', () => {
+    expect(canonicalizeUrl('http://127.0.0.1/secret')).toBeNull();
+    expect(canonicalizeUrl('http://192.168.1.1/admin')).toBeNull();
+    expect(canonicalizeUrl('http://10.0.0.1/internal')).toBeNull();
+    expect(canonicalizeUrl('http://169.254.169.254/metadata')).toBeNull();
+    expect(canonicalizeUrl('http://localhost:3000/')).toBeNull();
+  });
+
+  it('allows public URLs', () => {
+    expect(canonicalizeUrl('https://example.com/page')).not.toBeNull();
+  });
+
+  it('returns null for non-http schemes', () => {
+    expect(canonicalizeUrl('ftp://example.com')).toBeNull();
+    expect(canonicalizeUrl('javascript:alert(1)')).toBeNull();
+  });
+});
+
+describe('countWords', () => {
+  it('counts space-separated words', () => {
+    expect(countWords('one two three')).toBe(3);
+  });
+
+  it('handles multiple whitespace types', () => {
+    expect(countWords('one\ttwo\nthree  four')).toBe(4);
+  });
+
+  it('returns 0 for empty/whitespace input', () => {
+    expect(countWords('')).toBe(0);
+    expect(countWords('   ')).toBe(0);
   });
 });

--- a/tests/content-splitter.test.ts
+++ b/tests/content-splitter.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'bun:test';
+import { splitSections, extractLinks } from '../src/content-splitter.js';
+
+describe('splitSections', () => {
+  it('splits on h2 boundaries', () => {
+    const md = '## First\n\nContent one.\n\n## Second\n\nContent two.';
+    const sections = splitSections(md);
+    expect(sections).toHaveLength(2);
+    expect(sections[0].heading).toBe('First');
+    expect(sections[0].depth).toBe(2);
+    expect(sections[0].content).toContain('Content one');
+    expect(sections[1].heading).toBe('Second');
+  });
+
+  it('splits on h3 boundaries', () => {
+    const md = '### Alpha\n\nA content.\n\n### Beta\n\nB content.';
+    const sections = splitSections(md);
+    expect(sections).toHaveLength(2);
+    expect(sections[0].heading).toBe('Alpha');
+    expect(sections[0].depth).toBe(3);
+  });
+
+  it('captures preamble before first heading', () => {
+    const md = 'Intro text here.\n\n## Section\n\nSection content.';
+    const sections = splitSections(md);
+    expect(sections).toHaveLength(2);
+    expect(sections[0].heading).toBe('');
+    expect(sections[0].depth).toBe(0);
+    expect(sections[0].content).toContain('Intro text');
+    expect(sections[1].heading).toBe('Section');
+  });
+
+  it('returns single section for content with no headings', () => {
+    const md = 'Just a paragraph of text.\n\nAnother paragraph.';
+    const sections = splitSections(md);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].heading).toBe('');
+    expect(sections[0].content).toContain('Just a paragraph');
+  });
+
+  it('does not split on # inside fenced code blocks', () => {
+    const md = '## Real Heading\n\nBefore code.\n\n```\n## Not a heading\nconst x = 1;\n```\n\nAfter code.';
+    const sections = splitSections(md);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].heading).toBe('Real Heading');
+    expect(sections[0].content).toContain('## Not a heading');
+    expect(sections[0].content).toContain('After code');
+  });
+
+  it('does not split on # inside tilde fenced code blocks', () => {
+    const md = '## Heading\n\n~~~\n## Fake\n~~~\n\nReal content.';
+    const sections = splitSections(md);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].content).toContain('## Fake');
+  });
+
+  it('does not split on h1 (only h2 and h3)', () => {
+    const md = '# Title\n\nIntro.\n\n## Section\n\nContent.';
+    const sections = splitSections(md);
+    expect(sections).toHaveLength(2);
+    expect(sections[0].heading).toBe('');
+    expect(sections[0].content).toContain('# Title');
+    expect(sections[1].heading).toBe('Section');
+  });
+
+  it('does not split on h4+ (only h2 and h3)', () => {
+    const md = '## Main\n\nContent.\n\n#### Deep\n\nNested content.';
+    const sections = splitSections(md);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].content).toContain('#### Deep');
+    expect(sections[0].content).toContain('Nested content');
+  });
+
+  it('computes word counts per section', () => {
+    const md = '## Short\n\nOne two three.\n\n## Long\n\n' + 'word '.repeat(50);
+    const sections = splitSections(md);
+    expect(sections[0].wordCount).toBe(3);
+    expect(sections[1].wordCount).toBe(50);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(splitSections('')).toHaveLength(0);
+    expect(splitSections('   ')).toHaveLength(0);
+  });
+
+  it('handles multiple consecutive headings', () => {
+    const md = '## A\n\n## B\n\nContent B.\n\n## C\n\nContent C.';
+    const sections = splitSections(md);
+    expect(sections.length).toBeGreaterThanOrEqual(2);
+    const headings = sections.map(s => s.heading);
+    expect(headings).toContain('B');
+    expect(headings).toContain('C');
+  });
+
+  it('handles mixed h2 and h3 sections', () => {
+    const md = '## Parent\n\nParent content.\n\n### Child\n\nChild content.\n\n## Sibling\n\nSibling content.';
+    const sections = splitSections(md);
+    expect(sections).toHaveLength(3);
+    expect(sections[0].heading).toBe('Parent');
+    expect(sections[1].heading).toBe('Child');
+    expect(sections[1].depth).toBe(3);
+    expect(sections[2].heading).toBe('Sibling');
+  });
+});
+
+describe('extractLinks', () => {
+  it('extracts markdown links', () => {
+    const md = 'See [example](https://example.com) for details.';
+    const links = extractLinks(md);
+    expect(links).toHaveLength(1);
+    expect(links[0].url).toBe('https://example.com/');
+    expect(links[0].anchor).toBe('example');
+  });
+
+  it('extracts multiple links from one line', () => {
+    const md = 'Use [foo](https://foo.com) or [bar](https://bar.com).';
+    const links = extractLinks(md);
+    expect(links).toHaveLength(2);
+  });
+
+  it('deduplicates by canonical URL', () => {
+    const md = '[a](https://example.com/page) and [b](https://example.com/page).';
+    const links = extractLinks(md);
+    expect(links).toHaveLength(1);
+  });
+
+  it('strips tracking parameters', () => {
+    const md = '[link](https://example.com/page?utm_source=twitter&utm_medium=social&real=1)';
+    const links = extractLinks(md);
+    expect(links[0].url).toContain('real=1');
+    expect(links[0].url).not.toContain('utm_source');
+    expect(links[0].url).not.toContain('utm_medium');
+  });
+
+  it('strips fbclid and gclid', () => {
+    const md = '[link](https://example.com/?fbclid=abc123&gclid=xyz)';
+    const links = extractLinks(md);
+    expect(links[0].url).not.toContain('fbclid');
+    expect(links[0].url).not.toContain('gclid');
+  });
+
+  it('strips fragment identifiers', () => {
+    const md = '[link](https://example.com/page#section-2)';
+    const links = extractLinks(md);
+    expect(links[0].url).toBe('https://example.com/page');
+  });
+
+  it('skips non-http links', () => {
+    const md = '[mail](mailto:test@example.com) and [tel](tel:+1234) and [js](javascript:void(0))';
+    const links = extractLinks(md);
+    expect(links).toHaveLength(0);
+  });
+
+  it('associates links with their section heading', () => {
+    const md = '## Intro\n\n[link1](https://a.com)\n\n## Details\n\n[link2](https://b.com)';
+    const links = extractLinks(md);
+    expect(links).toHaveLength(2);
+    expect(links[0].section).toBe('Intro');
+    expect(links[1].section).toBe('Details');
+  });
+
+  it('resolves relative URLs when sourceUrl is provided', () => {
+    const md = '[guide](/docs/guide)';
+    const links = extractLinks(md, 'https://example.com/blog/post');
+    expect(links).toHaveLength(1);
+    expect(links[0].url).toBe('https://example.com/docs/guide');
+  });
+
+  it('skips links inside fenced code blocks', () => {
+    const md = '```\n[not a link](https://skip.com)\n```\n\n[real](https://keep.com)';
+    const links = extractLinks(md);
+    expect(links).toHaveLength(1);
+    expect(links[0].url).toContain('keep.com');
+  });
+
+  it('returns empty array for no links', () => {
+    expect(extractLinks('No links here.')).toHaveLength(0);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(extractLinks('')).toHaveLength(0);
+  });
+
+  it('handles links with empty anchor text', () => {
+    const md = '[](https://example.com/empty)';
+    const links = extractLinks(md);
+    expect(links).toHaveLength(1);
+    expect(links[0].anchor).toBe('');
+  });
+});

--- a/tests/url-extractor.test.ts
+++ b/tests/url-extractor.test.ts
@@ -713,3 +713,134 @@ describe('handleIngest output format', () => {
     expect(result).toContain('---');
   });
 });
+
+// ---- Integration: full pipeline (HTML → Readability → Turndown → sections → links) ----
+
+describe('full pipeline integration', () => {
+  const realisticHtml = `
+    <html>
+    <head><title>Getting Started with SQLite in Bun</title></head>
+    <body>
+      <nav><ul><li><a href="/">Home</a></li><li><a href="/docs">Docs</a></li></ul></nav>
+      <header><div class="logo">BunDocs</div></header>
+      <main>
+        <article>
+          <h1>Getting Started with SQLite in Bun</h1>
+          <p class="meta">By <span class="author" rel="author">Jarred Sumner</span> — Published 2024-01-15</p>
+          <p>Bun natively implements a high-performance SQLite3 driver. This guide covers installation, basic queries, transactions, and best practices for production use.</p>
+
+          <h2>Installation</h2>
+          <p>No installation needed — <code>bun:sqlite</code> is built into Bun. Just import it:</p>
+          <pre><code>import { Database } from "bun:sqlite";
+const db = new Database(":memory:");</code></pre>
+          <p>See the <a href="https://bun.sh/docs/api/sqlite">official SQLite docs</a> for the full API reference.</p>
+
+          <h2>Basic Queries</h2>
+          <p>Use <code>db.query()</code> to prepare a statement. The result is cached on the Database instance for performance.</p>
+          <pre><code>const query = db.query("SELECT * FROM users WHERE id = ?1");
+const user = query.get(42);</code></pre>
+          <p>For write operations, use <code>.run()</code> which returns metadata about the execution:</p>
+          <pre><code>const result = db.run("INSERT INTO users (name) VALUES (?)", "Alice");
+console.log(result.lastInsertRowid); // => 1</code></pre>
+
+          <h2>Transactions</h2>
+          <p>Wrap multiple operations in a transaction for atomicity. If any query throws, the entire transaction rolls back automatically.</p>
+          <pre><code>const insertUser = db.prepare("INSERT INTO users (name) VALUES ($name)");
+const insertMany = db.transaction(users => {
+  for (const user of users) insertUser.run(user);
+});
+insertMany([{ $name: "Bob" }, { $name: "Carol" }]);</code></pre>
+          <p>Transactions support <code>deferred</code>, <code>immediate</code>, and <code>exclusive</code> modes. See <a href="https://www.sqlite.org/lang_transaction.html">SQLite transaction docs</a> for details.</p>
+
+          <h2>Performance Tips</h2>
+          <p>Enable WAL mode for significantly better concurrent read performance:</p>
+          <pre><code>db.run("PRAGMA journal_mode = WAL;");</code></pre>
+          <p>Use prepared statements instead of string concatenation. The <code>.query()</code> method caches compiled statements automatically.</p>
+          <p>For bulk inserts, always wrap in a transaction — it can be 10-100x faster than individual inserts.</p>
+          <p>Read more about <a href="https://bun.sh/docs/api/sqlite#wal-mode">WAL mode</a> and <a href="https://bun.sh/blog/bun-v1.0#sqlite">Bun's SQLite benchmarks</a>.</p>
+        </article>
+      </main>
+      <aside><h3>Related</h3><ul><li><a href="/docs/api/http">HTTP Server</a></li></ul></aside>
+      <footer><p>&copy; 2024 Oven. <a href="/privacy">Privacy</a> | <a href="/terms">Terms</a></p></footer>
+    </body>
+    </html>`;
+
+  it('extracts article content and strips nav/sidebar/footer', async () => {
+    const result = await handleIngest({ html: realisticHtml, url: 'https://bun.sh/docs/guides/sqlite' });
+    expect(result).toContain('Getting Started with SQLite');
+    expect(result).not.toContain('BunDocs');
+    expect(result).not.toContain('Privacy');
+    expect(result).not.toContain('Terms');
+  });
+
+  it('produces multiple sections from h2 headings', async () => {
+    const result = await handleIngest({ html: realisticHtml, url: 'https://bun.sh/docs/guides/sqlite' });
+    expect(result).toContain('§ Installation');
+    expect(result).toContain('§ Basic Queries');
+    expect(result).toContain('§ Transactions');
+    expect(result).toContain('§ Performance Tips');
+    expect(result).toContain('**Sections:**');
+  });
+
+  it('includes word counts per section', async () => {
+    const result = await handleIngest({ html: realisticHtml, url: 'https://bun.sh/docs/guides/sqlite' });
+    const sectionMatches = result.match(/§ .+ \(\d+ words/g);
+    expect(sectionMatches).not.toBeNull();
+    expect(sectionMatches!.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('extracts outbound links with section context', async () => {
+    const result = await handleIngest({ html: realisticHtml, url: 'https://bun.sh/docs/guides/sqlite' });
+    expect(result).toContain('## Links Found');
+    expect(result).toContain('sqlite.org');
+    expect(result).toContain('§');
+  });
+
+  it('preserves code blocks in section content', async () => {
+    const result = await handleIngest({ html: realisticHtml, url: 'https://bun.sh/docs/guides/sqlite' });
+    expect(result).toContain('import { Database }');
+    expect(result).toContain('db.query');
+    expect(result).toContain('PRAGMA journal_mode');
+  });
+
+  it('extracts byline from author metadata', async () => {
+    const result = await handleIngest({ html: realisticHtml, url: 'https://bun.sh/docs/guides/sqlite' });
+    expect(result).toContain('Jarred Sumner');
+  });
+
+  it('includes traversal guidance in next steps', async () => {
+    const result = await handleIngest({ html: realisticHtml, url: 'https://bun.sh/docs/guides/sqlite' });
+    expect(result).toContain('## Next Steps');
+    expect(result).toContain('Follow at most 1-2');
+  });
+
+  it('handles HTML passed as pre-fetched content with URL for link resolution', async () => {
+    const result = await handleIngest({ html: realisticHtml, url: 'https://bun.sh/docs/guides/sqlite' });
+    expect(result).toContain('**URL:** https://bun.sh/docs/guides/sqlite');
+  });
+
+  it('produces coherent output when article has no h2 headings', async () => {
+    const flatHtml = `<html><head><title>Flat</title></head><body>
+      <article><h1>Single Section Article</h1>
+      <p>${'This is a flat article with no subsections but enough content for extraction. '.repeat(10)}</p>
+      </article></body></html>`;
+    const result = await handleIngest({ html: flatHtml });
+    expect(result).toContain('Single Section Article');
+    expect(result).not.toContain('**Sections:**');
+    expect(result).toContain('---');
+  });
+
+  it('handles markdown passed as html (passthrough)', async () => {
+    const markdownAsHtml = `<html><head><title>MD Content</title></head><body>
+      <article><h1>Markdown Article</h1>
+      <h2>First Section</h2>
+      <p>Some content here with a <a href="https://example.com">link</a> included.</p>
+      <h2>Second Section</h2>
+      <p>${'More detailed content about the second topic for testing purposes. '.repeat(5)}</p>
+      </article></body></html>`;
+    const result = await handleIngest({ html: markdownAsHtml });
+    expect(result).toContain('§ First Section');
+    expect(result).toContain('§ Second Section');
+    expect(result).toContain('## Links Found');
+  });
+});

--- a/tests/url-extractor.test.ts
+++ b/tests/url-extractor.test.ts
@@ -353,8 +353,9 @@ describe('fetchHtml', () => {
       status: 200,
       headers: { 'content-type': 'text/html; charset=utf-8' },
     })) as typeof fetch;
-    const html = await fetchHtml('https://example.com');
-    expect(html).toContain('<body>ok</body>');
+    const result = await fetchHtml('https://example.com');
+    expect(result.html).toContain('<body>ok</body>');
+    expect(result.finalUrl).toBe('https://example.com');
   });
 
   it('accepts text/plain content type', async () => {
@@ -362,8 +363,8 @@ describe('fetchHtml', () => {
       status: 200,
       headers: { 'content-type': 'text/plain' },
     })) as typeof fetch;
-    const html = await fetchHtml('https://example.com/text');
-    expect(html).toBe('plain text content');
+    const result = await fetchHtml('https://example.com/text');
+    expect(result.html).toBe('plain text content');
   });
 
   it('rejects when streamed body exceeds limit', async () => {
@@ -418,8 +419,9 @@ describe('fetchHtml', () => {
         headers: { 'content-type': 'text/html' },
       });
     }) as typeof fetch;
-    const html = await fetchHtml('https://example.com/start');
-    expect(html).toContain('redirected');
+    const result = await fetchHtml('https://example.com/start');
+    expect(result.html).toContain('redirected');
+    expect(result.finalUrl).toBe('https://example.com/final');
     expect(callCount).toBe(2);
   });
 
@@ -443,8 +445,9 @@ describe('fetchHtml', () => {
         headers: { 'content-type': 'text/html' },
       });
     }) as typeof fetch;
-    const html = await fetchHtml('https://example.com/old-path');
-    expect(html).toContain('relative redirect');
+    const result = await fetchHtml('https://example.com/old-path');
+    expect(result.html).toContain('relative redirect');
+    expect(result.finalUrl).toBe('https://example.com/new-path');
   });
 
   it('rejects redirect without Location header', async () => {
@@ -463,8 +466,9 @@ describe('fetchHtml', () => {
         headers: { 'content-type': 'text/html' },
       });
     }) as typeof fetch;
-    const html = await fetchHtml('https://example.com/start');
-    expect(html).toContain('chain done');
+    const result = await fetchHtml('https://example.com/start');
+    expect(result.html).toContain('chain done');
+    expect(result.finalUrl).toBe('https://example.com/final');
     expect(callCount).toBe(3);
   });
 
@@ -481,8 +485,8 @@ describe('fetchHtml', () => {
       status: 200,
       headers: { 'content-type': 'text/html' },
     })) as typeof fetch;
-    const html = await fetchHtml('https://example.com');
-    expect(html).toBe('');
+    const result = await fetchHtml('https://example.com');
+    expect(result.html).toBe('');
   });
 });
 
@@ -842,5 +846,128 @@ insertMany([{ $name: "Bob" }, { $name: "Carol" }]);</code></pre>
     expect(result).toContain('§ First Section');
     expect(result).toContain('§ Second Section');
     expect(result).toContain('## Links Found');
+  });
+});
+
+// ---- New: fe80::/10 full range ----
+
+describe('IPv6 link-local full fe80::/10 range', () => {
+  it('blocks fe80::1', () => {
+    expect(isPrivateOrReservedHost('[fe80::1]')).toBe(true);
+  });
+
+  it('blocks fe90::1 (within fe80::/10)', () => {
+    expect(isPrivateOrReservedHost('[fe90::1]')).toBe(true);
+  });
+
+  it('blocks fea0::1 (within fe80::/10)', () => {
+    expect(isPrivateOrReservedHost('[fea0::1]')).toBe(true);
+  });
+
+  it('blocks febf::1 (upper bound of fe80::/10)', () => {
+    expect(isPrivateOrReservedHost('[febf::1]')).toBe(true);
+  });
+
+  it('allows fec0::1 (outside fe80::/10)', () => {
+    expect(isPrivateOrReservedHost('[fec0::1]')).toBe(false);
+  });
+
+  it('allows fe7f::1 (below fe80::/10)', () => {
+    expect(isPrivateOrReservedHost('[fe7f::1]')).toBe(false);
+  });
+});
+
+// ---- New: fetchHtml finalUrl after redirects ----
+
+describe('fetchHtml finalUrl tracking', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it('returns original URL when no redirect', async () => {
+    globalThis.fetch = (async () => new Response('<html></html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    })) as typeof fetch;
+    const result = await fetchHtml('https://example.com/page');
+    expect(result.finalUrl).toBe('https://example.com/page');
+  });
+
+  it('returns final URL after redirect chain', async () => {
+    let callCount = 0;
+    globalThis.fetch = (async () => {
+      callCount++;
+      if (callCount === 1) return new Response('', { status: 301, headers: { 'location': 'https://example.com/step2' } });
+      if (callCount === 2) return new Response('', { status: 302, headers: { 'location': 'https://example.com/final-page' } });
+      return new Response('<html></html>', { status: 200, headers: { 'content-type': 'text/html' } });
+    }) as typeof fetch;
+    const result = await fetchHtml('https://example.com/start');
+    expect(result.finalUrl).toBe('https://example.com/final-page');
+  });
+});
+
+// ---- New: HTML input size guard ----
+
+describe('handleIngest HTML size guard', () => {
+  it('rejects HTML exceeding 5MB', async () => {
+    const hugeHtml = '<html><body>' + 'x'.repeat(6 * 1024 * 1024) + '</body></html>';
+    await expect(handleIngest({ html: hugeHtml })).rejects.toThrow('HTML content too large');
+  });
+
+  it('accepts HTML just under 5MB', async () => {
+    const body = 'A'.repeat(100) + ' content '.repeat(50);
+    const html = `<html><head><title>Big</title></head><body><article><h1>Big</h1><p>${body}</p></article></body></html>`;
+    const result = await handleIngest({ html });
+    expect(result).toContain('Big');
+  });
+});
+
+// ---- New: about:blank title fallback ----
+
+describe('extractArticle title fallback', () => {
+  const longContent = '<p>' + 'Substantial article content for testing. '.repeat(10) + '</p>';
+
+  it('falls back to Untitled when url is about:blank', () => {
+    const html = `<html><body><article>${longContent}</article></body></html>`;
+    const result = extractArticle(html, 'about:blank');
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Untitled');
+  });
+
+  it('falls back to hostname when url has one', () => {
+    const html = `<html><body><article>${longContent}</article></body></html>`;
+    const result = extractArticle(html, 'https://example.com/page');
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('example.com');
+  });
+});
+
+// ---- New: word count from textContent ----
+
+describe('word count accuracy', () => {
+  it('counts words from text, not markdown syntax', async () => {
+    const html = `<html><head><title>Count</title></head><body>
+      <article><h1>Count</h1>
+      <p><strong>Bold</strong> <a href="https://example.com/very/long/url">link text</a> normal words here.</p>
+      <p>${'More content for extraction to pass threshold. '.repeat(5)}</p>
+      </article></body></html>`;
+    const result = await handleIngest({ html });
+    const wordMatch = result.match(/\*\*Words:\*\* (\d+)/);
+    expect(wordMatch).not.toBeNull();
+    const count = Number(wordMatch![1]);
+    expect(count).toBeGreaterThan(0);
+    expect(count).toBeLessThan(200);
+  });
+});
+
+// ---- New: error message wording ----
+
+describe('SSRF error message clarity', () => {
+  it('says matches not resolves', async () => {
+    try {
+      await fetchHtml('http://127.0.0.1/secret');
+    } catch (e: unknown) {
+      expect((e as Error).message).toContain('matches a private/reserved range');
+      expect((e as Error).message).not.toContain('resolves to');
+    }
   });
 });

--- a/tests/url-extractor.test.ts
+++ b/tests/url-extractor.test.ts
@@ -222,7 +222,36 @@ describe('handleIngest', () => {
   });
 
   it('rejects empty URL', async () => {
-    await expect(handleIngest({ url: '' })).rejects.toThrow('Invalid URL');
+    await expect(handleIngest({ url: '' })).rejects.toThrow('Either url or html must be provided');
+  });
+
+  it('rejects when neither url nor html is provided', async () => {
+    await expect(handleIngest({})).rejects.toThrow('Either url or html must be provided');
+  });
+
+  it('extracts from raw HTML when html parameter is provided', async () => {
+    const html = `<html><head><title>Pre-fetched Article</title></head><body>
+      <article><h1>Pre-fetched Article</h1>
+      <p>${'This is meaningful content from a pre-fetched page. '.repeat(10)}</p>
+      </article></body></html>`;
+    const result = await handleIngest({ html });
+    expect(result).toContain('Pre-fetched Article');
+    expect(result).toContain('Extracted Content');
+  });
+
+  it('uses url for link resolution when both url and html are provided', async () => {
+    const html = `<html><head><title>Resolved Links</title></head><body>
+      <article><h1>Resolved Links</h1>
+      <p>${'Content with enough text to pass readability threshold. '.repeat(10)}</p>
+      </article></body></html>`;
+    const result = await handleIngest({ url: 'https://example.com/article', html });
+    expect(result).toContain('https://example.com/article');
+    expect(result).toContain('Resolved Links');
+  });
+
+  it('rejects html that has no extractable content', async () => {
+    await expect(handleIngest({ html: '<html><body><p>Too short</p></body></html>' }))
+      .rejects.toThrow('Could not extract article content');
   });
 });
 

--- a/tests/url-extractor.test.ts
+++ b/tests/url-extractor.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect } from 'bun:test';
+import { isValidUrl, extractArticle, extractFromUrl, fetchHtml } from '../src/url-extractor.js';
+import { handleIngest } from '../src/tool-handlers.js';
+
+// ---- Unit: isValidUrl ----
+
+describe('isValidUrl', () => {
+  it('accepts https URLs', () => {
+    expect(isValidUrl('https://example.com')).toBe(true);
+  });
+
+  it('accepts http URLs', () => {
+    expect(isValidUrl('http://example.com')).toBe(true);
+  });
+
+  it('accepts URLs with paths', () => {
+    expect(isValidUrl('https://example.com/blog/article-1')).toBe(true);
+  });
+
+  it('accepts URLs with query params', () => {
+    expect(isValidUrl('https://example.com/search?q=test&page=2')).toBe(true);
+  });
+
+  it('rejects ftp URLs', () => {
+    expect(isValidUrl('ftp://example.com/file')).toBe(false);
+  });
+
+  it('rejects javascript: URLs', () => {
+    expect(isValidUrl('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isValidUrl('')).toBe(false);
+  });
+
+  it('rejects plain text', () => {
+    expect(isValidUrl('not a url')).toBe(false);
+  });
+
+  it('rejects file: URLs', () => {
+    expect(isValidUrl('file:///etc/passwd')).toBe(false);
+  });
+
+  it('rejects data: URLs', () => {
+    expect(isValidUrl('data:text/html,<h1>hi</h1>')).toBe(false);
+  });
+});
+
+// ---- Unit: extractArticle ----
+
+describe('extractArticle', () => {
+  const makeArticleHtml = (title: string, body: string) => `
+    <html><head><title>${title}</title></head>
+    <body>
+      <nav>Navigation links here</nav>
+      <article>
+        <h1>${title}</h1>
+        ${body}
+      </article>
+      <footer>Footer content</footer>
+    </body></html>
+  `;
+
+  const longParagraph = '<p>' + 'This is a meaningful sentence about a topic. '.repeat(10) + '</p>';
+
+  it('extracts title from HTML', () => {
+    const html = makeArticleHtml('My Great Article', longParagraph);
+    const result = extractArticle(html, 'https://example.com/article');
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('My Great Article');
+  });
+
+  it('extracts content as markdown', () => {
+    const html = makeArticleHtml('Test', longParagraph);
+    const result = extractArticle(html, 'https://example.com');
+
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('meaningful sentence');
+    expect(result!.content).not.toContain('<p>');
+  });
+
+  it('strips navigation and footer', () => {
+    const html = makeArticleHtml('Test', longParagraph);
+    const result = extractArticle(html, 'https://example.com');
+
+    expect(result).not.toBeNull();
+    expect(result!.content).not.toContain('Navigation links');
+    expect(result!.content).not.toContain('Footer content');
+  });
+
+  it('converts headings to markdown ATX style', () => {
+    const html = makeArticleHtml('Test', '<h2>Subheading</h2>' + longParagraph);
+    const result = extractArticle(html, 'https://example.com');
+
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('## Subheading');
+  });
+
+  it('converts lists to markdown', () => {
+    const html = makeArticleHtml('Test', '<ul><li>Item A</li><li>Item B</li></ul>' + longParagraph);
+    const result = extractArticle(html, 'https://example.com');
+
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('Item A');
+    expect(result!.content).toContain('Item B');
+  });
+
+  it('converts links to markdown', () => {
+    const html = makeArticleHtml('Test', '<p>See <a href="https://example.com">this link</a> for details.</p>' + longParagraph);
+    const result = extractArticle(html, 'https://example.com');
+
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('[this link](https://example.com)');
+  });
+
+  it('counts words correctly', () => {
+    const html = makeArticleHtml('Test', '<p>one two three four five</p>' + longParagraph);
+    const result = extractArticle(html, 'https://example.com');
+
+    expect(result).not.toBeNull();
+    expect(result!.wordCount).toBeGreaterThan(5);
+  });
+
+  it('sets url in result', () => {
+    const html = makeArticleHtml('Test', longParagraph);
+    const result = extractArticle(html, 'https://example.com/page');
+
+    expect(result!.url).toBe('https://example.com/page');
+  });
+
+  it('sets extractedAt as ISO string', () => {
+    const html = makeArticleHtml('Test', longParagraph);
+    const result = extractArticle(html, 'https://example.com');
+
+    expect(result!.extractedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('returns null for non-article HTML', () => {
+    const html = '<html><body><p>Too short</p></body></html>';
+    const result = extractArticle(html, 'https://example.com');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty HTML', () => {
+    const result = extractArticle('', 'https://example.com');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for nav-only HTML', () => {
+    const html = '<html><body><nav><ul><li>Link 1</li><li>Link 2</li></ul></nav></body></html>';
+    const result = extractArticle(html, 'https://example.com');
+
+    expect(result).toBeNull();
+  });
+
+  it('extracts byline when present', () => {
+    const html = `<html><head><title>Test</title></head><body>
+      <article>
+        <h1>Test</h1>
+        <span class="author" rel="author">John Smith</span>
+        ${longParagraph}
+      </article>
+    </body></html>`;
+    const result = extractArticle(html, 'https://example.com');
+
+    if (result?.byline) {
+      expect(result.byline).toContain('John Smith');
+    }
+  });
+
+  it('extracts excerpt', () => {
+    const html = makeArticleHtml('Test', longParagraph);
+    const result = extractArticle(html, 'https://example.com');
+
+    expect(result).not.toBeNull();
+    if (result!.excerpt) {
+      expect(result!.excerpt.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('handles HTML with multiple articles (extracts main content)', () => {
+    const html = `<html><head><title>Multi</title></head><body>
+      <article><h1>Main Article</h1>${longParagraph}</article>
+      <aside><p>Sidebar content</p></aside>
+    </body></html>`;
+    const result = extractArticle(html, 'https://example.com');
+
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('meaningful sentence');
+  });
+
+  it('uses hostname as title fallback when title is missing', () => {
+    const html = `<html><head></head><body><article><h1></h1>${longParagraph}</article></body></html>`;
+    const result = extractArticle(html, 'https://myblog.example.com/post');
+
+    if (result && !result.title.includes('meaningful')) {
+      expect(result.title).toBeTruthy();
+    }
+  });
+});
+
+// ---- Unit: extractFromUrl error handling ----
+
+describe('extractFromUrl', () => {
+  it('rejects invalid URLs', async () => {
+    await expect(extractFromUrl('not-a-url')).rejects.toThrow('Invalid URL');
+  });
+
+  it('rejects ftp URLs', async () => {
+    await expect(extractFromUrl('ftp://example.com')).rejects.toThrow('Invalid URL');
+  });
+
+  it('rejects javascript: URLs', async () => {
+    await expect(extractFromUrl('javascript:void(0)')).rejects.toThrow('Invalid URL');
+  });
+});
+
+// ---- Integration: handleIngest ----
+
+describe('handleIngest', () => {
+  it('rejects invalid URLs with error message', async () => {
+    await expect(handleIngest({ url: 'not-a-url' })).rejects.toThrow('Invalid URL');
+  });
+
+  it('rejects empty URL', async () => {
+    await expect(handleIngest({ url: '' })).rejects.toThrow('Invalid URL');
+  });
+});
+
+// ---- Unit: fetchHtml ----
+
+describe('fetchHtml', () => {
+  it('rejects on non-HTML content type', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response('{}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch;
+
+    try {
+      await expect(fetchHtml('https://example.com/api')).rejects.toThrow('Unsupported content type');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('rejects on HTTP error status', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response('Not Found', {
+      status: 404,
+      statusText: 'Not Found',
+      headers: { 'content-type': 'text/html' },
+    })) as typeof fetch;
+
+    try {
+      await expect(fetchHtml('https://example.com/missing')).rejects.toThrow('HTTP 404');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('rejects when content-length exceeds limit', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response('x', {
+      status: 200,
+      headers: {
+        'content-type': 'text/html',
+        'content-length': '999999999',
+      },
+    })) as typeof fetch;
+
+    try {
+      await expect(fetchHtml('https://example.com/huge')).rejects.toThrow('Content too large');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('accepts text/html content type', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response('<html><body>ok</body></html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    })) as typeof fetch;
+
+    try {
+      const html = await fetchHtml('https://example.com');
+      expect(html).toContain('<body>ok</body>');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('accepts text/plain content type', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response('plain text content', {
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+    })) as typeof fetch;
+
+    try {
+      const html = await fetchHtml('https://example.com/text');
+      expect(html).toBe('plain text content');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/tests/url-extractor.test.ts
+++ b/tests/url-extractor.test.ts
@@ -430,4 +430,286 @@ describe('fetchHtml', () => {
     })) as typeof fetch;
     await expect(fetchHtml('https://example.com/start')).rejects.toThrow('Too many redirects');
   });
+
+  it('resolves relative Location headers', async () => {
+    let callCount = 0;
+    globalThis.fetch = (async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response('', { status: 301, headers: { 'location': '/new-path' } });
+      }
+      return new Response('<html><body>relative redirect</body></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      });
+    }) as typeof fetch;
+    const html = await fetchHtml('https://example.com/old-path');
+    expect(html).toContain('relative redirect');
+  });
+
+  it('rejects redirect without Location header', async () => {
+    globalThis.fetch = (async () => new Response('', { status: 302 })) as typeof fetch;
+    await expect(fetchHtml('https://example.com/start')).rejects.toThrow('without Location header');
+  });
+
+  it('follows mixed redirect chain (301 → 302 → 200)', async () => {
+    let callCount = 0;
+    globalThis.fetch = (async () => {
+      callCount++;
+      if (callCount === 1) return new Response('', { status: 301, headers: { 'location': 'https://example.com/step2' } });
+      if (callCount === 2) return new Response('', { status: 302, headers: { 'location': 'https://example.com/final' } });
+      return new Response('<html><body>chain done</body></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      });
+    }) as typeof fetch;
+    const html = await fetchHtml('https://example.com/start');
+    expect(html).toContain('chain done');
+    expect(callCount).toBe(3);
+  });
+
+  it('blocks redirect that changes to non-http scheme', async () => {
+    globalThis.fetch = (async () => new Response('', {
+      status: 302,
+      headers: { 'location': 'ftp://example.com/file' },
+    })) as typeof fetch;
+    await expect(fetchHtml('https://example.com/start')).rejects.toThrow('unsupported protocol');
+  });
+
+  it('handles empty response body', async () => {
+    globalThis.fetch = (async () => new Response('', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    })) as typeof fetch;
+    const html = await fetchHtml('https://example.com');
+    expect(html).toBe('');
+  });
+});
+
+// ---- SSRF bypass attempts ----
+
+describe('SSRF bypass vectors', () => {
+  it('blocks decimal IP notation (2130706433 = 127.0.0.1)', async () => {
+    await expect(fetchHtml('http://2130706433/')).rejects.toThrow('private/reserved');
+  });
+
+  it('blocks octal IP notation (0177.0.0.1 = 127.0.0.1)', async () => {
+    await expect(fetchHtml('http://0177.0.0.1/')).rejects.toThrow('private/reserved');
+  });
+
+  it('blocks hex IP notation (0x7f000001 = 127.0.0.1)', async () => {
+    await expect(fetchHtml('http://0x7f000001/')).rejects.toThrow('private/reserved');
+  });
+
+  it('blocks IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)', async () => {
+    await expect(fetchHtml('http://[::ffff:127.0.0.1]/')).rejects.toThrow('private/reserved');
+  });
+
+  it('blocks IPv4-mapped IPv6 private (::ffff:10.0.0.1)', async () => {
+    await expect(fetchHtml('http://[::ffff:10.0.0.1]/')).rejects.toThrow('private/reserved');
+  });
+
+  it('blocks IPv4-mapped IPv6 metadata (::ffff:169.254.169.254)', async () => {
+    await expect(fetchHtml('http://[::ffff:169.254.169.254]/')).rejects.toThrow('private/reserved');
+  });
+
+  it('blocks IPv4-compatible IPv6 loopback (::127.0.0.1)', async () => {
+    await expect(fetchHtml('http://[::127.0.0.1]/')).rejects.toThrow('private/reserved');
+  });
+
+  it('blocks URL with credentials targeting private IP', async () => {
+    await expect(fetchHtml('http://user:pass@127.0.0.1/')).rejects.toThrow('private/reserved');
+  });
+
+  it('blocks short hex notation (0x7f.1 = 127.0.0.1)', async () => {
+    await expect(fetchHtml('http://0x7f.1/')).rejects.toThrow('private/reserved');
+  });
+
+  it('blocks private IP with port number', async () => {
+    await expect(fetchHtml('http://127.0.0.1:8080/')).rejects.toThrow('private/reserved');
+  });
+
+  it('allows IPv4-mapped IPv6 public IP (::ffff:8.8.8.8)', () => {
+    expect(isPrivateOrReservedHost('[::ffff:808:808]')).toBe(false);
+  });
+});
+
+// ---- extractArticle edge cases ----
+
+describe('extractArticle edge cases', () => {
+  const longContent = '<p>' + 'Substantial article content for readability extraction testing. '.repeat(10) + '</p>';
+
+  it('handles malformed HTML with unclosed tags', () => {
+    const html = `<html><head><title>Broken</title></head><body>
+      <article><h1>Broken Article</h1><div>${longContent}</article></body>`;
+    const result = extractArticle(html, 'https://example.com');
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('Substantial article');
+  });
+
+  it('strips script tag content from output', () => {
+    const html = `<html><head><title>Scripts</title></head><body>
+      <article><h1>Clean Article</h1>
+      <script>var malicious = "should not appear";</script>
+      ${longContent}
+      </article></body></html>`;
+    const result = extractArticle(html, 'https://example.com');
+    expect(result).not.toBeNull();
+    expect(result!.content).not.toContain('malicious');
+    expect(result!.content).not.toContain('should not appear');
+  });
+
+  it('strips style tag content from output', () => {
+    const html = `<html><head><title>Styles</title></head><body>
+      <article><h1>Styled Article</h1>
+      <style>.hidden { display: none; }</style>
+      ${longContent}
+      </article></body></html>`;
+    const result = extractArticle(html, 'https://example.com');
+    expect(result).not.toBeNull();
+    expect(result!.content).not.toContain('display: none');
+  });
+
+  it('preserves HTML entities in content', () => {
+    const html = `<html><head><title>Entities</title></head><body>
+      <article><h1>Entities</h1>
+      <p>Use &amp; for ampersand, &lt;tag&gt; for angle brackets, &quot;quotes&quot; work too.</p>
+      ${longContent}
+      </article></body></html>`;
+    const result = extractArticle(html, 'https://example.com');
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('&');
+    expect(result!.content).toContain('<tag>');
+  });
+
+  it('handles unicode content (CJK characters)', () => {
+    const unicodeContent = '<p>' + '这是一篇关于人工智能技术发展的长篇文章内容。'.repeat(10) + '</p>';
+    const html = `<html><head><title>中文文章</title></head><body>
+      <article><h1>中文文章</h1>${unicodeContent}</article></body></html>`;
+    const result = extractArticle(html, 'https://example.com');
+    expect(result).not.toBeNull();
+    expect(result!.title).toContain('中文');
+    expect(result!.content).toContain('人工智能');
+  });
+
+  it('handles emoji in content', () => {
+    const emojiContent = '<p>' + 'Article with emoji 🚀 and more content for extraction. '.repeat(10) + '</p>';
+    const html = `<html><head><title>Emoji Test</title></head><body>
+      <article><h1>Emoji Test</h1>${emojiContent}</article></body></html>`;
+    const result = extractArticle(html, 'https://example.com');
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('🚀');
+  });
+
+  it('extracts code blocks', () => {
+    const html = `<html><head><title>Code</title></head><body>
+      <article><h1>Code Example</h1>
+      <pre><code>function hello() { return "world"; }</code></pre>
+      ${longContent}
+      </article></body></html>`;
+    const result = extractArticle(html, 'https://example.com');
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('function hello');
+  });
+
+  it('extracts table content', () => {
+    const html = `<html><head><title>Table</title></head><body>
+      <article><h1>Data Table</h1>
+      <table><tr><th>Name</th><th>Value</th></tr><tr><td>Alpha</td><td>100</td></tr></table>
+      ${longContent}
+      </article></body></html>`;
+    const result = extractArticle(html, 'https://example.com');
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('Alpha');
+    expect(result!.content).toContain('100');
+  });
+
+  it('returns null for whitespace-only content near MIN_READABLE_CHARS threshold', () => {
+    const shortContent = '<p>' + '  '.repeat(30) + 'tiny</p>';
+    const html = `<html><body><article>${shortContent}</article></body></html>`;
+    const result = extractArticle(html, 'https://example.com');
+    expect(result).toBeNull();
+  });
+
+  it('extracts content just above MIN_READABLE_CHARS threshold', () => {
+    const justEnough = '<p>' + 'A'.repeat(60) + '</p>';
+    const html = `<html><head><title>Threshold</title></head><body>
+      <article><h1>Threshold</h1>${justEnough}${longContent}</article></body></html>`;
+    const result = extractArticle(html, 'https://example.com');
+    expect(result).not.toBeNull();
+  });
+
+  it('preserves text around inline media', () => {
+    const html = `<html><head><title>Images</title></head><body>
+      <article><h1>Image Article</h1>
+      <p>Before image.</p>
+      <img src="photo.jpg" alt="A photo">
+      <p>After image.</p>
+      ${longContent}
+      </article></body></html>`;
+    const result = extractArticle(html, 'https://example.com');
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('Before image');
+    expect(result!.content).toContain('After image');
+  });
+});
+
+// ---- handleIngest output format ----
+
+describe('handleIngest output format', () => {
+  const makeHtml = (title: string, body: string) => `<html><head><title>${title}</title></head><body>
+    <article><h1>${title}</h1>${body}</article></body></html>`;
+  const longBody = '<p>' + 'Content for handleIngest output format testing. '.repeat(10) + '</p>';
+
+  it('includes all metadata fields in output', async () => {
+    const result = await handleIngest({ html: makeHtml('Full Metadata', longBody) });
+    expect(result).toContain('## Extracted Content');
+    expect(result).toContain('**Title:** Full Metadata');
+    expect(result).toContain('**Words:**');
+    expect(result).toContain('**Extracted:**');
+    expect(result).toContain('---');
+  });
+
+  it('shows about:blank as URL when html-only', async () => {
+    const result = await handleIngest({ html: makeHtml('No URL', longBody) });
+    expect(result).toContain('**URL:** about:blank');
+  });
+
+  it('sanitizes newlines in title', async () => {
+    const html = `<html><head><title>Line1\nLine2\rLine3</title></head><body>
+      <article><h1>Line1\nLine2</h1>${longBody}</article></body></html>`;
+    const result = await handleIngest({ html });
+    const titleLine = result.split('\n').find(l => l.startsWith('**Title:**'));
+    expect(titleLine).toBeDefined();
+    expect(titleLine).not.toContain('\n');
+    expect(titleLine).not.toContain('\r');
+  });
+
+  it('includes MODEL_HINT when model is not provided', async () => {
+    const result = await handleIngest({ html: makeHtml('Hint Test', longBody) });
+    expect(result).toContain('model');
+  });
+
+  it('excludes MODEL_HINT when model is provided', async () => {
+    const withModel = await handleIngest({ html: makeHtml('No Hint', longBody), model: 'gpt-4o' });
+    const withoutModel = await handleIngest({ html: makeHtml('No Hint', longBody) });
+    expect(withModel.length).toBeLessThan(withoutModel.length);
+  });
+
+  it('produces accurate word count on html path', async () => {
+    const fiveWords = '<p>one two three four five</p>';
+    const html = `<html><head><title>Count</title></head><body>
+      <article><h1>Count</h1>${fiveWords}${longBody}</article></body></html>`;
+    const result = await handleIngest({ html });
+    const wordMatch = result.match(/\*\*Words:\*\* (\d+)/);
+    expect(wordMatch).not.toBeNull();
+    expect(Number(wordMatch![1])).toBeGreaterThan(5);
+  });
+
+  it('handles very long metadata without breaking format', async () => {
+    const longTitle = 'A'.repeat(500);
+    const result = await handleIngest({ html: makeHtml(longTitle, longBody) });
+    expect(result).toContain('**Title:**');
+    expect(result).toContain('---');
+  });
 });

--- a/tests/url-extractor.test.ts
+++ b/tests/url-extractor.test.ts
@@ -315,6 +315,15 @@ describe('isPrivateOrReservedHost', () => {
     expect(isPrivateOrReservedHost('google.com')).toBe(false);
     expect(isPrivateOrReservedHost('8.8.8.8')).toBe(false);
   });
+
+  it('blocks trailing-dot hostnames', () => {
+    expect(isPrivateOrReservedHost('localhost.')).toBe(true);
+    expect(isPrivateOrReservedHost('app.localhost.')).toBe(true);
+  });
+
+  it('allows public hostnames with trailing dot', () => {
+    expect(isPrivateOrReservedHost('example.com.')).toBe(false);
+  });
 });
 
 // ---- Unit: fetchHtml ----
@@ -903,6 +912,18 @@ describe('fetchHtml finalUrl tracking', () => {
     const result = await fetchHtml('https://example.com/start');
     expect(result.finalUrl).toBe('https://example.com/final-page');
   });
+
+  it('strips credentials from finalUrl before downstream use', async () => {
+    const longContent = '<p>' + 'Enough content for readability extraction. '.repeat(10) + '</p>';
+    globalThis.fetch = (async () => new Response(
+      `<html><head><title>Creds</title></head><body><article><h1>Creds</h1>${longContent}</article></body></html>`,
+      { status: 200, headers: { 'content-type': 'text/html' } },
+    )) as typeof fetch;
+    const result = await extractFromUrl('https://admin:secret@example.com/page');
+    expect(result.url).not.toContain('admin');
+    expect(result.url).not.toContain('secret');
+    expect(result.url).toContain('example.com/page');
+  });
 });
 
 // ---- New: HTML input size guard ----
@@ -963,11 +984,7 @@ describe('word count accuracy', () => {
 
 describe('SSRF error message clarity', () => {
   it('says matches not resolves', async () => {
-    try {
-      await fetchHtml('http://127.0.0.1/secret');
-    } catch (e: unknown) {
-      expect((e as Error).message).toContain('matches a private/reserved range');
-      expect((e as Error).message).not.toContain('resolves to');
-    }
+    await expect(fetchHtml('http://127.0.0.1/secret'))
+      .rejects.toThrow(/matches a private\/reserved range/);
   });
 });

--- a/tests/url-extractor.test.ts
+++ b/tests/url-extractor.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'bun:test';
-import { isValidUrl, extractArticle, extractFromUrl, fetchHtml } from '../src/url-extractor.js';
+import { describe, it, expect, afterEach } from 'bun:test';
+import { isValidUrl, isPrivateOrReservedHost, extractArticle, extractFromUrl, fetchHtml } from '../src/url-extractor.js';
 import { handleIngest } from '../src/tool-handlers.js';
 
 // ---- Unit: isValidUrl ----
@@ -165,9 +165,8 @@ describe('extractArticle', () => {
     </body></html>`;
     const result = extractArticle(html, 'https://example.com');
 
-    if (result?.byline) {
-      expect(result.byline).toContain('John Smith');
-    }
+    expect(result).not.toBeNull();
+    expect(result!.byline).toContain('John Smith');
   });
 
   it('extracts excerpt', () => {
@@ -175,9 +174,8 @@ describe('extractArticle', () => {
     const result = extractArticle(html, 'https://example.com');
 
     expect(result).not.toBeNull();
-    if (result!.excerpt) {
-      expect(result!.excerpt.length).toBeGreaterThan(0);
-    }
+    expect(result!.excerpt).toBeTruthy();
+    expect(result!.excerpt!.length).toBeGreaterThan(0);
   });
 
   it('handles HTML with multiple articles (extracts main content)', () => {
@@ -195,9 +193,8 @@ describe('extractArticle', () => {
     const html = `<html><head></head><body><article><h1></h1>${longParagraph}</article></body></html>`;
     const result = extractArticle(html, 'https://myblog.example.com/post');
 
-    if (result && !result.title.includes('meaningful')) {
-      expect(result.title).toBeTruthy();
-    }
+    expect(result).not.toBeNull();
+    expect(result!.title).toBeTruthy();
   });
 });
 
@@ -229,82 +226,179 @@ describe('handleIngest', () => {
   });
 });
 
+// ---- Unit: isPrivateOrReservedHost ----
+
+describe('isPrivateOrReservedHost', () => {
+  it('blocks localhost', () => {
+    expect(isPrivateOrReservedHost('localhost')).toBe(true);
+  });
+
+  it('blocks *.localhost', () => {
+    expect(isPrivateOrReservedHost('app.localhost')).toBe(true);
+  });
+
+  it('blocks 127.x.x.x loopback', () => {
+    expect(isPrivateOrReservedHost('127.0.0.1')).toBe(true);
+    expect(isPrivateOrReservedHost('127.255.255.255')).toBe(true);
+  });
+
+  it('blocks 10.x.x.x private range', () => {
+    expect(isPrivateOrReservedHost('10.0.0.1')).toBe(true);
+    expect(isPrivateOrReservedHost('10.255.255.255')).toBe(true);
+  });
+
+  it('blocks 172.16-31.x.x private range', () => {
+    expect(isPrivateOrReservedHost('172.16.0.1')).toBe(true);
+    expect(isPrivateOrReservedHost('172.31.255.255')).toBe(true);
+    expect(isPrivateOrReservedHost('172.15.0.1')).toBe(false);
+    expect(isPrivateOrReservedHost('172.32.0.1')).toBe(false);
+  });
+
+  it('blocks 192.168.x.x private range', () => {
+    expect(isPrivateOrReservedHost('192.168.1.1')).toBe(true);
+    expect(isPrivateOrReservedHost('192.168.0.1')).toBe(true);
+  });
+
+  it('blocks 169.254.x.x link-local / cloud metadata', () => {
+    expect(isPrivateOrReservedHost('169.254.169.254')).toBe(true);
+    expect(isPrivateOrReservedHost('169.254.0.1')).toBe(true);
+  });
+
+  it('blocks 0.0.0.0', () => {
+    expect(isPrivateOrReservedHost('0.0.0.0')).toBe(true);
+  });
+
+  it('blocks IPv6 loopback', () => {
+    expect(isPrivateOrReservedHost('[::1]')).toBe(true);
+  });
+
+  it('blocks IPv6 unique local (fc/fd)', () => {
+    expect(isPrivateOrReservedHost('[fc00::1]')).toBe(true);
+    expect(isPrivateOrReservedHost('[fd12::1]')).toBe(true);
+  });
+
+  it('blocks IPv6 link-local (fe80)', () => {
+    expect(isPrivateOrReservedHost('[fe80::1]')).toBe(true);
+  });
+
+  it('allows public hostnames', () => {
+    expect(isPrivateOrReservedHost('example.com')).toBe(false);
+    expect(isPrivateOrReservedHost('google.com')).toBe(false);
+    expect(isPrivateOrReservedHost('8.8.8.8')).toBe(false);
+  });
+});
+
 // ---- Unit: fetchHtml ----
 
 describe('fetchHtml', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
   it('rejects on non-HTML content type', async () => {
-    const originalFetch = globalThis.fetch;
     globalThis.fetch = (async () => new Response('{}', {
       status: 200,
       headers: { 'content-type': 'application/json' },
     })) as typeof fetch;
-
-    try {
-      await expect(fetchHtml('https://example.com/api')).rejects.toThrow('Unsupported content type');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await expect(fetchHtml('https://example.com/api')).rejects.toThrow('Unsupported content type');
   });
 
   it('rejects on HTTP error status', async () => {
-    const originalFetch = globalThis.fetch;
     globalThis.fetch = (async () => new Response('Not Found', {
       status: 404,
       statusText: 'Not Found',
       headers: { 'content-type': 'text/html' },
     })) as typeof fetch;
-
-    try {
-      await expect(fetchHtml('https://example.com/missing')).rejects.toThrow('HTTP 404');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await expect(fetchHtml('https://example.com/missing')).rejects.toThrow('HTTP 404');
   });
 
   it('rejects when content-length exceeds limit', async () => {
-    const originalFetch = globalThis.fetch;
     globalThis.fetch = (async () => new Response('x', {
       status: 200,
-      headers: {
-        'content-type': 'text/html',
-        'content-length': '999999999',
-      },
+      headers: { 'content-type': 'text/html', 'content-length': '999999999' },
     })) as typeof fetch;
-
-    try {
-      await expect(fetchHtml('https://example.com/huge')).rejects.toThrow('Content too large');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await expect(fetchHtml('https://example.com/huge')).rejects.toThrow('Content too large');
   });
 
   it('accepts text/html content type', async () => {
-    const originalFetch = globalThis.fetch;
     globalThis.fetch = (async () => new Response('<html><body>ok</body></html>', {
       status: 200,
       headers: { 'content-type': 'text/html; charset=utf-8' },
     })) as typeof fetch;
-
-    try {
-      const html = await fetchHtml('https://example.com');
-      expect(html).toContain('<body>ok</body>');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    const html = await fetchHtml('https://example.com');
+    expect(html).toContain('<body>ok</body>');
   });
 
   it('accepts text/plain content type', async () => {
-    const originalFetch = globalThis.fetch;
     globalThis.fetch = (async () => new Response('plain text content', {
       status: 200,
       headers: { 'content-type': 'text/plain' },
     })) as typeof fetch;
+    const html = await fetchHtml('https://example.com/text');
+    expect(html).toBe('plain text content');
+  });
 
-    try {
-      const html = await fetchHtml('https://example.com/text');
-      expect(html).toBe('plain text content');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+  it('rejects when streamed body exceeds limit', async () => {
+    const largeBody = 'x'.repeat(1024);
+    globalThis.fetch = (async () => new Response(largeBody, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    })) as typeof fetch;
+    await expect(fetchHtml('https://example.com', { maxContentLength: 100 })).rejects.toThrow('Content too large');
+  });
+
+  it('aborts on timeout', async () => {
+    globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      return new Promise<Response>((_, reject) => {
+        const onAbort = () => reject(new DOMException('The operation was aborted.', 'AbortError'));
+        if (init?.signal?.aborted) { onAbort(); return; }
+        init?.signal?.addEventListener('abort', onAbort);
+      });
+    }) as typeof fetch;
+    await expect(fetchHtml('https://example.com', { timeoutMs: 50 })).rejects.toThrow();
+  });
+
+  it('blocks URLs targeting localhost', async () => {
+    await expect(fetchHtml('http://localhost/secret')).rejects.toThrow('private/reserved');
+  });
+
+  it('blocks URLs targeting private IPs', async () => {
+    await expect(fetchHtml('http://192.168.1.1/admin')).rejects.toThrow('private/reserved');
+  });
+
+  it('blocks URLs targeting cloud metadata endpoint', async () => {
+    await expect(fetchHtml('http://169.254.169.254/latest/meta-data/')).rejects.toThrow('private/reserved');
+  });
+
+  it('blocks redirects to private IPs', async () => {
+    globalThis.fetch = (async () => new Response('', {
+      status: 302,
+      headers: { 'location': 'http://127.0.0.1/secret' },
+    })) as typeof fetch;
+    await expect(fetchHtml('https://example.com/redirect')).rejects.toThrow('private/reserved');
+  });
+
+  it('follows valid redirects', async () => {
+    let callCount = 0;
+    globalThis.fetch = (async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response('', { status: 301, headers: { 'location': 'https://example.com/final' } });
+      }
+      return new Response('<html><body>redirected</body></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      });
+    }) as typeof fetch;
+    const html = await fetchHtml('https://example.com/start');
+    expect(html).toContain('redirected');
+    expect(callCount).toBe(2);
+  });
+
+  it('rejects on too many redirects', async () => {
+    globalThis.fetch = (async () => new Response('', {
+      status: 302,
+      headers: { 'location': 'https://example.com/loop' },
+    })) as typeof fetch;
+    await expect(fetchHtml('https://example.com/start')).rejects.toThrow('Too many redirects');
   });
 });


### PR DESCRIPTION
## Summary

New MCP tool `knowledge-ingest` that fetches a URL and extracts its article content as clean markdown. Fully deterministic — no LLM dependency. Agents use the extracted content to create notes via `knowledge-store`.

## Architecture

```
Agent calls knowledge-ingest(url) 
  → fetchHtml (Bun fetch + timeout + size guard)
  → extractArticle (linkedom DOM parsing + Mozilla Readability)  
  → turndown (HTML → clean markdown)
  → returns { title, content, wordCount, byline, excerpt, siteName, extractedAt }
```

## New Dependencies

| Package | Version | Purpose | Size |
|---------|---------|---------|------|
| `@mozilla/readability` | 0.6.0 | Article extraction (Firefox Reader View engine) |  ~30KB |
| `linkedom` | 0.18.12 | Lightweight DOM parser for server-side HTML |  ~30KB |
| `turndown` | 7.2.4 | HTML → Markdown conversion |  ~20KB |
| `@types/turndown` | 5.0.6 | TypeScript types (devDep) | — |

All pure JS, zero native deps, Bun-compatible. Same stack used by RSSNext/Folo in production.

## Changes

- **`src/url-extractor.ts`** (new): `isValidUrl()`, `fetchHtml()`, `extractArticle()`, `extractFromUrl()` 
- **`src/tool-handlers.ts`**: Added `IngestArgs` interface and `handleIngest()` handler
- **`src/mcp-server.ts`**: Registered `knowledge-ingest` tool with Zod schema
- **`tests/url-extractor.test.ts`** (new): 36 tests covering:
  - URL validation (10 tests): http/https/ftp/javascript/file/data/empty/paths/params
  - Article extraction (15 tests): title, markdown conversion, nav stripping, headings, lists, links, word count, byline, excerpt, empty/nav-only HTML
  - Fetch error handling (5 tests): HTTP errors, content-type validation, size limits
  - Integration (2 tests): handleIngest error propagation
  - Edge cases (4 tests): empty HTML, non-article pages, multi-article pages

## Non-Breaking

- New tool — no changes to existing tool behavior
- All 505 existing tests pass
- 0 lint errors

## Security

- URL validation: only `http:` and `https:` protocols allowed
- Content size limit: 5MB max HTML
- Fetch timeout: 15s default
- No code execution — pure content extraction

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a knowledge-ingest tool to extract article content from URLs or provided HTML, returning structured markdown and metadata (title, byline, excerpt, site, word count)
  * Added markdown content-splitting and link-extraction utilities to produce sections and canonicalized links
  * Added repository search by URL to locate related notes

* **Documentation**
  * Updated tools reference, README, and skill guide to describe the new ingestion flow and limitations

* **Tests**
  * Comprehensive test suites for URL extraction, fetching, SSRF protections, redirects, and markdown processing

* **Chores**
  * Added HTML parsing and markdown-conversion dependencies and type definitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->