### PR TITLE
Add domain note kind for project operating manuals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Shared, persistent memory for AI assistants, built on the Zettelkasten method. O
 | `handleMaintain` | function | `tool-handlers.ts` | knowledge-maintain implementation |
 | `handleIngest` | function | `tool-handlers.ts` | knowledge-ingest implementation |
 | `NoteMetadata` | interface | `storage/NoteRepository.ts` | Domain model for notes |
-| `NoteKind` | type | `types.ts` | 6 kinds: personalization, reference, decision, procedure, resource, observation |
+| `NoteKind` | type | `types.ts` | 7 kinds: personalization, reference, decision, procedure, resource, observation, domain |
 | `NoteStatus` | type | `types.ts` | 3 statuses: fleeting → permanent → archived |
 | `Lifecycle` | type | `types.ts` | 3 lifecycles: living, snapshot, append-only |
 | `KIND_DEFAULT_STATUS` | const | `types.ts` | Maps kind → default status |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Shared, persistent memory for AI assistants, built on the Zettelkasten method. O
 AI assistants forget everything between sessions. open-zk-kb gives your assistant a persistent, structured memory it queries automatically.
 
 - **Hybrid search** — full-text + local embeddings, so only relevant notes surface
-- **Atomic notes** — one concept per note (6 kinds, lifecycle management) keeps results precise
+- **Atomic notes** — one concept per note (7 kinds, lifecycle management) keeps results precise
 - **Local-first** — no API keys, works offline, scales to thousands of notes
 - **Human-readable** — Markdown + YAML frontmatter, rebuildable from files
 - **Shared memory across tools** — one knowledge base for OpenCode, Claude Code, Cursor, Windsurf, and Zed
@@ -83,6 +83,7 @@ Any OpenAI-compatible API works (OpenRouter, Together, Groq, local vLLM, etc.). 
 | `procedure` | fleeting | Step-by-step workflows and recurring tasks |
 | `resource` | permanent | Links, tools, libraries, and external documentation |
 | `observation` | fleeting | Insights, patterns, and temporary findings |
+| `domain` | permanent | Project operating manuals — agent role, scope, conventions, boundaries |
 
 Notes follow a lifecycle: **fleeting** → **permanent** → **archived**. See [Note Lifecycle](docs/note-lifecycle.md) for details.
 

--- a/agent-instructions-compact.md
+++ b/agent-instructions-compact.md
@@ -4,7 +4,7 @@ ALWAYS use the open-zk-kb MCP tools for persistent memory across sessions.
 
 - **FIRST**: Before every response: (1) `knowledge-search` for relevant context (always pass `client: "{{CLIENT_NAME}}"`), (2) follow each note's `<guidance>` tag, (3) scan for storage triggers (remember, always, never, I prefer, corrections) and call `knowledge-store` BEFORE other work.
 - **Store knowledge**: `knowledge-store` — **one concept per note**, include `summary` and `guidance`. Multiple findings = multiple calls.
-  - Kinds (target words): personalization (~50), decision (~150), observation (~100), reference (~120), procedure (~150), resource (~50)
+  - Kinds (target words): personalization (~50), decision (~150), observation (~100), reference (~120), procedure (~150), resource (~50), domain (~500 — project operating manual, one per project)
   - Lifecycle: `living` (default), `snapshot` (immutable — decisions, observations), `append-only`. Server enforces.
 - **Triggers**: user corrections/preferences, repeated lookups, non-obvious errors, architecture choices, multi-step workflows, useful URLs
 - **Client scoping**: Client-specific paths (`.cursor/`, `.claude/`) auto-tagged on store. No action needed.

--- a/agent-instructions-full.md
+++ b/agent-instructions-full.md
@@ -29,6 +29,7 @@ Use `knowledge-store` with **one concept per note**. Include `summary` (one-line
 - **reference** (~120 words) — "getStaleNotes filters on `created_at`, not `updated_at`"
 - **procedure** (~150 words) — "Release: `bun run release` → bumps version, changelog, PR"
 - **resource** (~50 words) — "Bun SQLite docs: https://bun.sh/docs/api/sqlite"
+- **domain** (~500 words) — Project operating manual: agent role, scope, conventions, boundaries. One per project, always surfaced in project-scoped searches.
 
 Notes exceeding the target will trigger a soft warning — heed it and split if the note covers more than one concept.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -26,7 +26,12 @@
 #     reference: living
 #     procedure: living
 #     resource: living
+#     domain: living
 #   detectSnapshotFromSlug: true          # Titles with YYYY-MM-DD auto-default to snapshot
+
+# ─── Search ───────────────────────────────────────────────────────────────────
+# search:
+#   alwaysIncludeDomainNote: true         # Prepend domain note to project-scoped searches
 
 # ─── Embeddings ──────────────────────────────────────────────────────────────
 # Local embeddings (23MB MiniLM model) are enabled by default — no config needed.

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -12,7 +12,7 @@ Store knowledge in the persistent knowledge base. One concept per note.
 |-----------|------|----------|-------------|
 | `title` | string | Yes | Note title — concise, descriptive |
 | `content` | string | Yes | Note content — the knowledge to store |
-| `kind` | enum | Yes | One of: `personalization`, `reference`, `decision`, `procedure`, `resource`, `observation` |
+| `kind` | enum | Yes | One of: `personalization`, `reference`, `decision`, `procedure`, `resource`, `observation`, `domain` |
 | `summary` | string | Yes | One-line present-tense key takeaway |
 | `guidance` | string | Yes | Imperative actionable instruction for future agents |
 | `status` | enum | No | Override default: `fleeting`, `permanent`, or `archived`. Defaults based on kind (see [Note Lifecycle](note-lifecycle.md)) |
@@ -22,6 +22,13 @@ Store knowledge in the persistent knowledge base. One concept per note.
 | `client` | string | No | Client identifier (e.g. `claude-code`, `opencode`). Auto-detected from content when omitted |
 | `related` | string[] | No | IDs of related notes to link via `[[wikilinks]]` |
 | `model` | string | No | Your model identifier. Enables richer responses for capable models |
+
+### Domain note constraints
+
+When `kind: "domain"`:
+- **Requires** `project` parameter — rejected without one
+- **One per project** — storing a second domain note for the same project returns an error with the existing note's ID
+- Default status: `permanent`, default lifecycle: `living`
 
 ### What happens
 
@@ -143,7 +150,8 @@ Search the knowledge base using full-text search and semantic similarity. Return
 1. **Full-text search** — tokenizes the query, strips special operators, searches title + content + tags + context
 2. **Semantic embedding search** — if embeddings are enabled, generates a query vector and finds cosine-similar notes (races against a 500ms timeout)
 3. **Reciprocal Rank Fusion** — merges both result sets into a single ranked list
-4. If the embedding model isn't ready (first query after startup), gracefully falls back to full-text-only
+4. **Domain note injection** — when a `project` filter is set and the project has a `domain` note, it is prepended to results regardless of relevance ranking. Configurable via `search.alwaysIncludeDomainNote` (default: `true`)
+5. If the embedding model isn't ready (first query after startup), gracefully falls back to full-text-only
 
 ### Example
 

--- a/llms.txt
+++ b/llms.txt
@@ -31,7 +31,7 @@ Store a note with one concept. Notes have YAML frontmatter and Markdown content.
 Parameters:
 - title (string, required): Note title
 - content (string, required): Note content
-- kind (string, required): personalization, reference, decision, procedure, resource, or observation
+- kind (string, required): personalization, reference, decision, procedure, resource, observation, or domain
 - summary (string, required): One-line takeaway
 - guidance (string, required): Imperative instruction for future agents
 - tags (array, optional): Categorization tags
@@ -55,6 +55,7 @@ The Zettelkasten ("slip box") method stores one atomic concept per note, with ex
 - procedure: Step-by-step workflows, recurring tasks (fleeting by default)
 - resource: Links, tools, libraries, external documentation (permanent by default)
 - observation: Insights, patterns, temporary findings (fleeting by default)
+- domain: Project operating manuals — agent role, scope, conventions, boundaries (permanent by default)
 
 ### Note Lifecycle
 

--- a/site/index.md
+++ b/site/index.md
@@ -20,7 +20,7 @@ Notes are Markdown files with YAML frontmatter. A SQLite index provides full-tex
 ## Key features
 
 - **Hybrid search** — full-text + semantic embeddings, so results match meaning not just keywords
-- **Atomic notes** — one concept per note, typed (6 kinds) with lifecycle management (fleeting, permanent, archived)
+- **Atomic notes** — one concept per note, typed (7 kinds) with lifecycle management (fleeting, permanent, archived)
 - **Local-first** — everything stays on your machine, no API keys required
 - **Multi-client** — Claude Code, Cursor, Windsurf, OpenCode, Zed
 - **Human-readable** — Markdown files you can browse, edit, and version control

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -38,6 +38,7 @@ Use `knowledge-store` with **one concept per note**. Include `summary` (one-line
 - **reference** (~120 words) — "getStaleNotes filters on `created_at`, not `updated_at`"
 - **procedure** (~150 words) — "Release: `bun run release` → bumps version, changelog, PR"
 - **resource** (~50 words) — "Bun SQLite docs: https://bun.sh/docs/api/sqlite"
+- **domain** (~200 words) — "Project operating manual: agent role, scope, conventions, boundaries"
 
 Notes exceeding the target trigger a soft warning — split if the note covers more than one concept. Client-specific paths (e.g., `.cursor/`, `.claude/`) are auto-tagged; no need to pass `client` on store.
 
@@ -67,6 +68,7 @@ guidance: "Check the database."
 | API endpoint for user creation is `POST /api/v2/users` | **reference** |
 | Deploy: run build, tag version, push to registry | **procedure** |
 | Bun SQLite docs: https://bun.sh/docs/api/sqlite | **resource** |
+| Project's agent role, scope, conventions, and boundaries | **domain** |
 
 ### Boundaries
 ✅ **Always**:
@@ -90,7 +92,7 @@ Notes have a `lifecycle` field controlling mutability. The server enforces it.
 
 | Lifecycle | Behavior | Default for |
 |-----------|----------|-------------|
-| `living` | Mutable, updated freely | personalization, reference, procedure, resource |
+| `living` | Mutable, updated freely | personalization, reference, procedure, resource, domain |
 | `snapshot` | Immutable after creation | decision, observation |
 | `append-only` | Additive only, no rewrites | (explicit opt-in) |
 

--- a/skills/open-zk-kb/kinds-reference.md
+++ b/skills/open-zk-kb/kinds-reference.md
@@ -62,6 +62,20 @@ Useful URLs, documentation links, and external references. Default lifecycle: `l
 - "FTS5 tokenizer reference: https://sqlite.org/fts5.html#tokenizers"
 - "MCP SDK repo: https://github.com/modelcontextprotocol/typescript-sdk"
 
+## domain
+Project operating manual — agent role, scope, conventions, and boundaries. Default lifecycle: `living`. Default status: `permanent`.
+
+**When to store**: When a project needs a persistent operating manual that defines how the agent should work within it. One per project — enforced by the server.
+
+**Constraints**:
+- Requires a `project` parameter (rejected without one)
+- One per project — storing a second domain note for the same project is rejected
+- Always included in project-scoped search results (prepended before relevance-ranked results)
+
+**Examples**:
+- "conductor — Operating Manual: Agent role is operations assistant. Priority order: 1) monitoring 2) alerting 3) reporting..."
+- "open-zk-kb — Operating Manual: Agent role is KB developer. Always use Bun, never Node.js..."
+
 ## Lifecycle Reference
 
 | Lifecycle | Behavior | When to use |

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,9 @@ interface RawConfig {
     defaultForKind?: Record<string, string>;
     detectSnapshotFromSlug?: boolean;
   };
+  search?: {
+    alwaysIncludeDomainNote?: boolean;
+  };
   embeddings?: EmbeddingsConfig;
 }
 
@@ -51,6 +54,9 @@ export const DEFAULT_CONFIG: AppConfig = {
   lifecycleDefaults: {
     defaultForKind: { ...KIND_DEFAULT_LIFECYCLE },
     detectSnapshotFromSlug: true,
+  },
+  search: {
+    alwaysIncludeDomainNote: true,
   },
 };
 
@@ -102,6 +108,9 @@ export function getConfig(): AppConfig {
         ),
       },
       detectSnapshotFromSlug: raw?.lifecycleDefaults?.detectSnapshotFromSlug ?? DEFAULT_CONFIG.lifecycleDefaults.detectSnapshotFromSlug,
+    },
+    search: {
+      alwaysIncludeDomainNote: raw?.search?.alwaysIncludeDomainNote ?? DEFAULT_CONFIG.search.alwaysIncludeDomainNote,
     },
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -110,7 +110,9 @@ export function getConfig(): AppConfig {
       detectSnapshotFromSlug: raw?.lifecycleDefaults?.detectSnapshotFromSlug ?? DEFAULT_CONFIG.lifecycleDefaults.detectSnapshotFromSlug,
     },
     search: {
-      alwaysIncludeDomainNote: raw?.search?.alwaysIncludeDomainNote ?? DEFAULT_CONFIG.search.alwaysIncludeDomainNote,
+      alwaysIncludeDomainNote: typeof raw?.search?.alwaysIncludeDomainNote === 'boolean'
+        ? raw.search.alwaysIncludeDomainNote
+        : DEFAULT_CONFIG.search.alwaysIncludeDomainNote,
     },
   };
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -77,13 +77,13 @@ const server = new McpServer({
 
 // ---- knowledge-store ----
 
-const NOTE_KINDS = ['personalization', 'reference', 'decision', 'procedure', 'resource', 'observation'] as const;
+const NOTE_KINDS = ['personalization', 'reference', 'decision', 'procedure', 'resource', 'observation', 'domain'] as const;
 const LIFECYCLES = ['living', 'snapshot', 'append-only'] as const;
 
 const storeSchema = z.object({
   title: z.string().describe('Note title — concise, descriptive'),
   content: z.string().describe('Note content — the knowledge to store'),
-  kind: z.enum(NOTE_KINDS).describe('Note kind: personalization, reference, decision, procedure, resource, observation'),
+  kind: z.enum(NOTE_KINDS).describe('Note kind: personalization, reference, decision, procedure, resource, observation, domain'),
   status: z.enum(['fleeting', 'permanent', 'archived']).optional().describe('Override default status (defaults based on kind)'),
   lifecycle: z.enum(LIFECYCLES).optional().describe('Note lifecycle: living (mutable), snapshot (immutable), append-only (additive only). Defaults per kind.'),
   tags: z.array(z.string()).optional().describe('Tags for categorization'),
@@ -224,7 +224,7 @@ server.registerTool(
         tags: args.tags,
         limit: args.limit,
         model: args.model,
-      }, getOrCreateRepo(), queryEmbedding);
+      }, getOrCreateRepo(), queryEmbedding, config);
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-search failed', {

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -782,6 +782,23 @@ export class NoteRepository {
     }));
   }
 
+  getDomainNote(project: string): NoteMetadata | null {
+    const pattern = `%"project:${project}"%`;
+    const stmt = this.db.prepare(`
+      SELECT * FROM notes
+      WHERE kind = 'domain' AND tags LIKE ? AND status != 'archived'
+      LIMIT 1
+    `);
+
+    const row = stmt.get(pattern) as NoteMetadata | undefined;
+    if (!row) return null;
+    return {
+      ...row,
+      kind: row.kind as NoteKind,
+      tags: JSON.parse(row.tags as unknown as string),
+    };
+  }
+
   getByStatus(status: NoteStatus, limit: number = 50): NoteMetadata[] {
     const stmt = this.db.prepare(`
       SELECT * FROM notes
@@ -1087,8 +1104,10 @@ export class NoteRepository {
     `).run(now, id);
   }
 
-  rebuildFromFiles(): { indexed: number; errors: number } {
+  rebuildFromFiles(): { indexed: number; errors: number; warnings: string[] } {
     const uniqueIds = new Set<string>();
+    const domainNotes = new Map<string, string>();
+    const warnings: string[] = [];
     let errors = 0;
 
     // Clear existing data
@@ -1142,13 +1161,29 @@ export class NoteRepository {
         this.ftsInsert(id, title, body, tagsJson, context);
         this.syncLinks(id, body);
         uniqueIds.add(id);
+
+        if (kind === 'domain') {
+          const projectTag = tags.find((t: string) => t.startsWith('project:'));
+          if (projectTag) {
+            const project = projectTag.replace('project:', '');
+            if (domainNotes.has(project)) {
+              warnings.push(`Duplicate domain note for project "${project}": ${file} (first: ${domainNotes.get(project)})`);
+            } else {
+              domainNotes.set(project, file);
+            }
+          }
+        }
       } catch (err) {
         logToFile('WARN', 'Failed to index file during rebuild', { file, error: String(err) });
         errors++;
       }
     }
 
-    return { indexed: uniqueIds.size, errors };
+    for (const warning of warnings) {
+      logToFile('WARN', warning);
+    }
+
+    return { indexed: uniqueIds.size, errors, warnings };
   }
 
   private extractWikiLinks(content: string): string[] {

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -787,6 +787,7 @@ export class NoteRepository {
     const stmt = this.db.prepare(`
       SELECT * FROM notes
       WHERE kind = 'domain' AND tags LIKE ? AND status != 'archived'
+      ORDER BY updated_at DESC
       LIMIT 1
     `);
 

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -42,6 +42,7 @@ export const KIND_WORD_GUIDELINES: Record<NoteKind, { target: number; warn: numb
   reference:       { target: 120, warn: 200 },
   observation:     { target: 100, warn: 200 },
   resource:        { target: 50, warn: 100 },
+  domain:          { target: 500, warn: 1000 },
 };
 
 /** Absolute word-count ceiling — warns regardless of kind. */
@@ -244,6 +245,17 @@ export function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConf
     }
   }
 
+  // Domain note constraints: require project, enforce one-per-project
+  if (args.kind === 'domain') {
+    if (!args.project) {
+      return 'Error: Domain notes require a project parameter. A domain note is a project operating manual — it must be scoped to a specific project.';
+    }
+    const existingDomain = repo.getDomainNote(args.project);
+    if (existingDomain) {
+      return `A domain note already exists for project "${args.project}" [${existingDomain.id}]: "${existingDomain.title}". Update the existing note instead of creating a duplicate.`;
+    }
+  }
+
   // Client tag — explicit or auto-detected from content/guidance
   const resolvedClient = args.client || detectClient(args.content, args.guidance);
   if (resolvedClient) {
@@ -321,7 +333,7 @@ export function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConf
   return output;
 }
 
-export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedding?: number[] | null): string {
+export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedding?: number[] | null, config?: AppConfig): string {
   let results = repo.searchHybrid(args.query, queryEmbedding || null, {
     kind: args.kind,
     status: args.status ? toNoteStatus(args.status, 'fleeting') : undefined,
@@ -354,11 +366,35 @@ export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedd
     ? `\n⚠ Unrecognized client "${args.client}". Known clients: opencode, claude-code, cursor, windsurf, zed.\n`
     : '';
 
-  if (results.length === 0) {
+  // Always-include domain note for project-scoped searches
+  let domainNote: NoteMetadata | null = null;
+  if (args.project && config?.search?.alwaysIncludeDomainNote !== false) {
+    domainNote = repo.getDomainNote(args.project);
+    if (domainNote) {
+      const domainId = domainNote.id;
+      results = results.filter(r => r.id !== domainId);
+    }
+  }
+
+  if (results.length === 0 && !domainNote) {
     return 'No matching notes found. Try broader keywords or remove filters.' + clientWarning;
   }
 
-  let output = `Found ${results.length} note(s):\n\n`;
+  const totalCount = results.length + (domainNote ? 1 : 0);
+  let output = `Found ${totalCount} note(s):\n\n`;
+
+  if (domainNote) {
+    output += renderNoteForSearch(domainNote) + '\n';
+    try {
+      repo.recordAccess(domainNote.id);
+    } catch (error) {
+      logToFile('WARN', 'Failed to record access', {
+        noteId: domainNote.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   for (const note of results) {
     output += renderNoteForSearch(note) + '\n';
     try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@
 
 // ============ NOTE KIND ============
 
-export type NoteKind = 'personalization' | 'reference' | 'decision' | 'procedure' | 'resource' | 'observation';
+export type NoteKind = 'personalization' | 'reference' | 'decision' | 'procedure' | 'resource' | 'observation' | 'domain';
 export type NoteStatus = 'fleeting' | 'permanent' | 'archived';
 export type Lifecycle = 'living' | 'snapshot' | 'append-only';
 
@@ -17,6 +17,7 @@ export const KIND_DEFAULT_STATUS: Record<NoteKind, NoteStatus> = {
   procedure: 'fleeting',
   resource: 'permanent',
   observation: 'fleeting',
+  domain: 'permanent',
 };
 
 /** Map kind to its default lifecycle */
@@ -27,6 +28,7 @@ export const KIND_DEFAULT_LIFECYCLE: Record<NoteKind, Lifecycle> = {
   procedure: 'living',
   resource: 'living',
   observation: 'snapshot',
+  domain: 'living',
 };
 
 export const VALID_LIFECYCLES = new Set<string>(['living', 'snapshot', 'append-only']);
@@ -36,6 +38,10 @@ export const VALID_LIFECYCLES = new Set<string>(['living', 'snapshot', 'append-o
 export interface LifecycleDefaults {
   defaultForKind: Record<string, string>;
   detectSnapshotFromSlug: boolean;
+}
+
+export interface SearchConfig {
+  alwaysIncludeDomainNote: boolean;
 }
 
 export interface AppConfig {
@@ -48,6 +54,7 @@ export interface AppConfig {
     autoArchiveFleetingDays: number;
   };
   lifecycleDefaults: LifecycleDefaults;
+  search: SearchConfig;
 }
 
 // NOTE: NoteMetadata and StoreResult are defined in storage/NoteRepository.ts

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -10,6 +10,7 @@ import {
 import type { TestContext } from './harness.js';
 import { renderNoteForAgent, renderNoteForSearch } from '../src/prompts.js';
 import { getPendingMigrations, getMigrationById } from '../src/data-migrations.js';
+import { getConfig } from '../src/config.js';
 import { handleStore, handleSearch, handleMaintain } from '../src/tool-handlers.js';
 import { LifecycleViolationError } from '../src/storage/NoteRepository.js';
 import { clearVersionCheckCache, getLatestVersion, isNewerVersion } from '../src/utils/version-check.js';
@@ -2093,5 +2094,250 @@ describe('MCP Tool: lifecycle field', () => {
     const afterRebuild = ctx.engine.search('rebuild lifecycle test');
     expect(afterRebuild.length).toBeGreaterThan(0);
     expect(afterRebuild[0].lifecycle).toBe('append-only');
+  });
+});
+
+describe('Domain note kind', () => {
+  let ctx: TestContext;
+
+  beforeEach(() => { ctx = createTestHarness(); });
+  afterEach(() => { cleanupTestHarness(ctx); });
+
+  it('should store domain note with permanent status by default', () => {
+    const output = handleStore({
+      title: 'MyApp Domain',
+      content: 'Core domain knowledge for MyApp.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'MyApp domain guide',
+      guidance: 'Read before project-scoped work',
+    }, ctx.engine, null, ctx.config);
+
+    expect(output).toContain('Status: permanent');
+  });
+
+  it('should store domain note with living lifecycle by default', () => {
+    const output = handleStore({
+      title: 'MyApp Domain',
+      content: 'Core domain knowledge for MyApp.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'MyApp domain guide',
+      guidance: 'Read before project-scoped work',
+    }, ctx.engine, null, ctx.config);
+
+    expect(output).toContain('Lifecycle: living');
+  });
+
+  it('should reject domain note without project', () => {
+    const output = handleStore({
+      title: 'Unscoped Domain',
+      content: 'Missing project scope.',
+      kind: 'domain',
+      summary: 'Invalid domain note',
+      guidance: 'Always provide a project',
+    }, ctx.engine, null, ctx.config);
+
+    expect(output).toContain('require a project');
+  });
+
+  it('should reject duplicate domain note for same project', () => {
+    const first = handleStore({
+      title: 'MyApp Domain',
+      content: 'Primary domain note.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'Primary domain guide',
+      guidance: 'Use this note',
+    }, ctx.engine, null, ctx.config);
+
+    const firstId = first.match(/ID: (\d+)/)?.[1];
+    expect(firstId).toBeDefined();
+
+    const second = handleStore({
+      title: 'MyApp Domain Duplicate',
+      content: 'Duplicate domain note.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'Duplicate domain guide',
+      guidance: 'Should be rejected',
+    }, ctx.engine, null, ctx.config);
+
+    expect(second).toContain('already exists for project "myapp"');
+    expect(second).toContain(firstId!);
+  });
+
+  it('should allow domain notes for different projects', () => {
+    const outputA = handleStore({
+      title: 'MyApp Domain',
+      content: 'Domain note for MyApp.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'MyApp domain guide',
+      guidance: 'Use for MyApp work',
+    }, ctx.engine, null, ctx.config);
+
+    const outputB = handleStore({
+      title: 'OtherApp Domain',
+      content: 'Domain note for OtherApp.',
+      kind: 'domain',
+      project: 'otherapp',
+      summary: 'OtherApp domain guide',
+      guidance: 'Use for OtherApp work',
+    }, ctx.engine, null, ctx.config);
+
+    expect(outputA).toContain('Knowledge stored (created)');
+    expect(outputB).toContain('Knowledge stored (created)');
+    expect(ctx.engine.getByKind('domain')).toHaveLength(2);
+  });
+
+  it('should auto-add project tag to domain note', () => {
+    handleStore({
+      title: 'MyApp Domain',
+      content: 'Tagged domain note.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'Tagged domain guide',
+      guidance: 'Check project tags',
+    }, ctx.engine, null, ctx.config);
+
+    const note = ctx.engine.getDomainNote('myapp');
+    expect(note).not.toBeNull();
+    expect(note!.tags).toContain('project:myapp');
+  });
+
+  it('should always-include domain note in project-scoped search', () => {
+    handleStore({
+      title: 'MyApp Domain',
+      content: 'Canonical operating manual for MyApp.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'MyApp operating manual',
+      guidance: 'Read first',
+    }, ctx.engine, null, ctx.config);
+
+    handleStore({
+      title: 'MyApp Query Match',
+      content: 'Contains onboarding keyword for project search.',
+      kind: 'observation',
+      project: 'myapp',
+      summary: 'Project note with keyword',
+      guidance: 'Used for search ordering test',
+    }, ctx.engine, null, ctx.config);
+
+    const config = { ...getConfig(), search: { alwaysIncludeDomainNote: true } };
+    const output = handleSearch({ query: 'onboarding', project: 'myapp' }, ctx.engine, null, config);
+
+    const domainIndex = output.indexOf('MyApp operating manual');
+    const regularIndex = output.indexOf('Project note with keyword');
+    expect(domainIndex).toBeGreaterThan(-1);
+    expect(regularIndex).toBeGreaterThan(-1);
+    expect(domainIndex).toBeLessThan(regularIndex);
+  });
+
+  it('should return domain note even with zero FTS matches', () => {
+    handleStore({
+      title: 'MyApp Domain',
+      content: 'Canonical operating manual for MyApp.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'MyApp operating manual',
+      guidance: 'Read first',
+    }, ctx.engine, null, ctx.config);
+
+    const config = { ...getConfig(), search: { alwaysIncludeDomainNote: true } };
+    const output = handleSearch({ query: 'totally-unrelated-query', project: 'myapp' }, ctx.engine, null, config);
+
+    expect(output).toContain('Found 1 note(s):');
+    expect(output).toContain('MyApp operating manual');
+  });
+
+  it('should not duplicate domain note if it matches search', () => {
+    handleStore({
+      title: 'MyApp Domain',
+      content: 'This domain note documents foobar workflows.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'Foobar domain guide',
+      guidance: 'Read first',
+    }, ctx.engine, null, ctx.config);
+
+    const config = { ...getConfig(), search: { alwaysIncludeDomainNote: true } };
+    const output = handleSearch({ query: 'foobar', project: 'myapp' }, ctx.engine, null, config);
+    const occurrences = output.match(/Foobar domain guide/g) ?? [];
+
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it('should not include domain note without project filter', () => {
+    handleStore({
+      title: 'MyApp Domain',
+      content: 'Canonical operating manual for MyApp.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'MyApp operating manual',
+      guidance: 'Read first',
+    }, ctx.engine, null, ctx.config);
+
+    const config = { ...getConfig(), search: { alwaysIncludeDomainNote: true } };
+    const output = handleSearch({ query: 'totally-unrelated-query' }, ctx.engine, null, config);
+
+    expect(output).toBe('No matching notes found. Try broader keywords or remove filters.');
+  });
+
+  it('should respect alwaysIncludeDomainNote=false config', () => {
+    handleStore({
+      title: 'MyApp Domain',
+      content: 'Canonical operating manual for MyApp.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'MyApp operating manual',
+      guidance: 'Read first',
+    }, ctx.engine, null, ctx.config);
+
+    const config = { ...getConfig(), search: { alwaysIncludeDomainNote: false } };
+    const output = handleSearch({ query: 'totally-unrelated-query', project: 'myapp' }, ctx.engine, null, config);
+
+    expect(output).toBe('No matching notes found. Try broader keywords or remove filters.');
+  });
+
+  it('should not include archived domain note', () => {
+    const storeOutput = handleStore({
+      title: 'MyApp Domain',
+      content: 'Canonical operating manual for MyApp.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'MyApp operating manual',
+      guidance: 'Read first',
+    }, ctx.engine, null, ctx.config);
+
+    const noteId = storeOutput.match(/ID: (\d+)/)?.[1];
+    expect(noteId).toBeDefined();
+    ctx.engine.archive(noteId!);
+
+    const config = { ...getConfig(), search: { alwaysIncludeDomainNote: true } };
+    const output = handleSearch({ query: 'totally-unrelated-query', project: 'myapp' }, ctx.engine, null, config);
+
+    expect(output).toBe('No matching notes found. Try broader keywords or remove filters.');
+  });
+
+  it('should find domain note via getDomainNote()', () => {
+    handleStore({
+      title: 'MyApp Domain',
+      content: 'Canonical operating manual for MyApp.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'MyApp operating manual',
+      guidance: 'Read first',
+    }, ctx.engine, null, ctx.config);
+
+    const note = ctx.engine.getDomainNote('myapp');
+    expect(note).not.toBeNull();
+    expect(note!.title).toBe('MyApp Domain');
+    expect(note!.kind).toBe('domain');
+  });
+
+  it('should return null for missing domain note', () => {
+    expect(ctx.engine.getDomainNote('nonexistent')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Implements #86 — adds a new `domain` note kind that captures project operating manuals (agent role, scope, conventions, boundaries). One per project, always surfaced in project-scoped search results.

- Add `domain` as 7th note kind (default: permanent status, living lifecycle)
- Enforce one-per-project uniqueness at store time
- Require `project` parameter for domain notes
- Always-include domain note in project-scoped search results (prepended before relevance-ranked results, configurable via `search.alwaysIncludeDomainNote`)
- Add `getDomainNote(project)` method to NoteRepository
- Add domain uniqueness validation in `rebuildFromFiles()` with warnings
- 14 new tests (662 total pass, 0 fail)
- Update all docs, skills, agent instructions, config example

## Determinism boundary

| Aspect | Layer | Control |
|--------|-------|---------|
| Storage uniqueness (one domain per project) | Server-side SQL | 🟢 Deterministic |
| Always-include on project-filtered searches | Server-side SQL | 🟢 Deterministic |
| Agent following the domain note's rules | Calling agent | 🔴 Probabilistic (same as AGENTS.md) |

## Ref #93

Closes #86