### PR TITLE
Add knowledge-open MCP tool to launch vault in Obsidian

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -47,5 +47,7 @@ jobs:
           github_action_config.auto_improve: "true"
           github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'
           pr_reviewer.require_ticket_analysis_review: "false"
+          pr_reviewer.require_estimate_effort_to_review: "false"
+          pr_reviewer.enable_review_labels_effort: "false"
           pr_code_suggestions.publish_output_no_suggestions: "false"
           pr_reviewer.publish_output_no_suggestions: "false"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -49,5 +49,6 @@ jobs:
           pr_reviewer.require_ticket_analysis_review: "false"
           pr_reviewer.require_estimate_effort_to_review: "false"
           pr_reviewer.enable_review_labels_effort: "false"
+          pr_reviewer.inline_code_comments: "true"
           pr_code_suggestions.publish_output_no_suggestions: "false"
           pr_reviewer.publish_output_no_suggestions: "false"

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ test-binary
 # Database & vault artifacts
 .index/
 .kb/
+.obsidian/
 *.db
 *.db-journal
 *.db-wal

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -37,6 +37,7 @@ glob = [
 persistent_comment = true
 final_update_message = true
 num_max_findings = 8
+inline_code_comments = true
 require_score_review = true
 require_security_review = true
 require_tests_review = true
@@ -67,6 +68,8 @@ or clearly state the remaining blocking items. Do not keep finding new nits inde
 
 ## Output Format (MANDATORY — follow this structure exactly)
 
+IMPORTANT: Your review comment title MUST be "## PR Review" (not "PR Reviewer Guide").
+
 ### 1. Verdict (first line, bold)
 
 **✅ Approved** or **⚠️ Needs Work (N blockers)**
@@ -85,31 +88,26 @@ One sentence explaining why.
 Grades: A = excellent, B = good (minor gaps), C = adequate, D = significant gaps, F = failing.
 One-line "Notes" per row — not paragraphs.
 
-### 3. Findings (if any)
+### 3. Findings
 
-Group by priority. Use headers + bullet points — NO paragraphs.
+Post each finding as an INLINE CODE COMMENT on the specific line in the PR diff.
+Format per inline comment: 🔴/🟡/⚪ **[Title]** — one-line description.
+Include a minimal code diff if suggesting a fix.
+
+In the summary comment, list findings as a reference:
 
 #### 🔴 Must Fix
-- **[Title]** — `file.ts:N` — one-line description
+- **[Title]** — `file.ts:N`
 
 #### 🟡 Should Fix
-- **[Title]** — `file.ts:N` — one-line description
+- **[Title]** — `file.ts:N`
 
 #### ⚪ Nits (max 2)
-- **[Title]** — `file.ts:N` — one-line description
+- **[Title]** — `file.ts:N`
 
-If suggesting a fix, include a minimal code diff under the bullet.
 If no findings in a tier, omit that header entirely.
 
-### 4. Focus Areas (concise)
-
-Bullet list of 1-3 areas worth a human reviewer's attention. One line each.
-- `src/obsidian.ts` — Platform detection edge cases
-- `tests/obsidian.test.ts` — Test isolation (side effects)
-
-Do NOT write paragraphs here. Headers and line items only.
-
-### 5. Review Log (persists across rounds)
+### 4. Review Log (persists across rounds)
 
 | Round | Commit | Findings | Verdict |
 |-------|--------|----------|---------|

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -40,10 +40,10 @@ num_max_findings = 8
 require_score_review = true
 require_security_review = true
 require_tests_review = true
-require_estimate_effort_to_review = true
+require_estimate_effort_to_review = false
 require_ticket_analysis_review = false
 enable_review_labels_security = true
-enable_review_labels_effort = true
+enable_review_labels_effort = false
 publish_output_no_suggestions = false
 
 extra_instructions = """\
@@ -64,6 +64,61 @@ previous feedback correctly, acknowledge resolution and approve.
 
 CONVERGE TO APPROVAL: After 1-2 rounds of feedback, the review should either approve
 or clearly state the remaining blocking items. Do not keep finding new nits indefinitely.
+
+## Output Format (MANDATORY — follow this structure exactly)
+
+### 1. Verdict (first line, bold)
+
+**✅ Approved** or **⚠️ Needs Work (N blockers)**
+
+One sentence explaining why.
+
+### 2. Quality Scorecard (table, always present)
+
+| Metric | Grade | Notes |
+|--------|-------|-------|
+| **Scope** | A-F | Does the PR do what the issue/description says? Missing pieces? Out-of-scope changes? |
+| **Code Quality** | A-F | Bugs, error handling, type safety, patterns match codebase conventions? |
+| **Testing** | A-F | Test coverage for new code, edge cases, mocks where needed, no side effects in tests? |
+| **Security** | A-F or N/A | Secrets, injection, auth, MCP stdout safety? |
+
+Grades: A = excellent, B = good (minor gaps), C = adequate, D = significant gaps, F = failing.
+One-line "Notes" per row — not paragraphs.
+
+### 3. Findings (if any)
+
+Group by priority. Use headers + bullet points — NO paragraphs.
+
+#### 🔴 Must Fix
+- **[Title]** — `file.ts:N` — one-line description
+
+#### 🟡 Should Fix
+- **[Title]** — `file.ts:N` — one-line description
+
+#### ⚪ Nits (max 2)
+- **[Title]** — `file.ts:N` — one-line description
+
+If suggesting a fix, include a minimal code diff under the bullet.
+If no findings in a tier, omit that header entirely.
+
+### 4. Focus Areas (concise)
+
+Bullet list of 1-3 areas worth a human reviewer's attention. One line each.
+- `src/obsidian.ts` — Platform detection edge cases
+- `tests/obsidian.test.ts` — Test isolation (side effects)
+
+Do NOT write paragraphs here. Headers and line items only.
+
+### 5. Review Log (persists across rounds)
+
+| Round | Commit | Findings | Verdict |
+|-------|--------|----------|---------|
+| 1 | `abc1234` | 3 (1 🔴, 2 🟡) | Needs Work |
+| 2 | `def5678` | 1 new, 2 resolved | Approved |
+
+This log MUST persist and accumulate — never delete previous entries.
+
+---
 
 ## Priority Tiers (exactly ONE per finding)
 
@@ -116,13 +171,13 @@ THEN verify: STRUCTURAL_KINDS (index, log) skip navigation hooks to prevent
      infinite loops. Auto-generated notes cannot be manually created.
 BECAUSE PR #99 introduced navigation hooks — missing guards cause infinite recursion.
 
-R4. DUAL STORAGE CONSISTENCY
+R4. DUAL STORAGE SYNC
 WHEN code modifies note content or metadata
 THEN verify: both filesystem (.md) and SQLite index are updated. Filesystem is
      source of truth — DB is rebuilt from files via rebuildFromFiles().
 BECAUSE split-brain between file and DB causes silent data inconsistency.
 
-R5. CONFIG FILE SAFETY
+R5. CONFIG INTEGRITY
 WHEN code modifies .toml, .yaml, or .json configuration files
 THEN verify: no TOML section shadowing (new [section] captures subsequent keys),
      no type mismatches, all new config keys have sensible defaults in config.ts
@@ -142,35 +197,14 @@ THEN verify: server returns data with annotations (not directives), no auto-modi
      agents to replicate server computation
 BECAUSE ownership policy (#93) — "server computes, agent judges."
 
-## File-Type-Specific Checks
+## Filetype-Specific Checks
 
 TOML files: Verify section scoping, check that keys land in intended section.
 YAML files: Check for hardcoded secrets, overly permissive permissions, unpinned actions.
 Markdown files (.md): This repo treats .md as first-class policy content (AGENTS.md,
      architecture.md). Review for accuracy, consistency with code, and stale references.
 Test files: Verify regression tests for bugfixes, proper cleanup via cleanupTestHarness(),
-     no .skip without justification.
-
-## Output Format
-
-Start with a one-line summary: "**N issues found** across N files" or "**No issues found** across N files."
-
-For each finding, use this format:
-🔴/🟡/⚪ **[Title]** — one-line summary
-File: `path/to/file.ts` line N
-[Explanation with specific variable/function names]
-[If suggesting a fix, include a minimal code diff]
-
-Group findings by priority — all 🔴 first, then 🟡, then ⚪ (max 2 nits).
-If no 🔴 findings: state "No blocking issues. Approve with optional fixes below."
-
-End with a review log section:
-## Review Log
-| Round | Commit | Findings | Status |
-Round 1: [short SHA] — N findings (X 🔴, Y 🟡, Z ⚪)
-Round 2: [short SHA] — N new, M resolved, [remaining blockers or "ready to merge"]
-
-This log must persist and accumulate across rounds — never delete previous entries.
+     no .skip without justification, no real side effects (mock OS interactions).
 """
 
 # ---------------------------------------------------------------------------

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Shared, persistent memory for AI assistants, built on the Zettelkasten method. O
 │   ├── storage/            # NoteRepository — SQLite+FTS5+filesystem
 │   │   ├── IndexBuilder.ts # Auto-generates per-project index notes
 │   │   └── LogAppender.ts  # Auto-appends to per-project log notes
+│   ├── obsidian.ts         # Obsidian detection, vault registry, launch
 │   └── utils/              # Path resolution, wikilink parsing
 ├── skills/                # Skill templates for Claude Code
 │   └── open-zk-kb/        # Copied to ~/.claude/skills/open-zk-kb/ on install
@@ -58,6 +59,9 @@ Shared, persistent memory for AI assistants, built on the Zettelkasten method. O
 | `handleMaintain` | function | `tool-handlers.ts` | knowledge-maintain implementation |
 | `handleIngest` | function | `tool-handlers.ts` | knowledge-ingest implementation |
 | `handleOverview` | function | `tool-handlers.ts` | knowledge-overview implementation |
+| `handleOpen` | function | `tool-handlers.ts` | knowledge-open implementation |
+| `detectObsidian` | function | `obsidian.ts` | Platform-specific Obsidian installation detection |
+| `launchObsidian` | function | `obsidian.ts` | URI scheme or binary spawn to open vault |
 | `NoteMetadata` | interface | `storage/NoteRepository.ts` | Domain model for notes |
 | `NoteKind` | type | `types.ts` | 9 kinds: personalization, reference, decision, procedure, resource, observation, domain, index, log |
 | `NavigationConfig` | interface | `types.ts` | Config shape for navigation: enableProjectIndex, enableProjectLog, overviewLogEntryLimit |
@@ -156,5 +160,5 @@ EVAL=1 bun test tests/eval/eval.test.ts --timeout 120000  # Agent eval suite
 - **Knowledge capture**: Claude Code uses skills (`~/.claude/skills/open-zk-kb/`); other clients use injected `AGENTS.md` instructions. Calling models use `knowledge-store` directly.
 - **Claude Code skill**: Instructions delivered as a skill at `~/.claude/skills/open-zk-kb/`. Template files in `skills/open-zk-kb/`.
 - **Local embeddings**: MiniLM-L6-v2 (~23MB) enabled by default via `@huggingface/transformers`. No API key required. Opt-in to API embeddings via `config.yaml`.
-- **5 MCP tools**: knowledge-store, knowledge-search, knowledge-maintain, knowledge-ingest, knowledge-overview
+- **6 MCP tools**: knowledge-store, knowledge-search, knowledge-maintain, knowledge-ingest, knowledge-overview, knowledge-open
 - **Auto-generated notes**: `index` (per-project catalog, wikilinks grouped by kind) and `log` (per-project append-only event log) are auto-generated on project-scoped events. Agents cannot create them manually.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Supported clients: **OpenCode**, **Claude Code**, **Cursor**, **Windsurf**, **Ze
 
 ## How It Works
 
-Your AI assistant gets five MCP tools:
+Your AI assistant gets six MCP tools:
 
 | Tool | What it does |
 |------|-------------|
@@ -52,6 +52,7 @@ Your AI assistant gets five MCP tools:
 | `knowledge-maintain` | Review, promote, archive, and rebuild notes |
 | `knowledge-ingest` | Extract article content from URLs or HTML into structured markdown |
 | `knowledge-overview` | Get a project overview with auto-generated index and recent log |
+| `knowledge-open` | Open the vault in Obsidian for visual browsing and graph view |
 
 The installer injects instructions that guide the AI to **proactively search** for relevant context before starting work and **store valuable knowledge** as it discovers it. No plugin required — the AI drives everything through tool calls.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ The system employs a hybrid storage strategy to balance portability with perform
 The MCP server provides a reactive interface to the knowledge base:
 
 * **Transport**: Uses `@modelcontextprotocol/sdk` with stdio transport.
-* **Tools**: Registers five core tools: `knowledge-store`, `knowledge-search`, `knowledge-maintain`, `knowledge-ingest`, and `knowledge-overview`.
+* **Tools**: Registers six core tools: `knowledge-store`, `knowledge-search`, `knowledge-maintain`, `knowledge-ingest`, `knowledge-overview`, and `knowledge-open`.
 * **Initialization**: Uses a lazy singleton pattern where the `NoteRepository` is initialized only upon the first tool call.
 * **Embeddings**: Generated locally by default via `@huggingface/transformers` (WASM backend, no native deps).
     * **Model**: `Xenova/all-MiniLM-L6-v2` (quantized q8, ~23MB).

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,7 +35,7 @@ For rapid iteration:
 ```
 src/
 ├── mcp-server.ts       # MCP server entry point (stdio transport)
-├── tool-handlers.ts    # Shared logic for all 5 tools
+├── tool-handlers.ts    # Shared logic for all 6 tools
 ├── storage/
 │   ├── NoteRepository.ts  # Core CRUD, FTS5, link tracking
 │   ├── IndexBuilder.ts    # Auto-generates per-project index notes

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -67,6 +67,7 @@ bun run setup install --client opencode
    - `knowledge-maintain` -- stats, review, promote, archive, rebuild
    - `knowledge-ingest` -- extract article content from URLs or HTML
    - `knowledge-overview` -- project entry point with auto-generated index and recent log
+   - `knowledge-open` -- open the vault in Obsidian for visual browsing
 
 ## Agent Instructions
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -61,7 +61,7 @@ bun run setup install --client opencode
 1. Restart your editor/client.
 2. Optionally run `bunx open-zk-kb@latest doctor --client <name>` to verify the local install. Add `--fix` to repair safe issues automatically.
 3. Ask your assistant: **"Run `knowledge-maintain stats`"**
-4. You should see vault statistics (0 notes on fresh install). This confirms the 5 tools are available:
+4. You should see vault statistics (0 notes on fresh install). This confirms the 6 tools are available:
    - `knowledge-store` -- save notes to the knowledge base
    - `knowledge-search` -- full-text search across notes
    - `knowledge-maintain` -- stats, review, promote, archive, rebuild

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -8,8 +8,8 @@ TypeScript source for the MCP server (`mcp-server.ts`), with core logic in `tool
 
 ```
 src/
-├── mcp-server.ts          # MCP stdio server — 5 tools via @modelcontextprotocol/sdk
-├── tool-handlers.ts       # Shared: handleStore, handleSearch, handleMaintain, handleIngest, handleOverview
+├── mcp-server.ts          # MCP stdio server — 6 tools via @modelcontextprotocol/sdk
+├── tool-handlers.ts       # Shared: handleStore, handleSearch, handleMaintain, handleIngest, handleOverview, handleOpen
 ├── storage/
 │   ├── NoteRepository.ts  # Core CRUD + FTS5 + link tracking (~1,370 LOC)
 │   ├── IndexBuilder.ts    # Auto-generates per-project index notes
@@ -18,6 +18,7 @@ src/
 │   ├── path.ts             # ~ expansion, XDG path resolution
 │   ├── wikilink.ts         # [[slug|display]] parsing, Obsidian-compatible
 │   └── simhash.ts          # SimHash for near-duplicate detection
+├── obsidian.ts            # Obsidian detection, vault registry, launch
 ├── config.ts              # getConfig(): YAML config with defaults
 ├── embeddings.ts          # Local + API embedding generation, similarity
 ├── data-migrations.ts     # Agent-driven content upgrades (summary/guidance)
@@ -33,7 +34,7 @@ src/
 ```
 Client request → mcp-server.ts
                         ↓
-               tool-handlers.ts (handleStore/Search/Maintain/Ingest/Overview)
+               tool-handlers.ts (handleStore/Search/Maintain/Ingest/Overview/Open)
                         ↓
                NoteRepository.store/search/getStats/...
                     ↓              ↓

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18,7 +18,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { getConfig, getEmbeddingsConfig } from './config.js';
 import { logToFile } from './logger.js';
-import { handleStore, handleSearch, handleMaintain, handleIngest, handleOverview } from './tool-handlers.js';
+import { handleStore, handleSearch, handleMaintain, handleIngest, handleOverview, handleOpen } from './tool-handlers.js';
 import { generateEmbedding, DEFAULT_EMBEDDING_CONFIG } from './embeddings.js';
 import type { EmbeddingConfig } from './embeddings.js';
 import type { NoteKind } from './types.js';
@@ -263,6 +263,36 @@ server.registerTool(
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-overview failed', {
+        error: error instanceof Error ? error.message : String(error),
+      }, config);
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+        isError: true,
+      };
+    }
+  },
+);
+
+// ---- knowledge-open ----
+
+const openSchema = z.object({
+  project: z.string().optional().describe('Open focused on a specific project\'s index note'),
+});
+
+server.registerTool(
+  'knowledge-open',
+  {
+    description: 'Open the knowledge base vault in Obsidian for visual browsing. Detects Obsidian installation and launches it pointed at the vault.',
+    inputSchema: openSchema as unknown as AnySchema,
+  },
+  async (args: z.infer<typeof openSchema>) => {
+    try {
+      const result = handleOpen({
+        project: args.project,
+      }, config, getOrCreateRepo());
+      return { content: [{ type: 'text' as const, text: result }] };
+    } catch (error) {
+      logToFile('ERROR', 'knowledge-open failed', {
         error: error instanceof Error ? error.message : String(error),
       }, config);
       return {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -289,7 +289,7 @@ server.registerTool(
     try {
       const result = handleOpen({
         project: args.project,
-      }, config, getOrCreateRepo());
+      }, config, args.project ? getOrCreateRepo() : repo ?? undefined);
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-open failed', {

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -191,8 +191,12 @@ function openUri(uri: string, platform?: string): string | null {
   }
 
   try {
+    const abort = new AbortController();
+    const timeout = setTimeout(() => abort.abort(), 5000);
     const proc = Bun.spawn([cmd, ...args], {
       stdio: ['ignore', 'ignore', 'ignore'],
+      signal: abort.signal,
+      onExit: () => clearTimeout(timeout),
     });
     proc.unref();
     return null;

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -17,21 +17,27 @@ export interface ObsidianDetection {
 // ---- Platform detection ----
 
 function detectMacOS(): ObsidianDetection {
-  const appPath = '/Applications/Obsidian.app';
-  if (fs.existsSync(appPath)) {
-    return { installed: true, binaryPath: `${appPath}/Contents/MacOS/Obsidian` };
+  const candidates = [
+    '/Applications/Obsidian.app',
+    path.join(process.env.HOME || '', 'Applications/Obsidian.app'),
+  ];
+  for (const appPath of candidates) {
+    if (appPath && fs.existsSync(appPath)) {
+      return { installed: true, binaryPath: `${appPath}/Contents/MacOS/Obsidian` };
+    }
   }
   return { installed: false };
 }
 
 function detectLinux(): ObsidianDetection {
+  const home = process.env.HOME || '';
   const candidates = [
     '/usr/bin/obsidian',
     '/snap/bin/obsidian',
-    path.join(process.env.HOME || '', '.local/bin/obsidian'),
+    ...(home ? [path.join(home, '.local/bin/obsidian')] : []),
   ];
   for (const p of candidates) {
-    if (p && fs.existsSync(p)) {
+    if (fs.existsSync(p)) {
       return { installed: true, binaryPath: p };
     }
   }
@@ -68,9 +74,9 @@ export function getRegistryPath(platform?: string): string | null {
   const home = process.env.HOME || '';
   switch (plat) {
     case 'darwin':
-      return path.join(home, 'Library', 'Application Support', 'obsidian', 'obsidian.json');
+      return home ? path.join(home, 'Library', 'Application Support', 'obsidian', 'obsidian.json') : null;
     case 'linux':
-      return path.join(home, '.config', 'obsidian', 'obsidian.json');
+      return home ? path.join(home, '.config', 'obsidian', 'obsidian.json') : null;
     case 'win32': {
       const appData = process.env.APPDATA || '';
       return appData ? path.join(appData, 'obsidian', 'obsidian.json') : null;
@@ -119,8 +125,8 @@ export function isVaultRegistered(vaultPath: string, platform?: string): boolean
 
 // ---- Launch ----
 
-/** Open a URI using the platform's default handler (open/xdg-open/start). */
-function openUri(uri: string, platform?: string): void {
+/** Open a URI using the platform's default handler. Returns error message or null. */
+function openUri(uri: string, platform?: string): string | null {
   const plat = platform || process.platform;
 
   let cmd: string;
@@ -145,20 +151,21 @@ function openUri(uri: string, platform?: string): void {
       stdio: ['ignore', 'ignore', 'ignore'],
     });
     proc.unref();
+    return null;
   } catch (error) {
-    logToFile('WARN', 'Failed to open URI', {
-      uri, error: error instanceof Error ? error.message : String(error),
-    });
+    const msg = error instanceof Error ? error.message : String(error);
+    logToFile('WARN', 'Failed to open URI', { uri, error: msg });
+    return msg;
   }
 }
 
-/** Launch Obsidian: URI scheme (vault=) if registered, binary spawn otherwise. */
+/** Launch Obsidian: URI scheme (vault=) if registered, binary spawn otherwise. Returns error or null. */
 export function launchObsidian(
   detection: ObsidianDetection,
   vaultPath: string,
   filePath?: string,
   platform?: string,
-): void {
+): string | null {
   const plat = platform || process.platform;
   const vaultName = path.basename(vaultPath);
   const registered = isVaultRegistered(vaultPath, plat);
@@ -172,7 +179,7 @@ export function launchObsidian(
       uri = `obsidian://open?vault=${encodeURIComponent(vaultName)}`;
     }
     logToFile('DEBUG', 'Launching Obsidian via URI scheme', { uri });
-    openUri(uri, plat);
+    return openUri(uri, plat);
   } else if (detection.binaryPath) {
     logToFile('DEBUG', 'Launching Obsidian binary', {
       binary: detection.binaryPath,
@@ -193,9 +200,9 @@ export function launchObsidian(
         proc.unref();
       }
     } catch (error) {
-      logToFile('WARN', 'Failed to spawn Obsidian', {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      const msg = error instanceof Error ? error.message : String(error);
+      logToFile('WARN', 'Failed to spawn Obsidian', { error: msg });
+      return msg;
     }
 
     // Best-effort: navigate to file after vault has time to register
@@ -203,7 +210,9 @@ export function launchObsidian(
       const fileUri = `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(filePath)}`;
       setTimeout(() => openUri(fileUri, plat), 2000);
     }
+    return null;
   }
+  return null;
 }
 
 // ---- Message formatting ----

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -124,6 +124,43 @@ export function isVaultRegistered(vaultPath: string, platform?: string): boolean
   }
 }
 
+/** Register a vault in Obsidian's obsidian.json so URI scheme works. */
+export function registerVault(vaultPath: string, platform?: string): boolean {
+  const registryPath = getRegistryPath(platform);
+  if (!registryPath) return false;
+
+  try {
+    // Obsidian requires .obsidian/ to recognize a directory as a vault
+    const obsidianDir = path.join(vaultPath, '.obsidian');
+    if (!fs.existsSync(obsidianDir)) {
+      fs.mkdirSync(obsidianDir, { recursive: true });
+    }
+
+    let data: Record<string, unknown>;
+    if (fs.existsSync(registryPath)) {
+      data = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+      if (!data.vaults || typeof data.vaults !== 'object') {
+        data.vaults = {};
+      }
+    } else {
+      fs.mkdirSync(path.dirname(registryPath), { recursive: true });
+      data = { vaults: {} };
+    }
+
+    const vaults = data.vaults as Record<string, { path: string; ts: number }>;
+    const id = Array.from({ length: 16 }, () => Math.floor(Math.random() * 16).toString(16)).join('');
+    vaults[id] = { path: path.resolve(vaultPath), ts: Date.now() };
+    fs.writeFileSync(registryPath, JSON.stringify(data, null, 2));
+    logToFile('INFO', 'Registered vault in Obsidian', { vaultPath, registryPath });
+    return true;
+  } catch (error) {
+    logToFile('WARN', 'Failed to register vault in Obsidian', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
 // ---- Launch ----
 
 /** Open a URI using the platform's default handler. Returns error message or null. */
@@ -171,49 +208,19 @@ export function launchObsidian(
   const vaultName = path.basename(vaultPath);
   const registered = isVaultRegistered(vaultPath, plat);
 
-  if (registered) {
-    // vault= opens by name; file= navigates within it (path= is for files only, not directories)
-    let uri: string;
-    if (filePath) {
-      uri = `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(filePath)}`;
-    } else {
-      uri = `obsidian://open?vault=${encodeURIComponent(vaultName)}`;
-    }
-    logToFile('DEBUG', 'Launching Obsidian via URI scheme', { uri });
-    return openUri(uri, plat);
-  } else if (detection.binaryPath) {
-    logToFile('DEBUG', 'Launching Obsidian binary', {
-      binary: detection.binaryPath,
-      vault: vaultPath,
-    });
-    try {
-      // macOS: `open -a Obsidian /path` reliably opens directory as vault
-      // Other platforms: spawn binary directly
-      if (plat === 'darwin') {
-        const proc = Bun.spawn(['open', '-a', 'Obsidian', vaultPath], {
-          stdio: ['ignore', 'ignore', 'ignore'],
-        });
-        proc.unref();
-      } else {
-        const proc = Bun.spawn([detection.binaryPath, vaultPath], {
-          stdio: ['ignore', 'ignore', 'ignore'],
-        });
-        proc.unref();
-      }
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      logToFile('WARN', 'Failed to spawn Obsidian', { error: msg });
-      return msg;
-    }
-
-    // Best-effort: navigate to file after vault has time to register
-    if (filePath) {
-      const fileUri = `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(filePath)}`;
-      setTimeout(() => openUri(fileUri, plat), 2000);
-    }
-    return null;
+  if (!registered) {
+    registerVault(vaultPath, plat);
   }
-  return null;
+
+  // vault= opens by name; file= navigates within it (path= is for files only, not directories)
+  let uri: string;
+  if (filePath) {
+    uri = `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(filePath)}`;
+  } else {
+    uri = `obsidian://open?vault=${encodeURIComponent(vaultName)}`;
+  }
+  logToFile('DEBUG', 'Launching Obsidian via URI scheme', { uri });
+  return openUri(uri, plat);
 }
 
 // ---- Message formatting ----

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -17,12 +17,13 @@ export interface ObsidianDetection {
 // ---- Platform detection ----
 
 function detectMacOS(): ObsidianDetection {
+  const home = process.env.HOME || '';
   const candidates = [
     '/Applications/Obsidian.app',
-    path.join(process.env.HOME || '', 'Applications/Obsidian.app'),
+    ...(home ? [path.join(home, 'Applications/Obsidian.app')] : []),
   ];
   for (const appPath of candidates) {
-    if (appPath && fs.existsSync(appPath)) {
+    if (fs.existsSync(appPath)) {
       return { installed: true, binaryPath: `${appPath}/Contents/MacOS/Obsidian` };
     }
   }

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -190,9 +190,9 @@ function openUri(uri: string, platform?: string): string | null {
       break;
   }
 
+  const abort = new AbortController();
+  const timeout = setTimeout(() => abort.abort(), 5000);
   try {
-    const abort = new AbortController();
-    const timeout = setTimeout(() => abort.abort(), 5000);
     const proc = Bun.spawn([cmd, ...args], {
       stdio: ['ignore', 'ignore', 'ignore'],
       signal: abort.signal,
@@ -201,6 +201,7 @@ function openUri(uri: string, platform?: string): string | null {
     proc.unref();
     return null;
   } catch (error) {
+    clearTimeout(timeout);
     const msg = error instanceof Error ? error.message : String(error);
     logToFile('WARN', 'Failed to open URI', { uri, error: msg });
     return msg;

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -152,9 +152,11 @@ export function registerVault(vaultPath: string, platform?: string): boolean {
     const alreadyRegistered = Object.values(vaults).some(v => v.path === resolvedPath);
     if (alreadyRegistered) return true;
 
-    const id = Array.from({ length: 16 }, () => Math.floor(Math.random() * 16).toString(16)).join('');
+    const id = crypto.randomUUID().replace(/-/g, '').slice(0, 16);
     vaults[id] = { path: resolvedPath, ts: Date.now() };
-    fs.writeFileSync(registryPath, JSON.stringify(data, null, 2));
+    const tmpPath = registryPath + '.tmp';
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2));
+    fs.renameSync(tmpPath, registryPath);
     logToFile('INFO', 'Registered vault in Obsidian', { vaultPath, registryPath });
     return true;
   } catch (error) {
@@ -180,7 +182,7 @@ function openUri(uri: string, platform?: string): string | null {
       break;
     case 'win32':
       cmd = 'cmd';
-      args = ['/c', 'start', '', uri];
+      args = ['/c', 'start', '', `"${uri}"`];
       break;
     default: // linux and others
       cmd = 'xdg-open';
@@ -213,7 +215,9 @@ export function launchObsidian(
   const registered = isVaultRegistered(vaultPath, plat);
 
   if (!registered) {
-    registerVault(vaultPath, plat);
+    if (!registerVault(vaultPath, plat)) {
+      return 'Failed to register vault in Obsidian — check vault path and permissions';
+    }
   }
 
   // vault= opens by name; file= navigates within it (path= is for files only, not directories)

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -148,8 +148,12 @@ export function registerVault(vaultPath: string, platform?: string): boolean {
     }
 
     const vaults = data.vaults as Record<string, { path: string; ts: number }>;
+    const resolvedPath = path.resolve(vaultPath);
+    const alreadyRegistered = Object.values(vaults).some(v => v.path === resolvedPath);
+    if (alreadyRegistered) return true;
+
     const id = Array.from({ length: 16 }, () => Math.floor(Math.random() * 16).toString(16)).join('');
-    vaults[id] = { path: path.resolve(vaultPath), ts: Date.now() };
+    vaults[id] = { path: resolvedPath, ts: Date.now() };
     fs.writeFileSync(registryPath, JSON.stringify(data, null, 2));
     logToFile('INFO', 'Registered vault in Obsidian', { vaultPath, registryPath });
     return true;

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -1,0 +1,230 @@
+// obsidian.ts - Obsidian detection, vault registry, and launch utilities
+// Isolates OS interaction from the pure handler functions in tool-handlers.ts.
+// This is the first OS interaction (process spawn) from the MCP layer.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { logToFile } from './logger.js';
+import { contractPath } from './utils/path.js';
+
+// ---- Types ----
+
+export interface ObsidianDetection {
+  installed: boolean;
+  binaryPath?: string;
+}
+
+// ---- Platform detection ----
+
+function detectMacOS(): ObsidianDetection {
+  const appPath = '/Applications/Obsidian.app';
+  if (fs.existsSync(appPath)) {
+    return { installed: true, binaryPath: `${appPath}/Contents/MacOS/Obsidian` };
+  }
+  return { installed: false };
+}
+
+function detectLinux(): ObsidianDetection {
+  const candidates = [
+    '/usr/bin/obsidian',
+    '/snap/bin/obsidian',
+    path.join(process.env.HOME || '', '.local/bin/obsidian'),
+  ];
+  for (const p of candidates) {
+    if (p && fs.existsSync(p)) {
+      return { installed: true, binaryPath: p };
+    }
+  }
+  return { installed: false };
+}
+
+function detectWindows(): ObsidianDetection {
+  const localAppData = process.env.LOCALAPPDATA || '';
+  if (localAppData) {
+    const exePath = path.join(localAppData, 'Obsidian', 'Obsidian.exe');
+    if (fs.existsSync(exePath)) {
+      return { installed: true, binaryPath: exePath };
+    }
+  }
+  return { installed: false };
+}
+
+/** Detect whether Obsidian is installed on this system. */
+export function detectObsidian(platform?: string): ObsidianDetection {
+  const plat = platform || process.platform;
+  switch (plat) {
+    case 'darwin': return detectMacOS();
+    case 'linux': return detectLinux();
+    case 'win32': return detectWindows();
+    default: return { installed: false };
+  }
+}
+
+// ---- Vault registry ----
+
+/** Platform-specific path to Obsidian's vault registry (obsidian.json). */
+export function getRegistryPath(platform?: string): string | null {
+  const plat = platform || process.platform;
+  const home = process.env.HOME || '';
+  switch (plat) {
+    case 'darwin':
+      return path.join(home, 'Library', 'Application Support', 'obsidian', 'obsidian.json');
+    case 'linux':
+      return path.join(home, '.config', 'obsidian', 'obsidian.json');
+    case 'win32': {
+      const appData = process.env.APPDATA || '';
+      return appData ? path.join(appData, 'obsidian', 'obsidian.json') : null;
+    }
+    default:
+      return null;
+  }
+}
+
+/** Check if a vault path is already registered in Obsidian's vault list. */
+export function isVaultRegistered(vaultPath: string, platform?: string): boolean {
+  const registryPath = getRegistryPath(platform);
+  if (!registryPath || !fs.existsSync(registryPath)) return false;
+
+  try {
+    const data = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+    const vaults = data?.vaults;
+    if (!vaults || typeof vaults !== 'object') return false;
+
+    // Normalize paths for comparison
+    let normalizedVault: string;
+    try {
+      normalizedVault = fs.realpathSync(vaultPath);
+    } catch {
+      normalizedVault = path.resolve(vaultPath);
+    }
+
+    for (const entry of Object.values(vaults)) {
+      const entryPath = (entry as { path?: string })?.path;
+      if (!entryPath) continue;
+      try {
+        if (fs.realpathSync(entryPath) === normalizedVault) return true;
+      } catch {
+        if (path.resolve(entryPath) === normalizedVault) return true;
+      }
+    }
+    return false;
+  } catch (error) {
+    logToFile('DEBUG', 'Failed to read Obsidian vault registry', {
+      registryPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
+// ---- Launch ----
+
+/** Open a URI using the platform's default handler (open/xdg-open/start). */
+function openUri(uri: string, platform?: string): void {
+  const plat = platform || process.platform;
+
+  let cmd: string;
+  let args: string[];
+  switch (plat) {
+    case 'darwin':
+      cmd = 'open';
+      args = [uri];
+      break;
+    case 'win32':
+      cmd = 'cmd';
+      args = ['/c', 'start', '', uri];
+      break;
+    default: // linux and others
+      cmd = 'xdg-open';
+      args = [uri];
+      break;
+  }
+
+  try {
+    const proc = Bun.spawn([cmd, ...args], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    proc.unref();
+  } catch (error) {
+    logToFile('WARN', 'Failed to open URI', {
+      uri, error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/** Launch Obsidian: URI scheme (vault=) if registered, binary spawn otherwise. */
+export function launchObsidian(
+  detection: ObsidianDetection,
+  vaultPath: string,
+  filePath?: string,
+  platform?: string,
+): void {
+  const plat = platform || process.platform;
+  const vaultName = path.basename(vaultPath);
+  const registered = isVaultRegistered(vaultPath, plat);
+
+  if (registered) {
+    // vault= opens by name; file= navigates within it (path= is for files only, not directories)
+    let uri: string;
+    if (filePath) {
+      uri = `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(filePath)}`;
+    } else {
+      uri = `obsidian://open?vault=${encodeURIComponent(vaultName)}`;
+    }
+    logToFile('DEBUG', 'Launching Obsidian via URI scheme', { uri });
+    openUri(uri, plat);
+  } else if (detection.binaryPath) {
+    logToFile('DEBUG', 'Launching Obsidian binary', {
+      binary: detection.binaryPath,
+      vault: vaultPath,
+    });
+    try {
+      // macOS: `open -a Obsidian /path` reliably opens directory as vault
+      // Other platforms: spawn binary directly
+      if (plat === 'darwin') {
+        const proc = Bun.spawn(['open', '-a', 'Obsidian', vaultPath], {
+          stdio: ['ignore', 'ignore', 'ignore'],
+        });
+        proc.unref();
+      } else {
+        const proc = Bun.spawn([detection.binaryPath, vaultPath], {
+          stdio: ['ignore', 'ignore', 'ignore'],
+        });
+        proc.unref();
+      }
+    } catch (error) {
+      logToFile('WARN', 'Failed to spawn Obsidian', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    // Best-effort: navigate to file after vault has time to register
+    if (filePath) {
+      const fileUri = `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(filePath)}`;
+      setTimeout(() => openUri(fileUri, plat), 2000);
+    }
+  }
+}
+
+// ---- Message formatting ----
+
+export function formatNotInstalledMessage(vaultPath: string): string {
+  const displayPath = contractPath(vaultPath);
+  return `Obsidian is not installed on this system.
+
+To browse your knowledge base visually:
+1. Download Obsidian from https://obsidian.md/download
+2. Open Obsidian and select "Open folder as vault"
+3. Point it to: ${displayPath}
+
+Your vault is already Obsidian-compatible — wikilinks, frontmatter, and markdown all work out of the box.`;
+}
+
+export function formatSuccessMessage(vaultPath: string, project?: string): string {
+  const displayPath = contractPath(vaultPath);
+  let msg = `Opened vault in Obsidian (${displayPath})`;
+  if (project) {
+    msg += `\nFocused on project: ${project}`;
+  }
+  return msg;
+}

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -1160,14 +1160,19 @@ export function handleOpen(args: OpenArgs, config: AppConfig, repo?: NoteReposit
   }
 
   let filePath: string | undefined;
+  let resolvedProject: string | undefined;
   if (args.project && repo) {
     const indexNote = repo.getIndexNote(args.project);
     if (indexNote?.path) {
       const noteFilename = path.basename(indexNote.path);
       filePath = noteFilename.replace(/\.md$/, '');
+      resolvedProject = args.project;
     }
   }
 
-  launchObsidian(detection, vaultPath, filePath);
-  return formatSuccessMessage(vaultPath, args.project);
+  const error = launchObsidian(detection, vaultPath, filePath);
+  if (error) {
+    return `Failed to launch Obsidian: ${error}`;
+  }
+  return formatSuccessMessage(vaultPath, resolvedProject);
 }

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -1,5 +1,7 @@
 // tool-handlers.ts - Handler functions for knowledge tools
 
+import * as fs from 'fs';
+import * as path from 'path';
 import type { NoteKind, NoteStatus, Lifecycle, AppConfig } from './types.js';
 import { KIND_DEFAULT_STATUS, KIND_DEFAULT_LIFECYCLE, VALID_LIFECYCLES } from './types.js';
 
@@ -33,6 +35,8 @@ import { classifyModel, MODEL_HINT } from './model-capabilities.js';
 import { extractFromUrl, extractArticle } from './url-extractor.js';
 import type { ExtractionResult } from './url-extractor.js';
 import { splitSections, extractLinks, countWords } from './content-splitter.js';
+import { detectObsidian, launchObsidian, formatNotInstalledMessage, formatSuccessMessage } from './obsidian.js';
+import { contractPath } from './utils/path.js';
 
 // ---- Constants ----
 
@@ -127,6 +131,10 @@ export interface OverviewArgs {
   project: string;
   logEntries?: number;
   model?: string;
+}
+
+export interface OpenArgs {
+  project?: string;
 }
 
 function sanitizeMetadata(value: string): string {
@@ -1136,4 +1144,30 @@ export function handleOverview(args: OverviewArgs, repo: NoteRepository, config?
   }
 
   return output;
+}
+
+export function handleOpen(args: OpenArgs, config: AppConfig, repo?: NoteRepository): string {
+  const vaultPath = config.vault;
+
+  if (!fs.existsSync(vaultPath)) {
+    return `Vault directory does not exist yet: ${contractPath(vaultPath)}\nStore a note first to create the vault, then try again.`;
+  }
+
+  const detection = detectObsidian();
+
+  if (!detection.installed) {
+    return formatNotInstalledMessage(vaultPath);
+  }
+
+  let filePath: string | undefined;
+  if (args.project && repo) {
+    const indexNote = repo.getIndexNote(args.project);
+    if (indexNote?.path) {
+      const noteFilename = path.basename(indexNote.path);
+      filePath = noteFilename.replace(/\.md$/, '');
+    }
+  }
+
+  launchObsidian(detection, vaultPath, filePath);
+  return formatSuccessMessage(vaultPath, args.project);
 }

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -135,6 +135,8 @@ export interface OverviewArgs {
 
 export interface OpenArgs {
   project?: string;
+  _detectObsidian?: typeof detectObsidian;
+  _launchObsidian?: typeof launchObsidian;
 }
 
 function sanitizeMetadata(value: string): string {
@@ -1153,7 +1155,8 @@ export function handleOpen(args: OpenArgs, config: AppConfig, repo?: NoteReposit
     return `Vault directory does not exist yet: ${contractPath(vaultPath)}\nStore a note first to create the vault, then try again.`;
   }
 
-  const detection = detectObsidian();
+  const detect = args._detectObsidian || detectObsidian;
+  const detection = detect();
 
   if (!detection.installed) {
     return formatNotInstalledMessage(vaultPath);
@@ -1170,7 +1173,8 @@ export function handleOpen(args: OpenArgs, config: AppConfig, repo?: NoteReposit
     }
   }
 
-  const error = launchObsidian(detection, vaultPath, filePath);
+  const launch = args._launchObsidian || launchObsidian;
+  const error = launch(detection, vaultPath, filePath);
   if (error) {
     return `Failed to launch Obsidian: ${error}`;
   }

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -19,6 +19,7 @@ tests/
 ├── config.test.ts         # Config loading: defaults, YAML override, partial, malformed
 ├── schema.test.ts         # DB schema: fresh creation, migrations v1→v6
 ├── setup.test.ts          # CLI installer: install, uninstall, skill + instruction injection
+├── obsidian.test.ts       # Obsidian detection, vault registry, launch, handleOpen
 ├── knowledge-quality-assessment.test.ts  # Content quality scoring
 ├── injection-quality-test.ts  # Agent self-search quality via MCP
 ├── docker/                # Docker-based integration tests

--- a/tests/docker/mcp-protocol-test.ts
+++ b/tests/docker/mcp-protocol-test.ts
@@ -30,12 +30,13 @@ async function run() {
   try {
     const tools = await client.listTools();
     const toolNames = tools.tools.map(t => t.name);
-    check('lists all 5 tools', toolNames.length === 5);
+    check('lists all 6 tools', toolNames.length === 6);
     check('has knowledge-store', toolNames.includes('knowledge-store'));
     check('has knowledge-search', toolNames.includes('knowledge-search'));
     check('has knowledge-maintain', toolNames.includes('knowledge-maintain'));
     check('has knowledge-ingest', toolNames.includes('knowledge-ingest'));
     check('has knowledge-overview', toolNames.includes('knowledge-overview'));
+    check('has knowledge-open', toolNames.includes('knowledge-open'));
   } catch (err) {
     check('list tools', false, String(err));
   }

--- a/tests/obsidian.test.ts
+++ b/tests/obsidian.test.ts
@@ -6,6 +6,7 @@ import {
   detectObsidian,
   getRegistryPath,
   isVaultRegistered,
+  registerVault,
   formatNotInstalledMessage,
   formatSuccessMessage,
 } from '../src/obsidian.js';
@@ -164,6 +165,104 @@ describe('Vault Registry', () => {
     const result = getRegistryPath('linux');
     process.env.HOME = origHome;
     expect(result).toBeNull();
+  });
+});
+
+describe('Vault Registration', () => {
+  let tempDir: string;
+  let origHome: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'obsidian-register-'));
+    origHome = process.env.HOME || '';
+    process.env.HOME = tempDir;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should create .obsidian/ directory in the vault', () => {
+    const vaultDir = path.join(tempDir, 'my-vault');
+    fs.mkdirSync(vaultDir);
+
+    registerVault(vaultDir, 'linux');
+
+    expect(fs.existsSync(path.join(vaultDir, '.obsidian'))).toBe(true);
+  });
+
+  it('should add vault entry to obsidian.json', () => {
+    const vaultDir = path.join(tempDir, 'my-vault');
+    fs.mkdirSync(vaultDir);
+
+    registerVault(vaultDir, 'linux');
+
+    const registryPath = path.join(tempDir, '.config', 'obsidian', 'obsidian.json');
+    expect(fs.existsSync(registryPath)).toBe(true);
+
+    const data = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+    const entries = Object.values(data.vaults) as Array<{ path: string }>;
+    expect(entries.some(e => e.path === path.resolve(vaultDir))).toBe(true);
+  });
+
+  it('should make isVaultRegistered return true after registration', () => {
+    const vaultDir = path.join(tempDir, 'my-vault');
+    fs.mkdirSync(vaultDir);
+
+    expect(isVaultRegistered(vaultDir, 'linux')).toBe(false);
+    registerVault(vaultDir, 'linux');
+    expect(isVaultRegistered(vaultDir, 'linux')).toBe(true);
+  });
+
+  it('should preserve existing vaults in registry', () => {
+    const configDir = path.join(tempDir, '.config', 'obsidian');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'obsidian.json'), JSON.stringify({
+      vaults: { 'existing-id': { path: '/existing/vault', ts: 1000 } },
+      frame: 'hidden',
+    }));
+
+    const vaultDir = path.join(tempDir, 'new-vault');
+    fs.mkdirSync(vaultDir);
+    registerVault(vaultDir, 'linux');
+
+    const data = JSON.parse(fs.readFileSync(path.join(configDir, 'obsidian.json'), 'utf-8'));
+    expect(data.vaults['existing-id'].path).toBe('/existing/vault');
+    expect(data.frame).toBe('hidden');
+    const entries = Object.values(data.vaults) as Array<{ path: string }>;
+    expect(entries.length).toBe(2);
+  });
+
+  it('should not duplicate if vault already registered', () => {
+    const vaultDir = path.join(tempDir, 'my-vault');
+    fs.mkdirSync(vaultDir);
+
+    registerVault(vaultDir, 'linux');
+    const registryPath = path.join(tempDir, '.config', 'obsidian', 'obsidian.json');
+    const beforeCount = Object.keys(JSON.parse(fs.readFileSync(registryPath, 'utf-8')).vaults).length;
+
+    registerVault(vaultDir, 'linux');
+    const afterCount = Object.keys(JSON.parse(fs.readFileSync(registryPath, 'utf-8')).vaults).length;
+
+    expect(afterCount).toBe(beforeCount);
+  });
+
+  it('should create registry from scratch if obsidian.json does not exist', () => {
+    const vaultDir = path.join(tempDir, 'my-vault');
+    fs.mkdirSync(vaultDir);
+
+    const result = registerVault(vaultDir, 'linux');
+
+    expect(result).toBe(true);
+    const registryPath = path.join(tempDir, '.config', 'obsidian', 'obsidian.json');
+    expect(fs.existsSync(registryPath)).toBe(true);
+  });
+
+  it('should return false when HOME is unavailable', () => {
+    process.env.HOME = '';
+    const result = registerVault('/some/vault', 'linux');
+    expect(result).toBe(false);
   });
 });
 

--- a/tests/obsidian.test.ts
+++ b/tests/obsidian.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  detectObsidian,
+  getRegistryPath,
+  isVaultRegistered,
+  formatNotInstalledMessage,
+  formatSuccessMessage,
+} from '../src/obsidian.js';
+import { handleOpen } from '../src/tool-handlers.js';
+import { createTestHarness, cleanupTestHarness } from './harness.js';
+import type { TestContext } from './harness.js';
+import { getConfig } from '../src/config.js';
+
+describe('Obsidian Detection', () => {
+  it('should return installed=false for unknown platforms', () => {
+    const result = detectObsidian('freebsd');
+    expect(result.installed).toBe(false);
+    expect(result.binaryPath).toBeUndefined();
+  });
+
+  it('should detect macOS Obsidian when app exists', () => {
+    const result = detectObsidian('darwin');
+    if (fs.existsSync('/Applications/Obsidian.app')) {
+      expect(result.installed).toBe(true);
+      expect(result.binaryPath).toBe('/Applications/Obsidian.app/Contents/MacOS/Obsidian');
+    } else {
+      expect(result.installed).toBe(false);
+    }
+  });
+
+  it('should use platform parameter over process.platform', () => {
+    const result = detectObsidian('win32');
+    if (!process.env.LOCALAPPDATA || !fs.existsSync(path.join(process.env.LOCALAPPDATA, 'Obsidian', 'Obsidian.exe'))) {
+      expect(result.installed).toBe(false);
+    }
+  });
+});
+
+describe('Vault Registry', () => {
+  it('should return correct registry path per platform', () => {
+    const macPath = getRegistryPath('darwin');
+    expect(macPath).toContain('Library/Application Support/obsidian/obsidian.json');
+
+    const linuxPath = getRegistryPath('linux');
+    expect(linuxPath).toContain('.config/obsidian/obsidian.json');
+
+    const unknownPath = getRegistryPath('freebsd');
+    expect(unknownPath).toBeNull();
+  });
+
+  it('should return null for win32 without APPDATA', () => {
+    const origAppData = process.env.APPDATA;
+    delete process.env.APPDATA;
+    const result = getRegistryPath('win32');
+    if (origAppData) process.env.APPDATA = origAppData;
+    expect(result).toBeNull();
+  });
+
+  it('should return false when registry file does not exist', () => {
+    const result = isVaultRegistered('/nonexistent/vault', 'freebsd');
+    expect(result).toBe(false);
+  });
+
+  it('should detect registered vault from obsidian.json', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'obsidian-reg-'));
+    const vaultDir = path.join(tempDir, 'test-vault');
+    fs.mkdirSync(vaultDir);
+
+    const registryDir = path.join(tempDir, 'obsidian-config');
+    fs.mkdirSync(registryDir, { recursive: true });
+    const registryFile = path.join(registryDir, 'obsidian.json');
+    fs.writeFileSync(registryFile, JSON.stringify({
+      vaults: {
+        'abc123': { path: vaultDir, ts: Date.now() },
+      },
+    }));
+
+    const origHome = process.env.HOME;
+    process.env.HOME = tempDir;
+    const origGetRegistryPath = getRegistryPath;
+
+    const registered = isVaultRegistered(vaultDir, 'linux');
+
+    process.env.HOME = origHome;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+
+    if (fs.existsSync(path.join(tempDir, '.config', 'obsidian', 'obsidian.json'))) {
+      expect(registered).toBe(true);
+    }
+  });
+
+  it('should return false for unregistered vault', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'obsidian-unreg-'));
+    const vaultDir = path.join(tempDir, 'my-vault');
+    fs.mkdirSync(vaultDir);
+
+    const configDir = path.join(tempDir, '.config', 'obsidian');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'obsidian.json'), JSON.stringify({
+      vaults: {
+        'xyz789': { path: '/some/other/vault' },
+      },
+    }));
+
+    const origHome = process.env.HOME;
+    process.env.HOME = tempDir;
+    const result = isVaultRegistered(vaultDir, 'linux');
+    process.env.HOME = origHome;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+
+    expect(result).toBe(false);
+  });
+
+  it('should handle malformed registry gracefully', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'obsidian-bad-'));
+    const configDir = path.join(tempDir, '.config', 'obsidian');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'obsidian.json'), 'not valid json');
+
+    const origHome = process.env.HOME;
+    process.env.HOME = tempDir;
+    const result = isVaultRegistered('/any/vault', 'linux');
+    process.env.HOME = origHome;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+
+    expect(result).toBe(false);
+  });
+
+  it('should handle registry with no vaults key', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'obsidian-novaults-'));
+    const configDir = path.join(tempDir, '.config', 'obsidian');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'obsidian.json'), JSON.stringify({ version: '1.0' }));
+
+    const origHome = process.env.HOME;
+    process.env.HOME = tempDir;
+    const result = isVaultRegistered('/any/vault', 'linux');
+    process.env.HOME = origHome;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('Message Formatting', () => {
+  it('should format not-installed message with vault path', () => {
+    const msg = formatNotInstalledMessage('/home/user/.local/share/open-zk-kb');
+    expect(msg).toContain('Obsidian is not installed');
+    expect(msg).toContain('https://obsidian.md/download');
+    expect(msg).toContain('Open folder as vault');
+    expect(msg).toContain('wikilinks, frontmatter, and markdown');
+  });
+
+  it('should contract home path in not-installed message', () => {
+    const home = process.env.HOME || os.homedir();
+    const msg = formatNotInstalledMessage(path.join(home, '.local/share/open-zk-kb'));
+    expect(msg).toContain('~/.local/share/open-zk-kb');
+  });
+
+  it('should format success message without project', () => {
+    const msg = formatSuccessMessage('/home/user/.local/share/open-zk-kb');
+    expect(msg).toContain('Opened vault in Obsidian');
+    expect(msg).not.toContain('Focused on project');
+  });
+
+  it('should format success message with project', () => {
+    const msg = formatSuccessMessage('/home/user/.local/share/open-zk-kb', 'conductor');
+    expect(msg).toContain('Opened vault in Obsidian');
+    expect(msg).toContain('Focused on project: conductor');
+  });
+});
+
+describe('handleOpen', () => {
+  let ctx: TestContext;
+
+  beforeEach(() => { ctx = createTestHarness(); });
+  afterEach(() => { cleanupTestHarness(ctx); });
+
+  it('should return error when vault does not exist', () => {
+    const config = { ...ctx.config, vault: '/nonexistent/vault/path' };
+    const result = handleOpen({}, config);
+    expect(result).toContain('Vault directory does not exist');
+    expect(result).toContain('Store a note first');
+  });
+
+  it('should return not-installed message when Obsidian is missing', () => {
+    const result = handleOpen({}, ctx.config);
+
+    if (!detectObsidian().installed) {
+      expect(result).toContain('Obsidian is not installed');
+      expect(result).toContain('https://obsidian.md/download');
+    } else {
+      expect(result).toContain('Opened vault in Obsidian');
+    }
+  });
+
+  it('should handle project parameter with index note', () => {
+    ctx.engine.store('Test content', {
+      title: 'Test Note',
+      kind: 'reference',
+      status: 'permanent',
+      tags: ['project:myapp'],
+      summary: 'A test note',
+      guidance: 'Test guidance',
+    });
+
+    const result = handleOpen({ project: 'myapp' }, ctx.config, ctx.engine);
+
+    if (detectObsidian().installed) {
+      expect(result).toContain('Focused on project: myapp');
+    } else {
+      expect(result).toContain('Obsidian is not installed');
+    }
+  });
+
+  it('should work without repo when no project specified', () => {
+    const result = handleOpen({}, ctx.config);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/obsidian.test.ts
+++ b/tests/obsidian.test.ts
@@ -197,29 +197,35 @@ describe('Message Formatting', () => {
 
 describe('handleOpen', () => {
   let ctx: TestContext;
+  const noObsidian = () => ({ installed: false as const });
+  const fakeObsidian = () => ({ installed: true as const, binaryPath: '/fake/obsidian' });
+  const noopLaunch = () => null;
 
   beforeEach(() => { ctx = createTestHarness(); });
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should return error when vault does not exist', () => {
     const config = { ...ctx.config, vault: '/nonexistent/vault/path' };
-    const result = handleOpen({}, config);
+    const result = handleOpen({ _detectObsidian: noObsidian }, config);
     expect(result).toContain('Vault directory does not exist');
     expect(result).toContain('Store a note first');
   });
 
   it('should return not-installed message when Obsidian is missing', () => {
-    const result = handleOpen({}, ctx.config);
-
-    if (!detectObsidian().installed) {
-      expect(result).toContain('Obsidian is not installed');
-      expect(result).toContain('https://obsidian.md/download');
-    } else {
-      expect(result).toContain('Opened vault in Obsidian');
-    }
+    const result = handleOpen({ _detectObsidian: noObsidian }, ctx.config);
+    expect(result).toContain('Obsidian is not installed');
+    expect(result).toContain('https://obsidian.md/download');
   });
 
-  it('should handle project parameter with index note', () => {
+  it('should return success when Obsidian is installed', () => {
+    const result = handleOpen({
+      _detectObsidian: fakeObsidian,
+      _launchObsidian: noopLaunch,
+    }, ctx.config);
+    expect(result).toContain('Opened vault in Obsidian');
+  });
+
+  it('should include project focus when index note exists', () => {
     handleStore({
       title: 'Test Note',
       content: 'Test content for project',
@@ -229,27 +235,35 @@ describe('handleOpen', () => {
       project: 'myapp',
     }, ctx.engine, null, ctx.config);
 
-    const result = handleOpen({ project: 'myapp' }, ctx.config, ctx.engine);
-
-    if (detectObsidian().installed) {
-      expect(result).toContain('Focused on project: myapp');
-    } else {
-      expect(result).toContain('Obsidian is not installed');
-    }
+    const result = handleOpen({
+      project: 'myapp',
+      _detectObsidian: fakeObsidian,
+      _launchObsidian: noopLaunch,
+    }, ctx.config, ctx.engine);
+    expect(result).toContain('Focused on project: myapp');
   });
 
   it('should not claim project focus when no index note exists', () => {
-    const result = handleOpen({ project: 'nonexistent' }, ctx.config, ctx.engine);
+    const result = handleOpen({
+      project: 'nonexistent',
+      _detectObsidian: fakeObsidian,
+      _launchObsidian: noopLaunch,
+    }, ctx.config, ctx.engine);
+    expect(result).not.toContain('Focused on project');
+  });
 
-    if (!detectObsidian().installed) {
-      expect(result).toContain('Obsidian is not installed');
-    } else {
-      expect(result).not.toContain('Focused on project');
-    }
+  it('should report launch failure', () => {
+    const failLaunch = () => 'spawn failed';
+    const result = handleOpen({
+      _detectObsidian: fakeObsidian,
+      _launchObsidian: failLaunch,
+    }, ctx.config);
+    expect(result).toContain('Failed to launch Obsidian');
+    expect(result).toContain('spawn failed');
   });
 
   it('should work without repo when no project specified', () => {
-    const result = handleOpen({}, ctx.config);
+    const result = handleOpen({ _detectObsidian: noObsidian }, ctx.config);
     expect(typeof result).toBe('string');
     expect(result.length).toBeGreaterThan(0);
   });

--- a/tests/obsidian.test.ts
+++ b/tests/obsidian.test.ts
@@ -10,9 +10,9 @@ import {
   formatSuccessMessage,
 } from '../src/obsidian.js';
 import { handleOpen } from '../src/tool-handlers.js';
+import { handleStore } from '../src/tool-handlers.js';
 import { createTestHarness, cleanupTestHarness } from './harness.js';
 import type { TestContext } from './harness.js';
-import { getConfig } from '../src/config.js';
 
 describe('Obsidian Detection', () => {
   it('should return installed=false for unknown platforms', () => {
@@ -69,10 +69,9 @@ describe('Vault Registry', () => {
     const vaultDir = path.join(tempDir, 'test-vault');
     fs.mkdirSync(vaultDir);
 
-    const registryDir = path.join(tempDir, 'obsidian-config');
-    fs.mkdirSync(registryDir, { recursive: true });
-    const registryFile = path.join(registryDir, 'obsidian.json');
-    fs.writeFileSync(registryFile, JSON.stringify({
+    const configDir = path.join(tempDir, '.config', 'obsidian');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'obsidian.json'), JSON.stringify({
       vaults: {
         'abc123': { path: vaultDir, ts: Date.now() },
       },
@@ -80,15 +79,13 @@ describe('Vault Registry', () => {
 
     const origHome = process.env.HOME;
     process.env.HOME = tempDir;
-    const origGetRegistryPath = getRegistryPath;
 
-    const registered = isVaultRegistered(vaultDir, 'linux');
-
-    process.env.HOME = origHome;
-    fs.rmSync(tempDir, { recursive: true, force: true });
-
-    if (fs.existsSync(path.join(tempDir, '.config', 'obsidian', 'obsidian.json'))) {
+    try {
+      const registered = isVaultRegistered(vaultDir, 'linux');
       expect(registered).toBe(true);
+    } finally {
+      process.env.HOME = origHome;
+      fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
 
@@ -107,11 +104,14 @@ describe('Vault Registry', () => {
 
     const origHome = process.env.HOME;
     process.env.HOME = tempDir;
-    const result = isVaultRegistered(vaultDir, 'linux');
-    process.env.HOME = origHome;
-    fs.rmSync(tempDir, { recursive: true, force: true });
 
-    expect(result).toBe(false);
+    try {
+      const result = isVaultRegistered(vaultDir, 'linux');
+      expect(result).toBe(false);
+    } finally {
+      process.env.HOME = origHome;
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('should handle malformed registry gracefully', () => {
@@ -122,11 +122,14 @@ describe('Vault Registry', () => {
 
     const origHome = process.env.HOME;
     process.env.HOME = tempDir;
-    const result = isVaultRegistered('/any/vault', 'linux');
-    process.env.HOME = origHome;
-    fs.rmSync(tempDir, { recursive: true, force: true });
 
-    expect(result).toBe(false);
+    try {
+      const result = isVaultRegistered('/any/vault', 'linux');
+      expect(result).toBe(false);
+    } finally {
+      process.env.HOME = origHome;
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('should handle registry with no vaults key', () => {
@@ -137,11 +140,30 @@ describe('Vault Registry', () => {
 
     const origHome = process.env.HOME;
     process.env.HOME = tempDir;
-    const result = isVaultRegistered('/any/vault', 'linux');
-    process.env.HOME = origHome;
-    fs.rmSync(tempDir, { recursive: true, force: true });
 
-    expect(result).toBe(false);
+    try {
+      const result = isVaultRegistered('/any/vault', 'linux');
+      expect(result).toBe(false);
+    } finally {
+      process.env.HOME = origHome;
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should return null for macOS registry when HOME is empty', () => {
+    const origHome = process.env.HOME;
+    process.env.HOME = '';
+    const result = getRegistryPath('darwin');
+    process.env.HOME = origHome;
+    expect(result).toBeNull();
+  });
+
+  it('should return null for linux registry when HOME is empty', () => {
+    const origHome = process.env.HOME;
+    process.env.HOME = '';
+    const result = getRegistryPath('linux');
+    process.env.HOME = origHome;
+    expect(result).toBeNull();
   });
 });
 
@@ -198,14 +220,14 @@ describe('handleOpen', () => {
   });
 
   it('should handle project parameter with index note', () => {
-    ctx.engine.store('Test content', {
+    handleStore({
       title: 'Test Note',
+      content: 'Test content for project',
       kind: 'reference',
-      status: 'permanent',
-      tags: ['project:myapp'],
       summary: 'A test note',
       guidance: 'Test guidance',
-    });
+      project: 'myapp',
+    }, ctx.engine, null, ctx.config);
 
     const result = handleOpen({ project: 'myapp' }, ctx.config, ctx.engine);
 
@@ -213,6 +235,16 @@ describe('handleOpen', () => {
       expect(result).toContain('Focused on project: myapp');
     } else {
       expect(result).toContain('Obsidian is not installed');
+    }
+  });
+
+  it('should not claim project focus when no index note exists', () => {
+    const result = handleOpen({ project: 'nonexistent' }, ctx.config, ctx.engine);
+
+    if (!detectObsidian().installed) {
+      expect(result).toContain('Obsidian is not installed');
+    } else {
+      expect(result).not.toContain('Focused on project');
     }
   });
 


### PR DESCRIPTION
## Summary

Implements #92. Adds a `knowledge-open` MCP tool that opens the KB vault in Obsidian for visual browsing.

- **New `src/obsidian.ts`** — platform detection (macOS/Linux/Windows), Obsidian vault registry check, URI scheme launch for registered vaults, `open -a` fallback for unregistered
- **`handleOpen()` handler** — vault existence check, project index note lookup via repo, not-installed fallback with download link
- **18 new tests** covering detection, registry parsing, message formatting, and handler edge cases
- **Docs updated** — 5→6 tools across 7 documentation files

## Design

Follows the architecture from #92 — OS interaction isolated in `obsidian.ts`, handler in `tool-handlers.ts`, registered in `mcp-server.ts`.

### Launch priority
1. **URI scheme** (`obsidian://open?vault=`) — if vault is registered in Obsidian's `obsidian.json`
2. **Binary spawn** (`open -a Obsidian /path` on macOS) — if vault is not yet registered (auto-registers on first open)
3. **Not installed** — returns download link and manual instructions

### Key decisions
- Uses `vault=` parameter (not `path=`) for URI scheme — `path=` is for files only, not directories
- macOS unregistered launch uses `open -a Obsidian` instead of direct binary spawn for reliable directory-as-vault handling
- `--project` parameter resolves to the project's index note filename via `repo.getIndexNote()`
- Vault existence checked before any launch attempt

## Verification

- ✅ Build clean (`tsc`)
- ✅ 705 tests pass, 0 fail (18 new)
- ✅ LSP diagnostics: 0 errors across all 27 src files
- ✅ Manually tested on macOS with both registered and unregistered vault scenarios

Closes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Open your knowledge vault in Obsidian (with optional project navigation) and automatic cross‑platform Obsidian detection and launch feedback

* **Documentation**
  * Updated guides, architecture, and README to reflect the expanded toolset (now 6 tools)

* **Tests**
  * Added test coverage for Obsidian detection, registry, launch flow, and the open handler

* **Chores**
  * Ignore Obsidian vault markers in repository and updated PR review workflow/configuration settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->