### PR TITLE
Improve SKILL.md with examples, boundaries, lifecycle guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Shared, persistent memory for AI assistants, built on the Zettelkasten method. O
 | Schema migrations | `src/schema.ts` | PRAGMA user_version based |
 | Data migrations | `src/data-migrations.ts` | Agent-driven content upgrades |
 | Configuration | `src/config.ts` | YAML config with defaults |
-| Types/interfaces | `src/types.ts` | NoteKind, NoteStatus, AppConfig |
+| Types/interfaces | `src/types.ts` | NoteKind, NoteStatus, Lifecycle, AppConfig |
 | Note rendering | `src/prompts.ts` | XML format for agent consumption |
 | Install/uninstall CLI | `src/setup.ts` | 5 clients: opencode, claude-code, cursor, windsurf, zed |
 | Tests | `tests/` | bun:test with harness + fixtures |
@@ -54,12 +54,16 @@ Shared, persistent memory for AI assistants, built on the Zettelkasten method. O
 | `handleStore` | function | `tool-handlers.ts` | knowledge-store implementation |
 | `handleSearch` | function | `tool-handlers.ts` | knowledge-search implementation |
 | `handleMaintain` | function | `tool-handlers.ts` | knowledge-maintain implementation |
+| `handleIngest` | function | `tool-handlers.ts` | knowledge-ingest implementation |
 | `NoteMetadata` | interface | `storage/NoteRepository.ts` | Domain model for notes |
 | `NoteKind` | type | `types.ts` | 6 kinds: personalization, reference, decision, procedure, resource, observation |
 | `NoteStatus` | type | `types.ts` | 3 statuses: fleeting → permanent → archived |
+| `Lifecycle` | type | `types.ts` | 3 lifecycles: living, snapshot, append-only |
 | `KIND_DEFAULT_STATUS` | const | `types.ts` | Maps kind → default status |
-| `AppConfig` | interface | `types.ts` | Config shape: vault, logLevel, lifecycle |
-| `SchemaManager` | class | `schema.ts` | DB schema versioning (v5), migrations |
+| `KIND_DEFAULT_LIFECYCLE` | const | `types.ts` | Maps kind → default lifecycle |
+| `AppConfig` | interface | `types.ts` | Config shape: vault, logLevel, lifecycle, lifecycleDefaults |
+| `SchemaManager` | class | `schema.ts` | DB schema versioning (v6), migrations |
+| `LifecycleViolationError` | class | `storage/NoteRepository.ts` | Thrown on snapshot update or append-only rewrite |
 | `getConfig` | function | `config.ts` | 2-layer merge: defaults → YAML config |
 | `logToFile` | function | `logger.ts` | File-based logging (XDG_STATE_HOME) |
 | `renderNoteForAgent` | function | `prompts.ts` | XML note rendering for agent consumption |

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ bun run setup            # interactive installer
 ## Links
 
 - [Setup Guide](docs/setup-guide.md) — installation, instruction injection, verification
-- [Tools Reference](docs/tools-reference.md) — all 3 MCP tools, parameters, examples
+- [Tools Reference](docs/tools-reference.md) — all 4 MCP tools, parameters, examples
 - [Configuration Reference](docs/configuration.md) — embeddings, vault, logging
 - [Note Lifecycle](docs/note-lifecycle.md) — statuses, review, promotion
 - [Architecture Design](docs/architecture.md) — system design, dual storage, instruction injection

--- a/agent-instructions-compact.md
+++ b/agent-instructions-compact.md
@@ -8,4 +8,5 @@ ALWAYS use the open-zk-kb MCP tools for persistent memory across sessions.
   - Lifecycle: `living` (default), `snapshot` (immutable — decisions, observations), `append-only`. Server enforces.
 - **Triggers**: user corrections/preferences, repeated lookups, non-obvious errors, architecture choices, multi-step workflows, useful URLs
 - **Client scoping**: Client-specific paths (`.cursor/`, `.claude/`) auto-tagged on store. No action needed.
+- **Ingest URLs**: `knowledge-ingest` to extract articles, then `knowledge-store` to save. Prefer passing HTML from your web tools.
 - **Maintain**: `knowledge-maintain stats` for health, `knowledge-maintain review` for stale notes

--- a/agent-instructions-compact.md
+++ b/agent-instructions-compact.md
@@ -5,6 +5,7 @@ ALWAYS use the open-zk-kb MCP tools for persistent memory across sessions.
 - **FIRST**: Before every response: (1) `knowledge-search` for relevant context (always pass `client: "{{CLIENT_NAME}}"`), (2) follow each note's `<guidance>` tag, (3) scan for storage triggers (remember, always, never, I prefer, corrections) and call `knowledge-store` BEFORE other work.
 - **Store knowledge**: `knowledge-store` — **one concept per note**, include `summary` and `guidance`. Multiple findings = multiple calls.
   - Kinds (target words): personalization (~50), decision (~150), observation (~100), reference (~120), procedure (~150), resource (~50)
+  - Lifecycle: `living` (default), `snapshot` (immutable — decisions, observations), `append-only`. Server enforces.
 - **Triggers**: user corrections/preferences, repeated lookups, non-obvious errors, architecture choices, multi-step workflows, useful URLs
 - **Client scoping**: Client-specific paths (`.cursor/`, `.claude/`) auto-tagged on store. No action needed.
 - **Maintain**: `knowledge-maintain stats` for health, `knowledge-maintain review` for stale notes

--- a/agent-instructions-full.md
+++ b/agent-instructions-full.md
@@ -32,6 +32,8 @@ Use `knowledge-store` with **one concept per note**. Include `summary` (one-line
 
 Notes exceeding the target will trigger a soft warning — heed it and split if the note covers more than one concept.
 
+**Lifecycle**: Notes have a `lifecycle` field — `living` (mutable, default), `snapshot` (immutable), or `append-only`. Decisions and observations default to `snapshot`; titles with dates auto-detect as `snapshot`. The server enforces immutability — snapshot updates and append-only rewrites are rejected.
+
 **Client scoping**: Notes containing client-specific paths (e.g., `.cursor/`, `.claude/`) are auto-tagged at store time. You don't need to pass `client` on store — it's auto-detected.
 
 ### Capture Checkpoints

--- a/agent-instructions-full.md
+++ b/agent-instructions-full.md
@@ -36,6 +36,11 @@ Notes exceeding the target will trigger a soft warning — heed it and split if 
 
 **Client scoping**: Notes containing client-specific paths (e.g., `.cursor/`, `.claude/`) are auto-tagged at store time. You don't need to pass `client` on store — it's auto-detected.
 
+### Ingesting URLs
+When a useful URL comes up: `knowledge-ingest` to extract content, then `knowledge-store` to save.
+- **With a web tool** (Playwright, Exa, web_fetch): fetch first, then `knowledge-ingest(html: "...", url: "...")`.
+- **Without a web tool**: `knowledge-ingest(url: "...")` directly — basic fetch, may fail on protected sites.
+
 ### Capture Checkpoints
 - Every task plan with 3+ todos: add a final **"Capture learnings → knowledge base"** todo.
 - At natural breakpoints (complex debug, architecture choice, topic change): ask *"Anything worth saving?"*

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -26,7 +26,7 @@
 #     reference: living
 #     procedure: living
 #     resource: living
-#   detectSnapshotFromSlug: true          # Titles with YYYY-MM-DD auto-default to snapshot
+#   detectSnapshotFromSlug: true          # Slugs containing YYYY-MM-DD auto-default to snapshot
 
 # ─── Embeddings ──────────────────────────────────────────────────────────────
 # Local embeddings (23MB MiniLM model) are enabled by default — no config needed.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,6 +16,18 @@
 #     - personalization
 #     - decision
 
+# ─── Lifecycle Defaults ───────────────────────────────────────────────────────
+# Per-kind lifecycle defaults and slug-based snapshot auto-detection.
+# lifecycleDefaults:
+#   defaultForKind:
+#     personalization: living
+#     decision: snapshot
+#     observation: snapshot
+#     reference: living
+#     procedure: living
+#     resource: living
+#   detectSnapshotFromSlug: true          # Titles with YYYY-MM-DD auto-default to snapshot
+
 # ─── Embeddings ──────────────────────────────────────────────────────────────
 # Local embeddings (23MB MiniLM model) are enabled by default — no config needed.
 # To use an API provider instead, uncomment below:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -26,7 +26,7 @@
 #     reference: living
 #     procedure: living
 #     resource: living
-#   detectSnapshotFromSlug: true          # Slugs containing YYYY-MM-DD auto-default to snapshot
+#   detectSnapshotFromSlug: true          # Titles with YYYY-MM-DD auto-default to snapshot
 
 # ─── Embeddings ──────────────────────────────────────────────────────────────
 # Local embeddings (23MB MiniLM model) are enabled by default — no config needed.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ Knowledge capture is driven by the calling agent's instructions (e.g., a Claude 
 ┌──────────▼──────────┐
 │   MCP Server        │
 │   (mcp-server.ts)   │
-│   - 3 tool handlers │
+│   - 4 tool handlers │
 │   - stdio transport │
 └──────────┬──────────┘
            │
@@ -61,7 +61,7 @@ The system employs a hybrid storage strategy to balance portability with perform
 The MCP server provides a reactive interface to the knowledge base:
 
 * **Transport**: Uses `@modelcontextprotocol/sdk` with stdio transport.
-* **Tools**: Registers three core tools: `knowledge-store`, `knowledge-search`, and `knowledge-maintain`.
+* **Tools**: Registers four core tools: `knowledge-store`, `knowledge-search`, `knowledge-maintain`, and `knowledge-ingest`.
 * **Initialization**: Uses a lazy singleton pattern where the `NoteRepository` is initialized only upon the first tool call.
 * **Embeddings**: Generated locally by default via `@huggingface/transformers` (WASM backend, no native deps).
     * **Model**: `Xenova/all-MiniLM-L6-v2` (quantized q8, ~23MB).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,7 @@ All settings live in a single YAML file: `~/.config/open-zk-kb/config.yaml`
 
 The SQLite schema is versioned and managed programmatically:
 
-* **Version Tracking**: Uses `PRAGMA user_version` (currently v5).
+* **Version Tracking**: Uses `PRAGMA user_version` (currently v6).
 * **DDL Migrations**: Managed by the `SchemaManager` class in `src/schema.ts`.
 * **Data Migrations**: Handled in `src/data-migrations.ts` for agent-driven content upgrades.
 * **Core Tables**:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,7 @@ Knowledge capture is driven by the calling agent's instructions (e.g., a Claude 
 │   handleStore()     │
 │   handleSearch()    │
 │   handleMaintain()  │
+│   handleIngest()    │
 └──────────┬──────────┘
            │
 ┌──────────▼──────────┐

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,7 +35,7 @@ For rapid iteration:
 ```
 src/
 ├── mcp-server.ts       # MCP server entry point (stdio transport)
-├── tool-handlers.ts    # Shared logic for all 3 tools
+├── tool-handlers.ts    # Shared logic for all 4 tools
 ├── storage/
 │   └── NoteRepository.ts  # Core CRUD, FTS5, link tracking
 ├── config.ts           # Config loading (YAML with defaults)

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -61,10 +61,11 @@ bun run setup install --client opencode
 1. Restart your editor/client.
 2. Optionally run `bunx open-zk-kb@latest doctor --client <name>` to verify the local install. Add `--fix` to repair safe issues automatically.
 3. Ask your assistant: **"Run `knowledge-maintain stats`"**
-4. You should see vault statistics (0 notes on fresh install). This confirms the 3 tools are available:
+4. You should see vault statistics (0 notes on fresh install). This confirms the 4 tools are available:
    - `knowledge-store` -- save notes to the knowledge base
    - `knowledge-search` -- full-text search across notes
    - `knowledge-maintain` -- stats, review, promote, archive, rebuild
+   - `knowledge-ingest` -- extract article content from URLs or HTML
 
 ## Agent Instructions
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -137,7 +137,6 @@ Search the knowledge base using full-text search and semantic similarity. Return
 | `client` | string | No | Your client name — excludes notes scoped to other clients |
 | `tags` | string[] | No | Filter by tags (all must match) |
 | `limit` | number | No | Max results (default 10) |
-| `model` | string | No | Your model identifier. Enables richer responses for capable models |
 
 ### How search works
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -16,9 +16,12 @@ Store knowledge in the persistent knowledge base. One concept per note.
 | `summary` | string | Yes | One-line present-tense key takeaway |
 | `guidance` | string | Yes | Imperative actionable instruction for future agents |
 | `status` | enum | No | Override default: `fleeting`, `permanent`, or `archived`. Defaults based on kind (see [Note Lifecycle](note-lifecycle.md)) |
+| `lifecycle` | enum | No | `living` (mutable), `snapshot` (immutable), or `append-only`. Defaults based on kind |
 | `tags` | string[] | No | Tags for categorization |
 | `project` | string | No | Project scope — auto-adds `project:<name>` tag |
+| `client` | string | No | Client identifier (e.g. `claude-code`, `opencode`). Auto-detected from content when omitted |
 | `related` | string[] | No | IDs of related notes to link via `[[wikilinks]]` |
+| `model` | string | No | Your model identifier. Enables richer responses for capable models |
 
 ### What happens
 
@@ -129,9 +132,12 @@ Search the knowledge base using full-text search and semantic similarity. Return
 | `query` | string | Yes | Natural language query or keywords |
 | `kind` | enum | No | Filter by note kind |
 | `status` | enum | No | Filter by status: `fleeting`, `permanent`, or `archived` |
+| `lifecycle` | enum | No | Filter by lifecycle: `living`, `snapshot`, or `append-only` |
 | `project` | string | No | Filter by project tag |
+| `client` | string | No | Your client name — excludes notes scoped to other clients |
 | `tags` | string[] | No | Filter by tags (all must match) |
 | `limit` | number | No | Max results (default 10) |
+| `model` | string | No | Your model identifier. Enables richer responses for capable models |
 
 ### How search works
 

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-zk-kb
-version: 1.0.11
+version: 1.0.12
 description: >
   Persistent knowledge base for cross-session memory. BEFORE responding to any
   user message: (1) knowledge-search for relevant context, (2) scan for storage
@@ -10,15 +10,12 @@ description: >
 
 ## Knowledge Base (open-zk-kb)
 
-ALWAYS use the open-zk-kb MCP tools to maintain persistent memory across sessions.
-
-### Pre-Flight: Before Responding to Any Message
-
+### Pre-Flight
 ALWAYS do both of these **before any other work**:
 
-1. **Search** — `knowledge-search` for relevant context. Always pass `client: "claude-code"` to filter out notes meant for other AI clients. Use filters (`kind`, `project`, `tags`) to narrow further. If no results, try broader keywords before proceeding without context.
-2. **Apply results** — each note has a `<guidance>` tag: follow it. Personalization shapes your style, decisions are binding unless overridden, procedures are step-by-step instructions, observations are verified gotchas.
-3. **Scan for storage triggers** — if the user's message matches a trigger below, call `knowledge-store` before proceeding with the task.
+1. **Search** — `knowledge-search` with `client: "claude-code"`. Use `kind`/`project`/`tags` filters to narrow. Try broader keywords if no results.
+2. **Apply results** — follow each note's `<guidance>` tag. Personalization shapes style, decisions are binding, procedures are step-by-step, observations are verified gotchas.
+3. **Scan for triggers** — if the user's message matches a trigger below, call `knowledge-store` before proceeding.
 
 | Trigger | Kind |
 |---------|------|
@@ -42,26 +39,77 @@ Use `knowledge-store` with **one concept per note**. Include `summary` (one-line
 - **procedure** (~150 words) — "Release: `bun run release` → bumps version, changelog, PR"
 - **resource** (~50 words) — "Bun SQLite docs: https://bun.sh/docs/api/sqlite"
 
-Notes exceeding the target will trigger a soft warning — heed it and split if the note covers more than one concept.
+Notes exceeding the target trigger a soft warning — split if the note covers more than one concept. Client-specific paths (e.g., `.cursor/`, `.claude/`) are auto-tagged; no need to pass `client` on store.
 
-**Client scoping**: Notes containing client-specific paths (e.g., `.cursor/`, `.claude/`) are auto-tagged at store time. You don't need to pass `client` on store — it's auto-detected.
+### Good vs Bad Examples
+✅ **Good** — specific title, correct kind, actionable guidance:
+```
+title: "Bun SQLite requires explicit WAL mode for concurrent access"
+kind: "observation"
+summary: "SQLite in Bun uses journal mode by default; WAL must be set explicitly."
+guidance: "Run `db.exec('PRAGMA journal_mode=WAL')` after opening any Bun SQLite db."
+```
+
+🚫 **Bad** — vague title, wrong kind, useless guidance:
+```
+title: "Database stuff"
+kind: "reference"
+summary: "Some notes about the database."
+guidance: "Check the database."
+```
+
+### Kind Selection Guide
+| Scenario | Kind |
+|----------|------|
+| User says they prefer tabs over spaces | **personalization** |
+| We chose PostgreSQL over MySQL after comparing replication | **decision** |
+| Bun's SQLite requires explicit WAL mode for concurrent access | **observation** |
+| API endpoint for user creation is `POST /api/v2/users` | **reference** |
+| Deploy: run build, tag version, push to registry | **procedure** |
+| Bun SQLite docs: https://bun.sh/docs/api/sqlite | **resource** |
+
+### Boundaries
+✅ **Always**:
+- One concept per note — split if in doubt
+- Include both `summary` and `guidance` on every store call
+- Search before storing to avoid duplicates
+- Pass `client: "claude-code"` on search calls
+
+⚠️ **Ask first**:
+- Before archiving or deleting notes you didn't create this session
+- Before changing the `kind` or `status` of a permanent note
+
+🚫 **Never**:
+- Bundle multiple concepts into one note
+- Use vague titles like "Notes" or "Stuff"
+- Store sensitive data (API keys, credentials, tokens)
+- Defer storage to after task completion
+
+### Lifecycle
+Notes have a `lifecycle` field controlling mutability. The server enforces it.
+
+| Lifecycle | Behavior | Default for |
+|-----------|----------|-------------|
+| `living` | Mutable, updated freely | personalization, reference, procedure, resource |
+| `snapshot` | Immutable after creation | decision, observation |
+| `append-only` | Additive only, no rewrites | (explicit opt-in) |
+
+- **Auto-detection**: titles with a date (e.g., "Analysis 2026-04-26") auto-set to `snapshot`.
+- **Enforcement**: snapshot updates and append-only rewrites are rejected by the server. Create a new note instead.
+- **Migration**: notes without `lifecycle` default to `living`. No action needed; the field is added on next update.
+
+**Server vs agent**: The server surfaces data and enforces constraints (lifecycle immutability, atomicity warnings, duplicate detection). You decide whether and how to act on surfaced information.
 
 ### Capture Checkpoints
-- Every task plan with 3+ todos: add a final **"Capture learnings → knowledge base"** todo.
-- At natural breakpoints (complex debug, architecture choice, topic change): ask *"Anything worth saving?"*
-- Before ending a session: review for uncaptured preferences, decisions, gotchas, or workflows.
+- 3+ todo tasks: add a final **"Capture learnings → knowledge base"** todo.
+- Natural breakpoints (debug, architecture choice, topic change): ask *"Anything worth saving?"*
+- Session end: review for uncaptured preferences, decisions, gotchas, or workflows.
 
 ### Ingesting URLs
-When a useful URL comes up, extract its content via `knowledge-ingest`, then store via `knowledge-store`.
+When a useful URL comes up: `knowledge-ingest` to extract, then `knowledge-store(kind: "resource", ...)`.
 
-**If you have a web tool** (Playwright, Exa, web_fetch, dev-browser — check your available tools):
-1. Fetch the page with your web tool (handles JS rendering, bot protection, auth)
-2. `knowledge-ingest(html: "<fetched html>", url: "<source url>")` → extracts title, content, metadata
-3. `knowledge-store(kind: "resource", ...)` with your summary
-
-**If you have no web tools** (fallback only):
-1. `knowledge-ingest(url: "...")` → basic fetch + extract (no JS rendering, may fail on protected sites)
-2. `knowledge-store(kind: "resource", ...)` with your summary
+- **With a web tool** (Playwright, Exa, web_fetch): fetch first, then `knowledge-ingest(html: "...", url: "...")` — handles JS rendering and bot protection.
+- **Without a web tool**: `knowledge-ingest(url: "...")` directly — basic fetch, may fail on protected sites.
 
 ### Maintenance
 - `knowledge-maintain stats` — KB health | `knowledge-maintain review` — stale notes

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -11,7 +11,7 @@ description: >
 ## Knowledge Base (open-zk-kb)
 
 ### Pre-Flight
-ALWAYS do both of these **before any other work**:
+ALWAYS do all of these **before any other work**:
 
 1. **Search** — `knowledge-search` with `client: "claude-code"`. Use `kind`/`project`/`tags` filters to narrow. Try broader keywords if no results.
 2. **Apply results** — follow each note's `<guidance>` tag. Personalization shapes style, decisions are binding, procedures are step-by-step, observations are verified gotchas.

--- a/skills/open-zk-kb/kinds-reference.md
+++ b/skills/open-zk-kb/kinds-reference.md
@@ -3,7 +3,7 @@
 Detailed descriptions and examples for each knowledge base note kind.
 
 ## personalization
-User preferences, habits, and working style.
+User preferences, habits, and working style. Default lifecycle: `living`.
 
 **When to store**: User says "I prefer", "always", "never", or corrects your approach.
 
@@ -13,9 +13,9 @@ User preferences, habits, and working style.
 - "User works in Pacific timezone, prefers async communication"
 
 ## decision
-Architecture choices, trade-off analyses, and rationale.
+Architecture choices, trade-off analyses, and rationale. Default lifecycle: `snapshot`.
 
-**When to store**: You and the user weigh options and pick one.
+**When to store**: You and the user weigh options and pick one. Decisions are immutable once stored — create a new decision note if the choice changes.
 
 **Examples**:
 - "Chose FTS5 over trigram search — better phrase matching, lower complexity"
@@ -23,7 +23,7 @@ Architecture choices, trade-off analyses, and rationale.
 - "Selected YAML for config over TOML — better multi-line string support"
 
 ## observation
-Non-obvious errors, gotchas, and runtime behaviors worth remembering.
+Non-obvious errors, gotchas, and runtime behaviors worth remembering. Default lifecycle: `snapshot`.
 
 **When to store**: You hit a surprising error or discover unexpected behavior.
 
@@ -33,7 +33,7 @@ Non-obvious errors, gotchas, and runtime behaviors worth remembering.
 - "SQLite WAL mode required for concurrent read/write in Bun"
 
 ## reference
-Facts about the codebase, APIs, or tools that you looked up and may need again.
+Facts about the codebase, APIs, or tools that you looked up and may need again. Default lifecycle: `living`.
 
 **When to store**: You look something up twice in one session, or find a detail that's hard to rediscover.
 
@@ -43,9 +43,9 @@ Facts about the codebase, APIs, or tools that you looked up and may need again.
 - "SchemaManager migration runs on every `open()` call, not just first use"
 
 ## procedure
-Multi-step workflows discovered by doing them.
+Multi-step workflows discovered by doing them. Default lifecycle: `living`.
 
-**When to store**: You figure out a workflow with 3+ steps that would be useful to repeat.
+**When to store**: You figure out a workflow with 3+ steps that would be useful to repeat. Procedures evolve — update freely as the workflow changes.
 
 **Examples**:
 - "Release: `bun run release` → bumps version, changelog, PR"
@@ -53,7 +53,7 @@ Multi-step workflows discovered by doing them.
 - "Debug MCP: set LOG_LEVEL=debug, check ~/.local/state/open-zk-kb/logs/"
 
 ## resource
-Useful URLs, documentation links, and external references.
+Useful URLs, documentation links, and external references. Default lifecycle: `living`.
 
 **When to store**: A useful URL comes up during work.
 
@@ -61,3 +61,13 @@ Useful URLs, documentation links, and external references.
 - "Bun SQLite docs: https://bun.sh/docs/api/sqlite"
 - "FTS5 tokenizer reference: https://sqlite.org/fts5.html#tokenizers"
 - "MCP SDK repo: https://github.com/modelcontextprotocol/typescript-sdk"
+
+## Lifecycle Reference
+
+| Lifecycle | Behavior | When to use |
+|-----------|----------|-------------|
+| `living` | Mutable — updated freely | Evolving docs, preferences, procedures |
+| `snapshot` | Immutable — server rejects updates | Point-in-time decisions, observations, dated analyses |
+| `append-only` | Additive only — server rejects rewrites | Operations logs, decision histories (opt-in) |
+
+Override via `lifecycle` parameter on `knowledge-store`. Titles containing dates (e.g., "2025-04-25") auto-default to `snapshot`.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -8,8 +8,8 @@ TypeScript source for the MCP server (`mcp-server.ts`), with core logic in `tool
 
 ```
 src/
-├── mcp-server.ts          # MCP stdio server — 3 tools via @modelcontextprotocol/sdk
-├── tool-handlers.ts       # Shared: handleStore, handleSearch, handleMaintain (~477 LOC)
+├── mcp-server.ts          # MCP stdio server — 4 tools via @modelcontextprotocol/sdk
+├── tool-handlers.ts       # Shared: handleStore, handleSearch, handleMaintain, handleIngest
 ├── storage/
 │   └── NoteRepository.ts  # Core CRUD + FTS5 + link tracking (~1,370 LOC)
 ├── utils/
@@ -21,9 +21,9 @@ src/
 ├── data-migrations.ts     # Agent-driven content upgrades (summary/guidance)
 ├── logger.ts              # logToFile() — file-based, never stdout
 ├── prompts.ts             # renderNoteForAgent() — XML <note> format
-├── schema.ts              # SchemaManager — PRAGMA user_version (v5)
+├── schema.ts              # SchemaManager — PRAGMA user_version (v6)
 ├── setup.ts               # CLI install/uninstall for 5 clients (bun run setup)
-└── types.ts               # NoteKind, NoteStatus, AppConfig
+└── types.ts               # NoteKind, NoteStatus, Lifecycle, AppConfig
 ```
 
 ## Data Flow

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -31,7 +31,7 @@ src/
 ```
 Client request → mcp-server.ts
                         ↓
-               tool-handlers.ts (handleStore/Search/Maintain)
+               tool-handlers.ts (handleStore/Search/Maintain/Ingest)
                         ↓
                NoteRepository.store/search/getStats/...
                     ↓              ↓

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -17,7 +17,7 @@ tests/
 ├── embeddings.test.ts     # Pure functions: cosineSimilarity, blob round-trip, buildEmbeddingText
 ├── simhash.test.ts        # SimHash duplicate detection
 ├── config.test.ts         # Config loading: defaults, YAML override, partial, malformed
-├── schema.test.ts         # DB schema: fresh creation, migrations v1→v5
+├── schema.test.ts         # DB schema: fresh creation, migrations v1→v6
 ├── setup.test.ts          # CLI installer: install, uninstall, skill + instruction injection
 ├── knowledge-quality-assessment.test.ts  # Content quality scoring
 ├── injection-quality-test.ts  # Agent self-search quality via MCP


### PR DESCRIPTION
## Summary

Closes #80. Restructures the Claude Code skill (`skills/open-zk-kb/SKILL.md`) with concrete patterns from GitHub's analysis of 2,500+ AGENTS.md files.

- **Good/bad examples** for `knowledge-store` calls — specific vs vague
- **Three-tier boundaries** (✅ Always / ⚠️ Ask first / 🚫 Never)
- **Lifecycle guidance** — living/snapshot/append-only with migration note for existing KBs
- **Kind selection guide** — real scenario → correct kind mapping table
- **Server vs agent responsibility** note per #93 ownership policy
- Updated `kinds-reference.md` with per-kind default lifecycle values

## Migration for existing knowledge bases

- Existing notes without `lifecycle:` in frontmatter default to `living` — no action needed
- The field is automatically added to frontmatter on next update (promote, archive, tag change, content edit)
- Documented in the new Lifecycle section: "Notes without `lifecycle` default to `living`. No action needed; the field is added on next update."
- Users get the new skill by running: `bunx open-zk-kb@latest install --client claude-code --force`
- `knowledge-maintain stats` flags outdated instruction versions

## Skill-only, not managed block

Per #80's design principle: all additions go into the on-demand-loaded skill (costs tokens only when relevant), NOT the always-injected managed block in AGENTS.md (which would increase every-session token cost across all clients).

## Changes

| File | Lines | Change |
|---|---|---|
| `skills/open-zk-kb/SKILL.md` | 69 → 117 | Added examples, boundaries, lifecycle, kind guide, version bump |
| `skills/open-zk-kb/kinds-reference.md` | 63 → 79 | Added lifecycle defaults per kind, lifecycle reference table |

## Determinism boundary (per #93)

All content is behavioral guidance — purely advisory. The server enforces lifecycle constraints; the skill teaches the agent when and how to use the feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added knowledge ingestion tool for extracting article content from URLs or HTML sources.
  * Introduced lifecycle management for stored notes with three modes: living (mutable), snapshot (immutable), and append-only (additive only).
  * Enhanced search to filter results by lifecycle and client attributes.
  * Added support for client-scoping and model identification in stored notes.
  * Database schema upgraded to support new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->