### PR TITLE
Harden migrate-layout with health checks and full nav coverage

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -42,8 +42,9 @@ jobs:
           # Model + review config lives in .pr_agent.toml (repo root)
           # Only secrets and action-level config set here
           # Phase 0 cost reduction (2026-04-28): /improve disabled on auto-run.
-          # /review still runs on every push event (anti-onion-peeling prompt
-          # constrains it to "only flag newly introduced issues" per .pr_agent.toml).
+          # /review runs on opened/reopened/ready_for_review only — synchronize is
+          # excluded via pr_actions in .pr_agent.toml so push events no longer
+          # auto-trigger /review. Re-run manually via `/review -i` PR comment.
           # User can manually invoke /improve via PR comment when wanted.
           # Rationale: agent-architecture/04-references/cost-analysis-by-tier.md
           github_action_config.auto_review: "true"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -41,6 +41,11 @@ jobs:
           OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
           # Model + review config lives in .pr_agent.toml (repo root)
           # Only secrets and action-level config set here
+          # Phase 0 cost reduction (2026-04-28): /improve disabled on auto-run.
+          # /review still runs on every push event (anti-onion-peeling prompt
+          # constrains it to "only flag newly introduced issues" per .pr_agent.toml).
+          # User can manually invoke /improve via PR comment when wanted.
+          # Rationale: agent-architecture/04-references/cost-analysis-by-tier.md
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
-          github_action_config.auto_improve: "true"
+          github_action_config.auto_improve: "false"

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -22,7 +22,9 @@ max_extra_lines_before_dynamic_context = 20
 ignore_pr_title = ["^\\[Auto\\]", "^dependabot", "^renovate"]
 
 [github_action_config]
-pr_actions = ["opened", "reopened", "ready_for_review", "synchronize"]
+# `synchronize` omitted: Action variant can't pass `-i` to auto_review.
+# For incremental re-review on push, post `/review -i` as a PR comment.
+pr_actions = ["opened", "reopened", "ready_for_review"]
 
 [ignore]
 glob = [

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -3,8 +3,12 @@
 # Model config also set via workflow env vars (TOML is read from base branch only)
 
 [config]
-model = "openrouter/deepseek/deepseek-v4-pro"
-fallback_models = ["openrouter/moonshotai/kimi-k2.6"]
+# Phase 0 swap rationale: agent-architecture/04-references/openzkkb-pr-review-current-state.md
+model = "openrouter/moonshotai/kimi-k2.6"
+fallback_models = [
+    "openrouter/anthropic/claude-sonnet-4.6",
+    "openrouter/z-ai/glm-5.1",
+]
 custom_model_max_tokens = 128000
 ai_timeout = 300
 response_language = "en-US"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,30 @@
 
 Shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools — so context persists across sessions and clients. TypeScript/Bun, SQLite FTS5, Markdown files with YAML frontmatter. Entry point: `mcp-server.ts` (MCP stdio).
 
+## Commands
+
+```bash
+bun run build              # Compile TS → dist/ (REQUIRED after every change)
+bun test                   # Run all tests
+bun test --watch           # Watch mode
+bun test --coverage        # Coverage report
+bun run lint               # ESLint check
+bun run lint:fix           # Auto-fix lint
+rm -rf dist/ && bun run build  # Clean rebuild
+EVAL=1 bun test tests/eval/eval.test.ts --timeout 120000  # Agent eval suite
+```
+
+## Testing
+
+> Six-areas template per <https://github.blog/ai-and-ml/github-copilot/how-to-write-a-great-agents-md-lessons-from-over-2500-repositories/>
+
+- **Framework**: `bun:test` with custom harness (`tests/harness.ts`) and fixtures
+- **Run all**: `bun test`; pre-commit also runs `bun run typecheck`
+- **Coverage**: `bun test --coverage`
+- **Eval suite**: `EVAL=1 bun test tests/eval/eval.test.ts --timeout 120000` (agent-quality regression tests)
+- **CI**: `.github/workflows/ci.yml` runs Bun build + lint + test + coverage on every PR
+- **Conventions**: tests use `createTestHarness()` / `cleanupTestHarness()`; never use `.skip` without justification; mock OS-level interactions, never real side effects
+
 ## Structure
 
 ```
@@ -109,17 +133,33 @@ For any new feature, ask in order:
 3. Requires runtime state MCP can't access? → **Plugin** owns it (calls MCP tools)
 4. Guides agent behavior across sessions? → **Behavioral guidance** owns it
 
-## Anti-Patterns (This Project)
+## Boundaries
 
-1. **NEVER** use `console.log()`, `console.warn()`, `console.error()` in server code
-   - **USE** `logToFile()` from `src/logger.ts` — MCP stdio requires clean stdout
-   - Exception: `src/setup.ts` and `scripts/` CLI commands (user-facing output is OK)
-2. **NEVER** skip rebuild after source changes — `dist/` is what actually runs
-3. **NEVER** use FTS5 triggers — manually managed for TEXT primary key reliability
-4. **NEVER** call `removeVault` without `confirm: true` — irreversible deletion
-5. **NEVER** auto-modify stored content beyond what the caller explicitly requested — server surfaces data, agent decides actions
-6. **NEVER** return directives in tool responses ("you should X") — return data with annotations, let the agent judge (target-state: existing handler output is being migrated, see [#93 violations](https://github.com/mrosnerr/open-zk-kb/issues/93))
-7. **NEVER** add skill instructions that ask the agent to compute what the server already computes — if the server has the data, surface it in the response
+> Three-tier format follows: <https://github.blog/ai-and-ml/github-copilot/how-to-write-a-great-agents-md-lessons-from-over-2500-repositories/>
+
+### ✅ Always
+- Run `bun run build` after every source change — `dist/` is what actually runs
+- Run `bun test` and `bun run typecheck` before committing
+- Use `logToFile()` from `src/logger.ts` for any logging in server code (`src/`)
+- Use parameterized SQL queries (handle `SQLITE_BUSY` with retries)
+- Surface computed data with annotations (similarity, dedup, staleness) — server returns data, agent decides
+
+### ⚠️ Ask first
+- Schema migrations (PRAGMA `user_version`-based; see `src/schema.ts`)
+- Adding new MCP capability advertisements (server capability negotiation)
+- Adding dependencies to `package.json`
+- Renaming top-level directories or changing the dual-storage layout
+
+### 🚫 Never
+- Use `console.log()`, `console.warn()`, `console.error()` in `src/` — MCP stdio requires clean stdout. Use `logToFile()`. (Exception: `src/setup.ts` and `scripts/` CLI commands.)
+- Skip the rebuild after source changes — `dist/` is what actually runs
+- Use FTS5 triggers — manually managed for TEXT primary key reliability
+- Call `removeVault` without `confirm: true` — irreversible deletion
+- Auto-modify stored content beyond what the caller explicitly requested — server surfaces data, agent decides actions
+- Return directives in tool responses ("you should X") — return data with annotations, let the agent judge ([#93 violations](https://github.com/mrosnerr/open-zk-kb/issues/93))
+- Add skill instructions that ask the agent to compute what the server already computes
+- Commit secrets (`.env`, credentials, API keys, tokens)
+- Suppress TypeScript errors with `as any`, `@ts-ignore`, `@ts-expect-error`
 
 ## Conventions
 
@@ -137,19 +177,6 @@ For any new feature, ask in order:
 - **Server surfaces, agent acts**: Every computed insight (similarity, dedup, staleness) appears in the tool response. The agent decides what to do with it.
 - **Hints, not directives**: Server responses include computed metrics (word count, similarity score, staleness days). Never phrased as recommendations.
 - **Behavioral guidance is advisory**: Instructions are "a request, not a guarantee" ([Anthropic](https://docs.anthropic.com/en/docs/claude-code/features-overview)). Deterministic enforcement requires hooks/plugins.
-
-## Commands
-
-```bash
-bun run build              # Compile TS → dist/ (REQUIRED after every change)
-bun test                   # Run all tests
-bun test --watch           # Watch mode
-bun test --coverage        # Coverage report
-bun run lint               # ESLint check
-bun run lint:fix           # Auto-fix lint
-rm -rf dist/ && bun run build  # Clean rebuild
-EVAL=1 bun test tests/eval/eval.test.ts --timeout 120000  # Agent eval suite
-```
 
 ## Notes
 

--- a/src/storage/IndexBuilder.ts
+++ b/src/storage/IndexBuilder.ts
@@ -47,6 +47,24 @@ function formatDateTime(date: Date = new Date()): string {
   return date.toISOString().replace('T', ' ').substring(0, 16);
 }
 
+function groupNotesByKind(notes: NoteMetadata[]): Map<string, NoteMetadata[]> {
+  const byKind = new Map<string, NoteMetadata[]>();
+  for (const note of notes) {
+    const kind = note.kind || 'observation';
+    const bucket = byKind.get(kind);
+    if (bucket) {
+      bucket.push(note);
+    } else {
+      byKind.set(kind, [note]);
+    }
+  }
+  return byKind;
+}
+
+function getSectionHeader(kind: string): string {
+  return SECTION_HEADERS[kind] || kind.charAt(0).toUpperCase() + kind.slice(1);
+}
+
 export function buildIndexContent(
   project: string,
   notes: NoteMetadata[],
@@ -60,26 +78,25 @@ export function buildIndexContent(
   lines.push(`# ${projectName} Index (${notes.length} notes)`);
   lines.push('');
 
-  const byKind = new Map<string, NoteMetadata[]>();
-  for (const note of notes) {
-    const kind = note.kind || 'observation';
-    const bucket = byKind.get(kind);
-    if (bucket) {
-      bucket.push(note);
-    } else {
-      byKind.set(kind, [note]);
-    }
-  }
+  const byKind = groupNotesByKind(notes);
 
   for (const kind of INDEX_SECTION_ORDER) {
     const kindNotes = byKind.get(kind);
     if (!kindNotes || kindNotes.length === 0) continue;
 
-    const header = SECTION_HEADERS[kind] || kind;
+    const header = getSectionHeader(kind);
     const count = kindNotes.length;
     const dirName = KIND_DIR_MAP[kind] || `${kind}s`;
 
-    // Split to sub-MOC: project exceeds threshold AND kind has 5+ notes
+    if (kind !== 'domain') {
+      subMocs.push({
+        kind,
+        dirName,
+        content: buildKindSubMocContent(project, kind, header, kindNotes),
+      });
+    }
+
+    // Split threshold controls preview-vs-inline rendering in parent index.
     if (shouldSplit && kind !== 'domain' && count >= 5) {
       const subMocPath = `projects/${project}/${dirName}/index`;
       const previewCount = splitConfig.previewCount;
@@ -96,11 +113,6 @@ export function buildIndexContent(
       }
       lines.push('');
 
-      subMocs.push({
-        kind,
-        dirName,
-        content: buildKindSubMocContent(project, kind, header, kindNotes),
-      });
       continue;
     }
 
@@ -119,7 +131,15 @@ export function buildIndexContent(
 
   for (const [kind, kindNotes] of byKind) {
     if (INDEX_SECTION_ORDER.includes(kind)) continue;
-    const header = kind.charAt(0).toUpperCase() + kind.slice(1);
+    const header = getSectionHeader(kind);
+    const dirName = KIND_DIR_MAP[kind] || `${kind}s`;
+
+    subMocs.push({
+      kind,
+      dirName,
+      content: buildKindSubMocContent(project, kind, header, kindNotes),
+    });
+
     lines.push(`## ${header} (${kindNotes.length})`);
     for (const note of kindNotes) {
       renderNoteInIndex(lines, note, kind);
@@ -197,7 +217,7 @@ export function buildGlobalIndexContent(
   }
 
   if (preferencesCount > 0) {
-    lines.push(`## Preferences — ${preferencesCount} notes`);
+    lines.push(`## [[preferences/index|Preferences]] — ${preferencesCount} notes`);
     lines.push('');
   }
 
@@ -223,22 +243,13 @@ export function buildGeneralIndexContent(notes: NoteMetadata[]): string {
   lines.push('# General Knowledge');
   lines.push('');
 
-  const byKind = new Map<string, NoteMetadata[]>();
-  for (const note of notes) {
-    const kind = note.kind || 'observation';
-    const bucket = byKind.get(kind);
-    if (bucket) {
-      bucket.push(note);
-    } else {
-      byKind.set(kind, [note]);
-    }
-  }
+  const byKind = groupNotesByKind(notes);
 
   for (const kind of INDEX_SECTION_ORDER) {
     const kindNotes = byKind.get(kind);
     if (!kindNotes || kindNotes.length === 0) continue;
 
-    const header = SECTION_HEADERS[kind] || kind;
+    const header = getSectionHeader(kind);
     lines.push(`## ${header} (${kindNotes.length})`);
     for (const note of kindNotes) {
       const link = formatNoteLink(note);
@@ -248,6 +259,47 @@ export function buildGeneralIndexContent(notes: NoteMetadata[]): string {
     lines.push('');
   }
 
+  lines.push('---');
+  lines.push(`Last rebuilt: ${formatDateTime()}`);
+
+  return lines.join('\n');
+}
+
+export function buildPreferencesIndexContent(notes: NoteMetadata[]): string {
+  const lines: string[] = [];
+
+  lines.push(`# Preferences (${notes.length} notes)`);
+  lines.push('');
+
+  for (const note of notes) {
+    const link = formatNoteLink(note);
+    const summary = note.summary || '';
+    lines.push(`- ${link}${summary ? ` — ${summary}` : ''}`);
+  }
+
+  lines.push('');
+  lines.push(`↑ [[index|Back to Knowledge Base]]`);
+  lines.push('');
+  lines.push('---');
+  lines.push(`Last rebuilt: ${formatDateTime()}`);
+
+  return lines.join('\n');
+}
+
+export function buildGeneralKindIndexContent(kind: string, notes: NoteMetadata[]): string {
+  const header = getSectionHeader(kind);
+  const lines: string[] = [];
+
+  lines.push(`# General — ${header} (${notes.length})`);
+  lines.push('');
+
+  for (const note of notes) {
+    renderNoteInIndex(lines, note, kind);
+  }
+
+  lines.push('');
+  lines.push('↑ [[general/index|Back to General]]');
+  lines.push('');
   lines.push('---');
   lines.push(`Last rebuilt: ${formatDateTime()}`);
 

--- a/src/storage/IndexBuilder.ts
+++ b/src/storage/IndexBuilder.ts
@@ -278,7 +278,7 @@ export function buildPreferencesIndexContent(notes: NoteMetadata[]): string {
   }
 
   lines.push('');
-  lines.push(`↑ [[index|Back to Knowledge Base]]`);
+  lines.push('↑ [Back to Knowledge Base](../index.md)');
   lines.push('');
   lines.push('---');
   lines.push(`Last rebuilt: ${formatDateTime()}`);

--- a/src/storage/LogAppender.ts
+++ b/src/storage/LogAppender.ts
@@ -19,9 +19,9 @@ export function appendToLogContent(existingContent: string, entry: string): stri
   return `${existingContent.trimEnd()}\n${entry}`;
 }
 
-export function buildGlobalLogEntry(project: string, event: string, date: Date = new Date()): string {
+export function buildGlobalLogEntry(project: string | null, event: string, date: Date = new Date()): string {
   const sanitized = event.replace(/[\r\n]+/g, ' ').trim();
-  return `- **${formatDate(date)}** — [${project}] ${sanitized}`;
+  return `- **${formatDate(date)}** — [${project ?? 'system'}] ${sanitized}`;
 }
 
 export function buildInitialGlobalLogContent(entry: string): string {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -110,6 +110,35 @@ function filterFalsePositiveBrokenLinks(broken: BrokenLink[], vaultPath: string 
   });
 }
 
+function removeEmptyDirsRecursive(dir: string, isRoot: boolean): number {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  let removed = 0;
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (isRoot && entry.name.startsWith('.')) continue;
+    removed += removeEmptyDirsRecursive(path.join(dir, entry.name), false);
+  }
+
+  if (!isRoot) {
+    try {
+      if (fs.readdirSync(dir).length === 0) {
+        fs.rmdirSync(dir);
+        removed++;
+      }
+    } catch {
+      // Non-fatal: another process may have removed the directory.
+    }
+  }
+
+  return removed;
+}
+
 // ---- Arg types ----
 
 export interface StoreArgs {
@@ -1388,20 +1417,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         }
         output += '- Navigation: index.md, log.md, review.md, and per-directory indexes will be auto-generated\n';
       } else if (!dryRun && moved > 0) {
-        let emptyDirsRemoved = 0;
-        if (config.vault) {
-          const vaultEntries = fs.readdirSync(config.vault, { withFileTypes: true });
-          for (const entry of vaultEntries) {
-            if (!entry.isDirectory()) continue;
-            if (entry.name.startsWith('.')) continue;
-            const dirPath = path.join(config.vault, entry.name);
-            const contents = fs.readdirSync(dirPath);
-            if (contents.length === 0) {
-              fs.rmdirSync(dirPath);
-              emptyDirsRemoved++;
-            }
-          }
-        }
+        const emptyDirsRemoved = config.vault ? removeEmptyDirsRecursive(config.vault, true) : 0;
         if (emptyDirsRemoved > 0) {
           output += `Empty directories removed: ${emptyDirsRemoved}\n`;
         }

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -22,7 +22,7 @@ import { renderNoteForSearch, renderNoteForAgent } from './prompts.js';
 import { buildIndexContent, buildGlobalIndexContent, buildGeneralIndexContent, buildPreferencesIndexContent, buildGeneralKindIndexContent } from './storage/IndexBuilder.js';
 import { buildLogEntry, buildInitialLogContent, appendToLogContent, buildGlobalLogEntry, buildInitialGlobalLogContent } from './storage/LogAppender.js';
 import { buildReviewContent } from './storage/ReviewBuilder.js';
-import { resolveNotePath, extractProjectFromTags as extractProjectTag } from './storage/path-resolver.js';
+import { resolveNotePath, extractProjectFromTags as extractProjectTag, KIND_DIR_MAP } from './storage/path-resolver.js';
 import { getPendingMigrations, getMigrationById } from './data-migrations.js';
 import { logToFile } from './logger.js';
 import { computeSimHash } from './utils/simhash.js';
@@ -461,23 +461,24 @@ function updateGlobalNavigation(
         if (!fs.existsSync(generalDir)) fs.mkdirSync(generalDir, { recursive: true });
         fs.writeFileSync(path.join(generalDir, 'index.md'), content, 'utf-8');
 
-        const notesByDir = new Map<string, NoteMetadata[]>();
+        const notesByKindDir = new Map<string, { kind: string; notes: NoteMetadata[] }>();
         for (const note of unscopedNotes) {
-          const dirName = path.basename(path.dirname(note.path));
-          const bucket = notesByDir.get(dirName);
+          const kind = note.kind;
+          const dirName = KIND_DIR_MAP[kind] || `${kind}s`;
+          const bucket = notesByKindDir.get(dirName);
           if (bucket) {
-            bucket.push(note);
+            bucket.notes.push(note);
           } else {
-            notesByDir.set(dirName, [note]);
+            notesByKindDir.set(dirName, { kind, notes: [note] });
           }
         }
 
-        for (const [dirName, kindNotes] of notesByDir) {
+        for (const [dirName, { kind, notes: kindNotes }] of notesByKindDir) {
           const kindDir = path.join(generalDir, dirName);
           if (!fs.existsSync(kindDir)) fs.mkdirSync(kindDir, { recursive: true });
           fs.writeFileSync(
             path.join(kindDir, 'index.md'),
-            buildGeneralKindIndexContent(kindNotes[0].kind, kindNotes),
+            buildGeneralKindIndexContent(kind, kindNotes),
             'utf-8',
           );
         }
@@ -486,7 +487,7 @@ function updateGlobalNavigation(
           for (const entry of fs.readdirSync(generalDir, { withFileTypes: true })) {
             if (!entry.isDirectory()) continue;
             const kindIndex = path.join(generalDir, entry.name, 'index.md');
-            if (!notesByDir.has(entry.name) && fs.existsSync(kindIndex)) {
+            if (!notesByKindDir.has(entry.name) && fs.existsSync(kindIndex)) {
               fs.unlinkSync(kindIndex);
             }
           }

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -1382,7 +1382,9 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         output += '\ndryRun: true — no changes applied. Set dryRun: false to apply migration.';
         output += '\n\n## Impact Preview\n';
         output += '- Post-migration: full DB rebuild + project index regeneration + global navigation update\n';
-        output += '- Embeddings: will need backfill after migration (semantic search temporarily unavailable)\n';
+        if (embeddingConfig) {
+          output += '- Embeddings: will need backfill after migration (semantic search temporarily unavailable)\n';
+        }
         output += '- Navigation: index.md, log.md, review.md, and per-directory indexes will be auto-generated\n';
       } else if (!dryRun && moved > 0) {
         let emptyDirsRemoved = 0;

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -19,7 +19,7 @@ function toLifecycle(lifecycle: string | undefined, fallback: Lifecycle): Lifecy
 import type { NoteRepository, NoteMetadata } from './storage/NoteRepository.js';
 import { formatWikiLink } from './utils/wikilink.js';
 import { renderNoteForSearch, renderNoteForAgent } from './prompts.js';
-import { buildIndexContent, buildGlobalIndexContent, buildGeneralIndexContent } from './storage/IndexBuilder.js';
+import { buildIndexContent, buildGlobalIndexContent, buildGeneralIndexContent, buildPreferencesIndexContent, buildGeneralKindIndexContent } from './storage/IndexBuilder.js';
 import { buildLogEntry, buildInitialLogContent, appendToLogContent, buildGlobalLogEntry, buildInitialGlobalLogContent } from './storage/LogAppender.js';
 import { buildReviewContent } from './storage/ReviewBuilder.js';
 import { resolveNotePath, extractProjectFromTags as extractProjectTag } from './storage/path-resolver.js';
@@ -82,6 +82,22 @@ function getRecommendation(note: NoteMetadata, daysOld: number, promotionThresho
   if (accesses >= promotionThreshold) return '2caa Promote';
   if (accesses === 0 && daysOld > 30) return '1f44 Archive';
   return '1f914 Review';
+}
+
+type BrokenLink = {
+  sourceId: string;
+  sourceTitle: string;
+  brokenTarget: string;
+  line: number;
+};
+
+function filterFalsePositiveBrokenLinks(broken: BrokenLink[], vaultPath: string | undefined): BrokenLink[] {
+  if (!vaultPath) return broken;
+  return broken.filter(({ brokenTarget }) => {
+    const notePath = path.join(vaultPath, `${brokenTarget}.md`);
+    const directoryIndexPath = path.join(vaultPath, brokenTarget, 'index.md');
+    return !fs.existsSync(notePath) && !fs.existsSync(directoryIndexPath);
+  });
 }
 
 // ---- Arg types ----
@@ -397,7 +413,7 @@ function updateGlobalNavigation(
     }
   }
 
-  if (config?.navigation?.enableGlobalLog !== false && project) {
+  if (config?.navigation?.enableGlobalLog !== false) {
     try {
       const globalLogPath = path.join(vaultPath, 'log.md');
       const entry = buildGlobalLogEntry(project, event);
@@ -428,15 +444,67 @@ function updateGlobalNavigation(
   if (config?.navigation?.enableGlobalIndex !== false) {
     try {
       const unscopedNotes = getUnscopedNotes();
+      const personalizationNotes = repo.getPersonalizationNotes();
       const generalDir = path.join(vaultPath, 'general');
       if (unscopedNotes.length > 0) {
         const content = buildGeneralIndexContent(unscopedNotes);
         if (!fs.existsSync(generalDir)) fs.mkdirSync(generalDir, { recursive: true });
         fs.writeFileSync(path.join(generalDir, 'index.md'), content, 'utf-8');
+
+        const notesByDir = new Map<string, NoteMetadata[]>();
+        for (const note of unscopedNotes) {
+          const dirName = path.basename(path.dirname(note.path));
+          const bucket = notesByDir.get(dirName);
+          if (bucket) {
+            bucket.push(note);
+          } else {
+            notesByDir.set(dirName, [note]);
+          }
+        }
+
+        for (const [dirName, kindNotes] of notesByDir) {
+          const kindDir = path.join(generalDir, dirName);
+          if (!fs.existsSync(kindDir)) fs.mkdirSync(kindDir, { recursive: true });
+          fs.writeFileSync(
+            path.join(kindDir, 'index.md'),
+            buildGeneralKindIndexContent(kindNotes[0].kind, kindNotes),
+            'utf-8',
+          );
+        }
+
+        if (fs.existsSync(generalDir)) {
+          for (const entry of fs.readdirSync(generalDir, { withFileTypes: true })) {
+            if (!entry.isDirectory()) continue;
+            const kindIndex = path.join(generalDir, entry.name, 'index.md');
+            if (!notesByDir.has(entry.name) && fs.existsSync(kindIndex)) {
+              fs.unlinkSync(kindIndex);
+            }
+          }
+        }
       }
       if (unscopedNotes.length === 0) {
         const generalIndex = path.join(generalDir, 'index.md');
         if (fs.existsSync(generalIndex)) fs.unlinkSync(generalIndex);
+        if (fs.existsSync(generalDir)) {
+          for (const entry of fs.readdirSync(generalDir, { withFileTypes: true })) {
+            if (!entry.isDirectory()) continue;
+            const kindIndex = path.join(generalDir, entry.name, 'index.md');
+            if (fs.existsSync(kindIndex)) fs.unlinkSync(kindIndex);
+          }
+        }
+      }
+
+      const preferencesDir = path.join(vaultPath, 'preferences');
+      if (personalizationNotes.length > 0) {
+        if (!fs.existsSync(preferencesDir)) fs.mkdirSync(preferencesDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(preferencesDir, 'index.md'),
+          buildPreferencesIndexContent(personalizationNotes),
+          'utf-8',
+        );
+      } else {
+        const preferencesIndex = path.join(preferencesDir, 'index.md');
+        if (fs.existsSync(preferencesIndex)) fs.unlinkSync(preferencesIndex);
       }
     } catch (error) {
       logToFile('WARN', 'Failed to rebuild general index', {
@@ -1213,7 +1281,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       return output;
     }
     case 'broken-links': {
-      const broken = repo.getBrokenLinks();
+      const broken = filterFalsePositiveBrokenLinks(repo.getBrokenLinks(), config?.vault);
       if (broken.length === 0) {
         return 'No broken wikilinks found. All links resolve to existing notes.';
       }
@@ -1302,7 +1370,29 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
 
       if (dryRun && moves.length > 0) {
         output += '\ndryRun: true — no changes applied. Set dryRun: false to apply migration.';
+        output += '\n\n## Impact Preview\n';
+        output += '- Post-migration: full DB rebuild + project index regeneration + global navigation update\n';
+        output += '- Embeddings: will need backfill after migration (semantic search temporarily unavailable)\n';
+        output += '- Navigation: index.md, log.md, review.md, and per-directory indexes will be auto-generated\n';
       } else if (!dryRun && moved > 0) {
+        let emptyDirsRemoved = 0;
+        if (config.vault) {
+          const vaultEntries = fs.readdirSync(config.vault, { withFileTypes: true });
+          for (const entry of vaultEntries) {
+            if (!entry.isDirectory()) continue;
+            if (entry.name.startsWith('.')) continue;
+            const dirPath = path.join(config.vault, entry.name);
+            const contents = fs.readdirSync(dirPath);
+            if (contents.length === 0) {
+              fs.rmdirSync(dirPath);
+              emptyDirsRemoved++;
+            }
+          }
+        }
+        if (emptyDirsRemoved > 0) {
+          output += `Empty directories removed: ${emptyDirsRemoved}\n`;
+        }
+
         const rebuildResult = repo.rebuildFromFiles();
         const projects = repo.getAllProjects();
         for (const proj of projects) {
@@ -1310,6 +1400,26 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         }
         output += `\nPost-migration rebuild: indexed ${rebuildResult.indexed} notes, rebuilt ${projects.length} project index(es).`;
         updateGlobalNavigation(null, 'Layout migration completed', repo, config);
+
+        const embeddingStats = repo.getEmbeddingStats();
+        const brokenLinks = filterFalsePositiveBrokenLinks(repo.getBrokenLinks(), config?.vault);
+
+        output += '\n\n## Health Summary\n';
+        if (embeddingStats.withoutEmbedding > 0) {
+          output += `Embeddings: ${embeddingStats.withoutEmbedding}/${embeddingStats.total} notes need backfill (run \`knowledge-maintain embed\`)\n`;
+        }
+        if (brokenLinks.length > 0) {
+          output += `Link health: ${brokenLinks.length} broken wikilinks found (run \`knowledge-maintain broken-links\` for details)\n`;
+        } else {
+          output += 'Link health: all links resolve ✓\n';
+        }
+
+        output += '\n## Next Steps\n';
+        if (embeddingStats.withoutEmbedding > 0) {
+          output += '- Backfill embeddings: knowledge-maintain embed\n';
+        }
+        output += '- Check link health: knowledge-maintain broken-links\n';
+        output += '- View vault stats: knowledge-maintain stats\n';
       }
 
       return output;

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -93,10 +93,20 @@ type BrokenLink = {
 
 function filterFalsePositiveBrokenLinks(broken: BrokenLink[], vaultPath: string | undefined): BrokenLink[] {
   if (!vaultPath) return broken;
+  const resolvedVault = path.resolve(vaultPath);
+  const vaultPrefix = resolvedVault + path.sep;
+  const insideVault = (candidate: string): boolean => {
+    const resolved = path.resolve(vaultPath, candidate);
+    return resolved === resolvedVault || resolved.startsWith(vaultPrefix);
+  };
   return broken.filter(({ brokenTarget }) => {
-    const notePath = path.join(vaultPath, `${brokenTarget}.md`);
-    const directoryIndexPath = path.join(vaultPath, brokenTarget, 'index.md');
-    return !fs.existsSync(notePath) && !fs.existsSync(directoryIndexPath);
+    const notePathRel = `${brokenTarget}.md`;
+    const dirIndexPathRel = path.join(brokenTarget, 'index.md');
+    const noteResolves = insideVault(notePathRel)
+      && fs.existsSync(path.resolve(vaultPath, notePathRel));
+    const dirResolves = insideVault(dirIndexPathRel)
+      && fs.existsSync(path.resolve(vaultPath, dirIndexPathRel));
+    return !noteResolves && !dirResolves;
   });
 }
 

--- a/tests/vault-layout.test.ts
+++ b/tests/vault-layout.test.ts
@@ -584,6 +584,27 @@ describe('Structured navigation regressions', () => {
     expect(output).toContain('No broken wikilinks found');
   });
 
+  it('reports out-of-vault traversal targets as broken (no filesystem bypass)', async () => {
+    // Security: an existing sibling outside the vault must NOT silence broken links via path-traversal.
+    const outsideDir = path.join(context.tempDir, '..', 'outside-vault');
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(path.join(outsideDir, 'secret.md'), '# secret', 'utf-8');
+
+    try {
+      const traversalTarget = `../${path.basename(outsideDir)}/secret`;
+      context.engine.store(`Bad link [[${traversalTarget}]]`, {
+        title: 'Traversal Link',
+        kind: 'observation',
+      });
+
+      const output = await handleMaintain({ action: 'broken-links' }, context.engine, context.config);
+      expect(output).toContain('Broken Wikilinks');
+      expect(output).toContain(traversalTarget);
+    } finally {
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   it('creates global log for null-project events with system label', async () => {
     context.engine.store('Seed note', { title: 'Seed', kind: 'observation' });
 
@@ -608,7 +629,8 @@ describe('Structured navigation regressions', () => {
     expect(fs.existsSync(preferencesIndex)).toBe(true);
     const content = fs.readFileSync(preferencesIndex, 'utf-8');
     expect(content).toContain('# Preferences (1 notes)');
-    expect(content).toContain('Back to Knowledge Base');
+    expect(content).toContain('[Back to Knowledge Base](../index.md)');
+    expect(content).not.toContain('[[index|Back to Knowledge Base]]');
 
     const globalIndex = fs.readFileSync(path.join(context.tempDir, 'index.md'), 'utf-8');
     expect(globalIndex).toContain('[[preferences/index|Preferences]]');

--- a/tests/vault-layout.test.ts
+++ b/tests/vault-layout.test.ts
@@ -299,10 +299,12 @@ Decision content`, flatFilename);
 
     context.engine.rebuildFromFiles();
 
+    const embeddingConfig = { provider: 'local', model: 'all-MiniLM-L6-v2', dimensions: 384 } as any;
     const output = await handleMaintain(
       { action: 'migrate-layout', dryRun: true } as any,
       context.engine,
       context.config,
+      embeddingConfig,
     );
 
     expect(output).toContain('Dry Run');
@@ -314,7 +316,35 @@ Decision content`, flatFilename);
     expect(fs.existsSync(flatPath)).toBe(true);
   });
 
-   it('actual migration moves files, cleans empty dirs, and reports health summary', async () => {
+  it('dry run omits embedding warning when embeddings are not configured', async () => {
+    createNoteFile(context, '2026042700000005', `---
+id: 2026042700000005
+title: No Embeddings Note
+kind: decision
+status: permanent
+lifecycle: snapshot
+type: atomic
+tags:
+  - project:myproject
+created: 2026-04-27
+updated: 2026-04-27
+---
+
+Content`, '2026042700000005-no-embeddings.md');
+    context.engine.rebuildFromFiles();
+
+    const output = await handleMaintain(
+      { action: 'migrate-layout', dryRun: true } as any,
+      context.engine,
+      context.config,
+    );
+
+    expect(output).toContain('## Impact Preview');
+    expect(output).not.toContain('Embeddings: will need backfill');
+    expect(output).toContain('Navigation: index.md, log.md, review.md, and per-directory indexes will be auto-generated');
+  });
+
+  it('actual migration moves files, cleans empty dirs, and reports health summary', async () => {
     createNoteFile(context, '2026042700000002', `---
 id: 2026042700000002
 title: Moveable Note
@@ -586,8 +616,7 @@ describe('Structured navigation regressions', () => {
 
   it('reports out-of-vault traversal targets as broken (no filesystem bypass)', async () => {
     // Security: an existing sibling outside the vault must NOT silence broken links via path-traversal.
-    const outsideDir = path.join(context.tempDir, '..', 'outside-vault');
-    fs.mkdirSync(outsideDir, { recursive: true });
+    const outsideDir = fs.mkdtempSync(path.join(path.dirname(context.tempDir), 'outside-vault-'));
     fs.writeFileSync(path.join(outsideDir, 'secret.md'), '# secret', 'utf-8');
 
     try {

--- a/tests/vault-layout.test.ts
+++ b/tests/vault-layout.test.ts
@@ -308,10 +308,13 @@ Decision content`, flatFilename);
     expect(output).toContain('Dry Run');
     expect(output).toContain('Would move');
     expect(output).toContain('projects/myproject/decisions/');
+    expect(output).toContain('## Impact Preview');
+    expect(output).toContain('Embeddings: will need backfill after migration');
+    expect(output).toContain('Navigation: index.md, log.md, review.md, and per-directory indexes will be auto-generated');
     expect(fs.existsSync(flatPath)).toBe(true);
   });
 
-  it('actual migration moves files and rebuilds DB', async () => {
+   it('actual migration moves files, cleans empty dirs, and reports health summary', async () => {
     createNoteFile(context, '2026042700000002', `---
 id: 2026042700000002
 title: Moveable Note
@@ -325,7 +328,10 @@ created: 2026-04-27
 updated: 2026-04-27
 ---
 
-Observation content`, '2026042700000002-moveable-note.md');
+Observation content with [[missing-note]]`, '2026042700000002-moveable-note.md');
+
+    const emptyDir = path.join(context.tempDir, 'legacy');
+    fs.mkdirSync(emptyDir, { recursive: true });
 
     context.engine.rebuildFromFiles();
 
@@ -336,7 +342,17 @@ Observation content`, '2026042700000002-moveable-note.md');
     );
 
     expect(output).toContain('Moved: 1');
+    expect(output).toContain('Empty directories removed: 1');
     expect(output).toContain('Post-migration rebuild');
+    expect(output).toContain('## Health Summary');
+    expect(output).toContain('Embeddings: ');
+    expect(output).toContain('need backfill');
+    expect(output).toContain('Link health: 1 broken wikilinks found');
+    expect(output).toContain('## Next Steps');
+    expect(output).toContain('- Backfill embeddings: knowledge-maintain embed');
+    expect(output).toContain('- Check link health: knowledge-maintain broken-links');
+    expect(output).toContain('- View vault stats: knowledge-maintain stats');
+    expect(fs.existsSync(emptyDir)).toBe(false);
 
     const note = context.engine.getById('2026042700000002');
     expect(note).not.toBeNull();
@@ -479,7 +495,8 @@ describe('MOC Splitting', () => {
     ];
 
     const { content, subMocs } = buildIndexContent('test', notes, { threshold: 30, previewCount: 5 });
-    expect(subMocs).toHaveLength(0);
+    expect(subMocs).toHaveLength(2);
+    expect(subMocs.map(s => s.kind).sort()).toEqual(['decision', 'observation']);
     expect(content).toContain('## Decisions (2)');
     expect(content).toContain('Dec 1');
     expect(content).toContain('Dec 2');
@@ -502,9 +519,9 @@ describe('MOC Splitting', () => {
 
     const { content, subMocs } = buildIndexContent('test', notes, { threshold: 30, previewCount: 3 });
 
-    expect(subMocs.length).toBe(3);
+    expect(subMocs.length).toBe(4);
     const subMocKinds = subMocs.map(s => s.kind).sort();
-    expect(subMocKinds).toEqual(['decision', 'observation', 'reference']);
+    expect(subMocKinds).toEqual(['decision', 'observation', 'procedure', 'reference']);
 
     expect(content).toContain('View all 10');
     expect(content).toContain('## Procedures (3)');
@@ -534,9 +551,101 @@ describe('MOC Splitting', () => {
 
     const { content, subMocs } = buildIndexContent('test', notes, { threshold: 30, previewCount: 5 });
 
-    expect(subMocs.length).toBe(1);
-    expect(subMocs[0].kind).toBe('decision');
+    expect(subMocs.length).toBe(2);
+    expect(subMocs.map(s => s.kind).sort()).toEqual(['decision', 'resource']);
     expect(content).toContain('## Resources (2)');
     expect(content).toContain('Single Resource');
+  });
+
+});
+
+describe('Structured navigation regressions', () => {
+  let context: TestContext;
+
+  beforeEach(() => {
+    context = createTestHarness();
+  });
+
+  afterEach(() => {
+    cleanupTestHarness(context);
+  });
+
+  it('does not flag plain sub-MOC index files as broken links', async () => {
+    const decisionsDir = path.join(context.tempDir, 'projects', 'open-zk-kb', 'decisions');
+    fs.mkdirSync(decisionsDir, { recursive: true });
+    fs.writeFileSync(path.join(decisionsDir, 'index.md'), '# Decisions', 'utf-8');
+
+    context.engine.store('See [[projects/open-zk-kb/decisions/index]]', {
+      title: 'Links to Decisions Index',
+      kind: 'observation',
+    });
+
+    const output = await handleMaintain({ action: 'broken-links' }, context.engine, context.config);
+    expect(output).toContain('No broken wikilinks found');
+  });
+
+  it('creates global log for null-project events with system label', async () => {
+    context.engine.store('Seed note', { title: 'Seed', kind: 'observation' });
+
+    await handleMaintain({ action: 'rebuild' }, context.engine, context.config);
+
+    const globalLog = path.join(context.tempDir, 'log.md');
+    expect(fs.existsSync(globalLog)).toBe(true);
+    const content = fs.readFileSync(globalLog, 'utf-8');
+    expect(content).toContain('# Operations Log');
+    expect(content).toContain('[system] Full DB rebuild');
+  });
+
+  it('generates preferences/index.md when personalization notes exist', () => {
+    handleStore(
+      { title: 'Pref', content: 'Pref content', kind: 'personalization', summary: 'User prefers Bun', guidance: 'Use Bun' } as any,
+      context.engine,
+      null,
+      context.config,
+    );
+
+    const preferencesIndex = path.join(context.tempDir, 'preferences', 'index.md');
+    expect(fs.existsSync(preferencesIndex)).toBe(true);
+    const content = fs.readFileSync(preferencesIndex, 'utf-8');
+    expect(content).toContain('# Preferences (1 notes)');
+    expect(content).toContain('Back to Knowledge Base');
+
+    const globalIndex = fs.readFileSync(path.join(context.tempDir, 'index.md'), 'utf-8');
+    expect(globalIndex).toContain('[[preferences/index|Preferences]]');
+  });
+
+  it('generates general kind subdir indexes for unscoped notes', () => {
+    handleStore(
+      { title: 'General Decision', content: 'Decide', kind: 'decision', summary: 'General summary', guidance: 'Use it' } as any,
+      context.engine,
+      null,
+      context.config,
+    );
+
+    const generalKindIndex = path.join(context.tempDir, 'general', 'decisions', 'index.md');
+    expect(fs.existsSync(generalKindIndex)).toBe(true);
+    const content = fs.readFileSync(generalKindIndex, 'utf-8');
+    expect(content).toContain('# General — Decisions (1)');
+    expect(content).toContain('Back to General');
+  });
+
+  it('creates sub-MOC files for small project kinds below split threshold', () => {
+    handleStore(
+      { title: 'Decision One', content: 'One', kind: 'decision', project: 'smallproj', summary: 'One', guidance: 'Use one' } as any,
+      context.engine,
+      null,
+      context.config,
+    );
+    handleStore(
+      { title: 'Decision Two', content: 'Two', kind: 'decision', project: 'smallproj', summary: 'Two', guidance: 'Use two' } as any,
+      context.engine,
+      null,
+      context.config,
+    );
+
+    const subMocPath = path.join(context.tempDir, 'projects', 'smallproj', 'decisions', 'index.md');
+    expect(fs.existsSync(subMocPath)).toBe(true);
+    const content = fs.readFileSync(subMocPath, 'utf-8');
+    expect(content).toContain('# Smallproj — Decisions (2)');
   });
 });

--- a/tests/vault-layout.test.ts
+++ b/tests/vault-layout.test.ts
@@ -680,6 +680,31 @@ describe('Structured navigation regressions', () => {
     expect(content).toContain('Back to General');
   });
 
+  it('groups general kind subdirs by note kind, not by filesystem path (flat-vault safe)', async () => {
+    // Regression: pre-migration flat vaults must not pollute general/ with vault-name dirs.
+    const flatNote = `---
+id: 2026042700000099
+title: Flat Unscoped Decision
+kind: decision
+status: permanent
+lifecycle: snapshot
+type: atomic
+created: 2026-04-27
+updated: 2026-04-27
+---
+
+Flat content`;
+    createNoteFile(context, '2026042700000099', flatNote, '2026042700000099-flat-unscoped.md');
+    context.engine.rebuildFromFiles();
+
+    await handleMaintain({ action: 'rebuild' }, context.engine, context.config);
+
+    expect(fs.existsSync(path.join(context.tempDir, 'general', 'decisions', 'index.md'))).toBe(true);
+
+    const vaultBasename = path.basename(context.tempDir);
+    expect(fs.existsSync(path.join(context.tempDir, 'general', vaultBasename))).toBe(false);
+  });
+
   it('creates sub-MOC files for small project kinds below split threshold', () => {
     handleStore(
       { title: 'Decision One', content: 'One', kind: 'decision', project: 'smallproj', summary: 'One', guidance: 'Use one' } as any,

--- a/tests/vault-layout.test.ts
+++ b/tests/vault-layout.test.ts
@@ -390,6 +390,41 @@ Observation content with [[missing-note]]`, '2026042700000002-moveable-note.md')
     expect(fs.existsSync(note!.path)).toBe(true);
   });
 
+  it('recursively removes nested empty directories during cleanup', async () => {
+    createNoteFile(context, '2026042700000010', `---
+id: 2026042700000010
+title: Trigger Migration
+kind: decision
+status: permanent
+lifecycle: snapshot
+type: atomic
+tags:
+  - project:cleanproj
+created: 2026-04-27
+updated: 2026-04-27
+---
+
+content`, '2026042700000010-trigger-migration.md');
+
+    fs.mkdirSync(path.join(context.tempDir, 'legacy', 'level2', 'level3'), { recursive: true });
+    const keepDir = path.join(context.tempDir, 'keep-this');
+    fs.mkdirSync(keepDir, { recursive: true });
+    fs.writeFileSync(path.join(keepDir, 'note.md'), 'content', 'utf-8');
+
+    context.engine.rebuildFromFiles();
+
+    const output = await handleMaintain(
+      { action: 'migrate-layout', dryRun: false } as any,
+      context.engine,
+      context.config,
+    );
+
+    expect(output).toContain('Empty directories removed: 3');
+    expect(fs.existsSync(path.join(context.tempDir, 'legacy'))).toBe(false);
+    expect(fs.existsSync(keepDir)).toBe(true);
+    expect(fs.existsSync(path.join(keepDir, 'note.md'))).toBe(true);
+  });
+
   it('skips notes already in correct location', async () => {
     context.engine.store('Already structured', {
       title: 'Structured Note',


### PR DESCRIPTION
## Summary

Follow-up to #102 (kind-based vault directories) addressing real-world issues discovered during migration of a 225-note vault from flat to structured layout.

- **Hardened `migrate-layout`** with dry-run impact preview, post-migration health summary (embedding + broken-link counts), empty depth-1 directory cleanup, and actionable next-steps guidance — so future users get a self-documenting migration experience
- **Eliminated broken-links false positives** for plain-file sub-MOCs (`projects/*/decisions/index.md`) by extracting a reusable filesystem filter shared between `broken-links` action and post-migration health check
- **Always-generate sub-MOC indexes** for every kind directory with notes (not just above split threshold), plus `preferences/index.md` and `general/{kind}/index.md` — every directory in the vault now has a navigation entry point
- **Global `log.md` for null-project events** like migrations and rebuilds (rendered with `[system]` label)

## Discovery context

While migrating an existing 225-note vault to verify #102 end-to-end, three issues surfaced that would repeat for any future user:

1. `broken-links` reported 16 sub-MOC files as broken (false positives — plain files not in DB)
2. Migration completed but no `log.md` was created (`&& project` guard skipped null-project events)
3. Small projects' kind directories lacked indexes (split-threshold logic gated all sub-MOC generation)

After fixing those, three more gaps in the user experience emerged:

4. Embedding index silently invalidated post-migration with no warning to backfill
5. No post-migration health check
6. Dry-run gave no preview of side effects

This PR fixes all six.

## Test results

- 759 pass, 39 skip, 0 fail (was 754 pass before)
- New tests in `tests/vault-layout.test.ts` cover: plain sub-MOC links not flagged broken, null-project global log creation, `preferences/index.md` generation, `general/decisions/index.md` generation, sub-MOC generation below split threshold, dry-run impact preview, post-migration health summary, empty directory cleanup, and next-steps guidance
- Verified end-to-end against the real 225-note vault: 0 errors, all 60 index files generated, 0 directories missing coverage, 16 → 0 false-positive broken links

## Files changed

| File | Change |
|------|--------|
| `src/storage/IndexBuilder.ts` | Always emit sub-MOC content; add `buildPreferencesIndexContent` and `buildGeneralKindIndexContent` |
| `src/storage/LogAppender.ts` | `buildGlobalLogEntry` accepts null project, renders as `[system]` |
| `src/tool-handlers.ts` | Reusable `filterFalsePositiveBrokenLinks` helper; null-project log support; preferences + general kind index generation; migrate-layout hardening (impact preview, health summary, dir cleanup, next steps) |
| `tests/vault-layout.test.ts` | Comprehensive regression coverage for all changes |

Closes the post-#102 gaps. No schema changes, no MCP tool schema changes, no breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directory-scoped general index pages and a Preferences index for better navigation.
  * Migration output now includes an Impact Preview, Health Summary, and Next Steps.
  * Improved broken-link detection and vault-aware false-positive filtering.
  * Global log entries now mark system-level events when no project is specified.

* **Documentation**
  * Overhauled agent guidance with Commands, Testing, and a new Boundaries framework.

* **Tests**
  * Expanded migration and navigation tests covering diagnostics, splitting, and health reporting.

* **Chores**
  * PR agent behavior and model selection updated; automatic improve disabled for non-manual runs and triggers clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->