### PR TITLE
Add local-only tool invocation telemetry

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -41,12 +41,18 @@ jobs:
           OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
           # Model + review config lives in .pr_agent.toml (repo root)
           # Only secrets and action-level config set here
-          # Phase 0 cost reduction (2026-04-28): /improve disabled on auto-run.
-          # /review runs on opened/reopened/ready_for_review only — synchronize is
-          # excluded via pr_actions in .pr_agent.toml so push events no longer
-          # auto-trigger /review. Re-run manually via `/review -i` PR comment.
-          # User can manually invoke /improve via PR comment when wanted.
-          # Rationale: agent-architecture/04-references/cost-analysis-by-tier.md
+          #
+          # 2026-04-29 update: re-enabled /improve to get per-line inline
+          # suggestion comments (Greptile/CodeRabbit-style) which `/review`
+          # cannot produce. /improve posts comments with native GitHub
+          # ```suggestion``` blocks; pr-agent NEVER auto-commits. Source-verified
+          # in agent-architecture/04-References/pr-agent-extra-instructions-scope.md.
+          # The pr_actions filter in .pr_agent.toml restricts /improve and /review
+          # to opened/reopened/ready_for_review only — synchronize events do NOT
+          # auto-fire either tool. Use `/improve` or `/review -i` PR comment to
+          # re-run manually. Cost rises ~$3.65/mo → ~$7-12/mo (still below
+          # CodeRabbit's $24).
+          # Rationale: agent-architecture/04-References/cost-analysis-by-tier.md
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
-          github_action_config.auto_improve: "false"
+          github_action_config.auto_improve: "true"

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,21 @@
 # PR Agent configuration for open-zk-kb
 # Docs: https://www.pr-agent.ai
-# Model config also set via workflow env vars (TOML is read from base branch only)
+#
+# CONFIG LOADING: pr-agent reads this file from the repo's DEFAULT branch (= dev),
+# not main, not the PR base. Source: qodo-ai/pr-agent github_provider.py:730
+# (`get_repo_settings` calls `get_contents(".pr_agent.toml")` without a ref,
+# defaulting to the default branch). So changes here take effect for all PRs
+# once they merge to dev.
+#
+# WORKFLOW ENV VARS in .github/workflows/pr-agent.yml only set
+# [github_action_config] flags (auto_review, auto_describe, auto_improve).
+# Model + reviewer config lives here.
+#
+# extra_instructions SCOPE: controls what the LLM thinks about (categories,
+# severity language, what NOT to flag, WHEN/THEN/BECAUSE rules) but CANNOT
+# override pr-agent's hardcoded output format/title. Title `## PR Reviewer
+# Guide 🔍` is a Python enum constant; output schema is rigid Pydantic.
+# See: agent-architecture/04-References/pr-agent-extra-instructions-scope.md
 
 [config]
 # Phase 0 swap rationale: agent-architecture/04-references/openzkkb-pr-review-current-state.md
@@ -75,58 +90,6 @@ previous feedback correctly, acknowledge resolution and approve.
 
 CONVERGE TO APPROVAL: After 1-2 rounds of feedback, the review should either approve
 or clearly state the remaining blocking items. Do not keep finding new nits indefinitely.
-
-## Output Format (MANDATORY — follow this structure exactly)
-
-IMPORTANT: Your review comment title MUST be "## PR Review" (not "PR Reviewer Guide").
-
-### 1. Verdict (first line, bold)
-
-**✅ Approved** or **⚠️ Needs Work (N blockers)**
-
-One sentence explaining why.
-
-### 2. Quality Scorecard (table, always present)
-
-| Metric | Grade | Notes |
-|--------|-------|-------|
-| **Scope** | A-F | Does the PR do what the issue/description says? Missing pieces? Out-of-scope changes? |
-| **Code Quality** | A-F | Bugs, error handling, type safety, patterns match codebase conventions? |
-| **Testing** | A-F | Test coverage for new code, edge cases, mocks where needed, no side effects in tests? |
-| **Security** | A-F or N/A | Secrets, injection, auth, MCP stdout safety? |
-
-Grades: A = excellent, B = good (minor gaps), C = adequate, D = significant gaps, F = failing.
-One-line "Notes" per row — not paragraphs.
-
-### 3. Findings
-
-Post each finding as an INLINE CODE COMMENT on the specific line in the PR diff.
-Format per inline comment: 🔴/🟡/⚪ **[Title]** — one-line description.
-Include a minimal code diff if suggesting a fix.
-
-In the summary comment, list findings as a reference:
-
-#### 🔴 Must Fix
-- **[Title]** — `file.ts:N`
-
-#### 🟡 Should Fix
-- **[Title]** — `file.ts:N`
-
-#### ⚪ Nits (max 2)
-- **[Title]** — `file.ts:N`
-
-If no findings in a tier, omit that header entirely.
-
-### 4. Review Log (persists across rounds)
-
-| Round | Commit | Findings | Verdict |
-|-------|--------|----------|---------|
-| 1 | `abc1234` | 3 (1 🔴, 2 🟡) | Needs Work |
-| 2 | `def5678` | 1 new, 2 resolved | Approved |
-
-This log MUST persist and accumulate — never delete previous entries.
-
----
 
 ## Priority Tiers (exactly ONE per finding)
 
@@ -221,8 +184,14 @@ Test files: Verify regression tests for bugfixes, proper cleanup via cleanupTest
 [pr_code_suggestions]
 focus_only_on_problems = true
 suggestions_score_threshold = 3
-num_code_suggestions_per_chunk = 4
-commitable_code_suggestions = false
+num_code_suggestions_per_chunk = 5
+# commitable_code_suggestions = true posts each suggestion as a separate inline
+# GitHub review comment with a native ```suggestion``` block (the "Commit
+# suggestion" button you see on Greptile/CodeRabbit comments). Clicking that
+# button is a manual action that creates a commit authored by the clicker —
+# pr-agent itself never commits. Source: pr_code_suggestions.py L573-L575 +
+# github_provider.py:417 (calls pr.create_review, not git_commit).
+commitable_code_suggestions = true
 publish_output_no_suggestions = false
 auto_extended_mode = true
 max_number_of_calls = 3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ For any new feature, ask in order:
 - **Server surfaces, agent acts**: Every computed insight (similarity, dedup, staleness) appears in the tool response. The agent decides what to do with it.
 - **Hints, not directives**: Server responses include computed metrics (word count, similarity score, staleness days). Never phrased as recommendations.
 - **Behavioral guidance is advisory**: Instructions are "a request, not a guarantee" ([Anthropic](https://docs.anthropic.com/en/docs/claude-code/features-overview)). Deterministic enforcement requires hooks/plugins.
-- **Telemetry is local-only and opt-out**: Tool invocation counters stay in SQLite, never include content or query strings, and `telemetry.enabled: false` disables counters plus access timestamp updates.
+- **Telemetry is local-only and opt-in**: Tool invocation counters are disabled by default; set `telemetry.enabled: true` to enable. Counters stay in SQLite, never include content or query strings. When disabled, both counter rows and access timestamp updates are skipped.
 
 ## Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,7 @@ For any new feature, ask in order:
 - **Server surfaces, agent acts**: Every computed insight (similarity, dedup, staleness) appears in the tool response. The agent decides what to do with it.
 - **Hints, not directives**: Server responses include computed metrics (word count, similarity score, staleness days). Never phrased as recommendations.
 - **Behavioral guidance is advisory**: Instructions are "a request, not a guarantee" ([Anthropic](https://docs.anthropic.com/en/docs/claude-code/features-overview)). Deterministic enforcement requires hooks/plugins.
+- **Telemetry is local-only and opt-out**: Tool invocation counters stay in SQLite, never include content or query strings, and `telemetry.enabled: false` disables counters plus access timestamp updates.
 
 ## Notes
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -34,6 +34,11 @@
 #   alwaysIncludeDomainNote: true         # Prepend domain note to project-scoped searches
 #   excludeLogFromSearch: true            # Exclude structural log notes from default search results
 
+# ─── Telemetry ────────────────────────────────────────────────────────────────
+# Local-only SQLite counters for tool invocation rates. No content or queries are recorded.
+# telemetry:
+#   enabled: true                         # Set false to disable counters and access timestamps
+
 # ─── Navigation ───────────────────────────────────────────────────────────────
 # Auto-generated per-project index and operations log.
 # navigation:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -36,8 +36,9 @@
 
 # ─── Telemetry ────────────────────────────────────────────────────────────────
 # Local-only SQLite counters for tool invocation rates. No content or queries are recorded.
+# Disabled by default — uncomment and set true to opt in.
 # telemetry:
-#   enabled: true                         # Set false to disable counters and access timestamps
+#   enabled: false                        # Set true to enable counters and access timestamps
 
 # ─── Navigation ───────────────────────────────────────────────────────────────
 # Auto-generated per-project index and operations log.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ embeddings:
 | lifecycle.reviewAfterDays | number | 14 | Days until a note is surfaced for review |
 | lifecycle.promotionThreshold | number | 2 | Accesses needed to recommend promotion to permanent |
 | lifecycle.exemptKinds | string[] | ["personalization", "decision"] | Note kinds exempt from the review queue |
+| telemetry.enabled | boolean | true | Enable local-only tool invocation counters and access timestamps |
 | embeddings.enabled | boolean | true | Enable vector embeddings |
 | embeddings.provider | string | local | Embedding provider: local or api |
 | embeddings.model | string | all-MiniLM-L6-v2 | Embedding model (local or API) |
@@ -48,6 +49,33 @@ Embeddings work **out of the box** with zero configuration using a local model (
 - ~23MB model downloaded on first use, cached in `~/.cache/open-zk-kb/models/`
 - To override with an API provider (for higher-quality embeddings), configure the `embeddings` section with `provider: api`.
 - To disable embeddings entirely, set `enabled: false`.
+
+## Telemetry (Local-Only)
+
+Telemetry is enabled by default and is stored only in the local SQLite database under the vault. It records coarse tool invocation counters for `knowledge-maintain stats` when called with `telemetry: true`.
+
+```yaml
+telemetry:
+  enabled: false
+```
+
+When disabled, open-zk-kb records no telemetry rows and also skips note access tracking (`last_accessed_at` and `access_count`). This treats access timestamps as privacy-sensitive metadata and makes opt-out comprehensive.
+
+Recorded fields:
+- Synthetic per-connection session ID
+- Tool name (`search`, `store`, `maintain`)
+- Store kind or maintain action
+- Timestamp
+- Result count for searches and successful stores
+
+Not recorded:
+- Note content
+- Note bodies
+- Search query strings
+- Search result snippets
+- File paths
+- User identifiers, client identifiers, hostnames, or account names
+- API keys, tokens, credentials, or other secrets
 
 ## Example Configurations
 
@@ -72,6 +100,12 @@ embeddings:
 ### d) Embeddings disabled
 ```yaml
 embeddings:
+  enabled: false
+```
+
+### e) Telemetry disabled
+```yaml
+telemetry:
   enabled: false
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ embeddings:
 | lifecycle.reviewAfterDays | number | 14 | Days until a note is surfaced for review |
 | lifecycle.promotionThreshold | number | 2 | Accesses needed to recommend promotion to permanent |
 | lifecycle.exemptKinds | string[] | ["personalization", "decision"] | Note kinds exempt from the review queue |
-| telemetry.enabled | boolean | true | Enable local-only tool invocation counters and access timestamps |
+| telemetry.enabled | boolean | false | Enable local-only tool invocation counters and access timestamps (opt-in) |
 | embeddings.enabled | boolean | true | Enable vector embeddings |
 | embeddings.provider | string | local | Embedding provider: local or api |
 | embeddings.model | string | all-MiniLM-L6-v2 | Embedding model (local or API) |
@@ -50,16 +50,16 @@ Embeddings work **out of the box** with zero configuration using a local model (
 - To override with an API provider (for higher-quality embeddings), configure the `embeddings` section with `provider: api`.
 - To disable embeddings entirely, set `enabled: false`.
 
-## Telemetry (Local-Only)
+## Telemetry (Local-Only, Opt-In)
 
-Telemetry is enabled by default and is stored only in the local SQLite database under the vault. It records coarse tool invocation counters for `knowledge-maintain stats` when called with `telemetry: true`.
+Telemetry is **disabled by default** and must be explicitly opted into. When enabled, it is stored only in the local SQLite database under the vault — nothing is ever sent remotely. It records coarse tool invocation counters for `knowledge-maintain stats` when called with `telemetry: true`.
 
 ```yaml
 telemetry:
-  enabled: false
+  enabled: true
 ```
 
-When disabled, open-zk-kb records no telemetry rows and also skips note access tracking (`last_accessed_at` and `access_count`). This treats access timestamps as privacy-sensitive metadata and makes opt-out comprehensive.
+When disabled (the default), open-zk-kb records no telemetry rows and also skips note access tracking (`last_accessed_at` and `access_count`). This treats access timestamps as privacy-sensitive metadata and makes the default posture maximally private.
 
 Recorded fields:
 - Synthetic per-connection session ID

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,7 +84,7 @@ export const DEFAULT_CONFIG: AppConfig = {
     overviewLogEntryLimit: 10,
   },
   telemetry: {
-    enabled: true,
+    enabled: false,
   },
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,9 @@ interface RawConfig {
     mocPreviewCount?: number;
     overviewLogEntryLimit?: number;
   };
+  telemetry?: {
+    enabled?: boolean;
+  };
   embeddings?: EmbeddingsConfig;
 }
 
@@ -79,6 +82,9 @@ export const DEFAULT_CONFIG: AppConfig = {
     mocSplitThreshold: 30,
     mocPreviewCount: 5,
     overviewLogEntryLimit: 10,
+  },
+  telemetry: {
+    enabled: true,
   },
 };
 
@@ -164,6 +170,11 @@ export function getConfig(): AppConfig {
       overviewLogEntryLimit: typeof raw?.navigation?.overviewLogEntryLimit === 'number'
         ? raw.navigation.overviewLogEntryLimit
         : DEFAULT_CONFIG.navigation.overviewLogEntryLimit,
+    },
+    telemetry: {
+      enabled: typeof raw?.telemetry?.enabled === 'boolean'
+        ? raw.telemetry.enabled
+        : DEFAULT_CONFIG.telemetry.enabled,
     },
   };
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -32,7 +32,7 @@ let repo: NoteRepositoryType | null = null;
 
 function getOrCreateRepo(): NoteRepositoryType {
   if (!repo) {
-    repo = new NoteRepository(config.vault);
+    repo = new NoteRepository(config.vault, { telemetryEnabled: config.telemetry.enabled });
     logToFile('INFO', 'MCP server: repository opened', { vault: config.vault }, config);
   }
   return repo;
@@ -312,6 +312,7 @@ const maintainSchema = z.object({
   filter: z.enum(['fleeting', 'permanent']).optional().describe('Filter for review action: fleeting or permanent notes'),
   days: z.number().optional().describe('Days threshold for review (default: from lifecycle.reviewAfterDays config)'),
   limit: z.number().optional().describe('Max notes to show (default: 3 for review)'),
+  telemetry: z.boolean().optional().describe('Include 30-day local-only tool invocation aggregates in stats output'),
   dryRun: z.boolean().optional().describe('Preview changes without applying'),
   model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
 });
@@ -330,6 +331,7 @@ server.registerTool(
         filter: args.filter as 'fleeting' | 'permanent' | undefined,
         days: args.days,
         limit: args.limit,
+        telemetry: args.telemetry,
         dryRun: args.dryRun,
         model: args.model,
       }, getOrCreateRepo(), config, getEmbeddingConfig(), PKG_VERSION);

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5,7 +5,7 @@ import { Database } from 'bun:sqlite';
 import { logToFile } from './logger.js';
 
 export class SchemaManager {
-  static readonly SCHEMA_VERSION = 6;
+  static readonly SCHEMA_VERSION = 7;
 
   private static readonly MIGRATIONS: Array<{
     version: number;
@@ -97,7 +97,34 @@ export class SchemaManager {
         }
       },
     },
+    {
+      version: 7,
+      description: 'Add local tool telemetry and last access index',
+      migrate: (db) => {
+        const columns = db.prepare('PRAGMA table_info(notes)').all() as Array<{ name: string }>;
+        if (!columns.some(c => c.name === 'last_accessed_at')) {
+          db.run('ALTER TABLE notes ADD COLUMN last_accessed_at INTEGER');
+        }
+        db.run('CREATE INDEX IF NOT EXISTS idx_notes_last_accessed_at ON notes(last_accessed_at)');
+        SchemaManager.createTelemetryTable(db);
+      },
+    },
   ];
+
+  private static createTelemetryTable(db: Database): void {
+    db.run(`
+      CREATE TABLE IF NOT EXISTS tool_telemetry (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        tool_name TEXT NOT NULL,
+        arg_kind TEXT,
+        timestamp INTEGER NOT NULL,
+        result_count INTEGER
+      )
+    `);
+    db.run('CREATE INDEX IF NOT EXISTS idx_telemetry_timestamp ON tool_telemetry(timestamp)');
+    db.run('CREATE INDEX IF NOT EXISTS idx_telemetry_session ON tool_telemetry(session_id)');
+  }
 
   private db: Database;
 
@@ -183,6 +210,8 @@ export class SchemaManager {
     `);
 
     this.db.run('CREATE INDEX IF NOT EXISTS idx_notes_content_hash ON notes(content_hash)');
+    this.db.run('CREATE INDEX IF NOT EXISTS idx_notes_last_accessed_at ON notes(last_accessed_at)');
+    SchemaManager.createTelemetryTable(this.db);
 
     this.db.run(`
       CREATE TABLE IF NOT EXISTS note_links (

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -187,10 +187,21 @@ function getInstalledClients(): McpClient[] {
   return ALL_CLIENTS.filter(isClientInstalled);
 }
 
-function getNestedValue(obj: any, path: string[]): any {
-  let current = obj;
+type JsonObject = Record<string, unknown>;
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseJsonObject(content: string): JsonObject {
+  const parsed: unknown = JSON.parse(content);
+  return isJsonObject(parsed) ? parsed : {};
+}
+
+function getNestedValue(obj: JsonObject, path: string[]): unknown {
+  let current: unknown = obj;
   for (const key of path) {
-    if (current && typeof current === 'object' && key in current) {
+    if (isJsonObject(current) && key in current) {
       current = current[key];
     } else {
       return undefined;
@@ -199,24 +210,28 @@ function getNestedValue(obj: any, path: string[]): any {
   return current;
 }
 
-function setNestedValue(obj: any, path: string[], value: any): void {
+function setNestedValue(obj: JsonObject, path: string[], value: unknown): void {
   let current = obj;
   for (let i = 0; i < path.length - 1; i++) {
-    if (!(path[i] in current)) {
-      current[path[i]] = {};
+    const key = path[i];
+    const next = current[key];
+    if (!isJsonObject(next)) {
+      current[key] = {};
     }
-    current = current[path[i]];
+    const updated = current[key];
+    if (isJsonObject(updated)) current = updated;
   }
   current[path[path.length - 1]] = value;
 }
 
-function deleteNestedValue(obj: any, path: string[]): boolean {
+function deleteNestedValue(obj: JsonObject, path: string[]): boolean {
   let current = obj;
   for (let i = 0; i < path.length - 1; i++) {
-    if (!(path[i] in current)) {
+    const next = current[path[i]];
+    if (!isJsonObject(next)) {
       return false;
     }
-    current = current[path[i]];
+    current = next;
   }
   const lastKey = path[path.length - 1];
   if (lastKey in current) {
@@ -626,12 +641,12 @@ export function install(args: InstallArgs): string {
     throw new Error(`Server not found at: ${serverPath}`);
   }
   
-  let config: any = {};
+  let config: JsonObject = {};
   
   if (fs.existsSync(clientConfig.configPath)) {
     try {
       const content = fs.readFileSync(clientConfig.configPath, 'utf-8');
-      config = JSON.parse(content);
+      config = parseJsonObject(content);
     } catch (e) {
       throw new Error(`Failed to parse ${clientConfig.configPath}: ${e}`, { cause: e });
     }
@@ -726,10 +741,10 @@ export function uninstall(args: UninstallArgs): string {
     return `No config found for ${clientConfig.name} at ${clientConfig.configPath}`;
   }
   
-  let config: any;
+  let config: JsonObject;
   try {
     const content = fs.readFileSync(clientConfig.configPath, 'utf-8');
-    config = JSON.parse(content);
+    config = parseJsonObject(content);
   } catch (e) {
     throw new Error(`Failed to parse ${clientConfig.configPath}: ${e}`, { cause: e });
   }

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -79,7 +79,31 @@ export interface TelemetryAggregates {
   stores: number;
   maintains: number;
   storesByKind: Record<string, number>;
+  maintainByAction: Record<string, number>;
   sessionDurations: number[];
+}
+
+export interface TelemetryRow {
+  session_id: string;
+  tool_name: TelemetryToolName;
+  arg_kind: string | null;
+  timestamp: number;
+  result_count: number | null;
+}
+
+function withBusyRetry<T>(fn: () => T, maxRetries = 3): T {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      return fn();
+    } catch (e: unknown) {
+      if (e instanceof Error && e.message.includes('SQLITE_BUSY') && i < maxRetries - 1) {
+        Bun.sleepSync(50);
+        continue;
+      }
+      throw e;
+    }
+  }
+  throw new Error('unreachable');
 }
 
 // Monotonic timestamp tracking to avoid ID collisions within a process
@@ -1283,10 +1307,12 @@ export class NoteRepository {
 
   recordToolInvocation(toolName: TelemetryToolName, argKind?: string, resultCount?: number): void {
     if (!this.telemetryEnabled) return;
-    this.db.prepare(`
-      INSERT INTO tool_telemetry (session_id, tool_name, arg_kind, timestamp, result_count)
-      VALUES (?, ?, ?, ?, ?)
-    `).run(this.sessionId, toolName, argKind ?? null, Date.now(), resultCount ?? null);
+    withBusyRetry(() => {
+      this.db.prepare(`
+        INSERT INTO tool_telemetry (session_id, tool_name, arg_kind, timestamp, result_count)
+        VALUES (?, ?, ?, ?, ?)
+      `).run(this.sessionId, toolName, argKind ?? null, Date.now(), resultCount ?? null);
+    });
   }
 
   updateLastAccessed(noteIds: string[]): void {
@@ -1302,7 +1328,7 @@ export class NoteRepository {
     const transaction = this.db.transaction((ids: string[]) => {
       for (const id of ids) update.run(now, id);
     });
-    transaction(uniqueIds);
+    withBusyRetry(() => transaction(uniqueIds));
   }
 
   getTelemetryAggregates(days: number = 30): TelemetryAggregates {
@@ -1328,6 +1354,17 @@ export class NoteRepository {
       storesByKind[row.arg_kind] = row.count;
     }
 
+    const maintainRows = this.db.prepare(`
+      SELECT arg_kind, COUNT(*) as count
+      FROM tool_telemetry
+      WHERE timestamp >= ? AND tool_name = 'maintain' AND arg_kind IS NOT NULL
+      GROUP BY arg_kind
+    `).all(cutoff) as Array<{ arg_kind: string; count: number }>;
+    const maintainByAction: Record<string, number> = {};
+    for (const row of maintainRows) {
+      maintainByAction[row.arg_kind] = row.count;
+    }
+
     const durationRows = this.db.prepare(`
       SELECT MAX(timestamp) - MIN(timestamp) as duration
       FROM tool_telemetry
@@ -1341,6 +1378,7 @@ export class NoteRepository {
       stores: counts.stores ?? 0,
       maintains: counts.maintains ?? 0,
       storesByKind,
+      maintainByAction,
       sessionDurations: durationRows.map(row => row.duration ?? 0),
     };
   }
@@ -1348,12 +1386,22 @@ export class NoteRepository {
   recordAccess(id: string): void {
     if (!this.telemetryEnabled) return;
     const now = Date.now();
-    this.db.prepare(`
-      UPDATE notes
-      SET access_count = COALESCE(access_count, 0) + 1,
-          last_accessed_at = ?
-      WHERE id = ?
-    `).run(now, id);
+    withBusyRetry(() => {
+      this.db.prepare(`
+        UPDATE notes
+        SET access_count = COALESCE(access_count, 0) + 1,
+            last_accessed_at = ?
+        WHERE id = ?
+      `).run(now, id);
+    });
+  }
+
+  getTelemetryRows(): TelemetryRow[] {
+    return this.db.prepare(`
+      SELECT session_id, tool_name, arg_kind, timestamp, result_count
+      FROM tool_telemetry
+      ORDER BY id
+    `).all() as TelemetryRow[];
   }
 
   rebuildFromFiles(): { indexed: number; errors: number; warnings: string[] } {

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -98,7 +98,7 @@ export class NoteRepository {
     try {
       // Telemetry is configured once per repository/MCP connection. Opt-out disables both
       // tool_telemetry inserts and note access metadata writes for privacy consistency.
-      this.telemetryEnabled = options.telemetryEnabled !== false;
+      this.telemetryEnabled = options.telemetryEnabled === true;
       this.sessionId = crypto.randomUUID();
       const originalPath = docsPath;
       this.docsPath = expandPath(docsPath);

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -71,6 +71,17 @@ export interface StoreOptions {
   related?: string[];
 }
 
+export type TelemetryToolName = 'search' | 'store' | 'maintain';
+
+export interface TelemetryAggregates {
+  sessions: number;
+  searches: number;
+  stores: number;
+  maintains: number;
+  storesByKind: Record<string, number>;
+  sessionDurations: number[];
+}
+
 // Monotonic timestamp tracking to avoid ID collisions within a process
 let idCounter = 0;
 let lastIdTimestamp = '';
@@ -80,9 +91,15 @@ export class NoteRepository {
   protected docsPath: string;
   protected dbPath: string;
   protected schemaManager: SchemaManager;
+  private readonly sessionId: string;
+  private readonly telemetryEnabled: boolean;
 
-  constructor(docsPath: string = '~/.local/share/open-zk-kb') {
+  constructor(docsPath: string = '~/.local/share/open-zk-kb', options: { telemetryEnabled?: boolean } = {}) {
     try {
+      // Telemetry is configured once per repository/MCP connection. Opt-out disables both
+      // tool_telemetry inserts and note access metadata writes for privacy consistency.
+      this.telemetryEnabled = options.telemetryEnabled !== false;
+      this.sessionId = crypto.randomUUID();
       const originalPath = docsPath;
       this.docsPath = expandPath(docsPath);
 
@@ -1235,10 +1252,10 @@ export class NoteRepository {
     const stmt = this.db.prepare(`
       SELECT
         COUNT(*) as total,
-        SUM(CASE WHEN status = 'fleeting' THEN 1 ELSE 0 END) as fleeting,
-        SUM(CASE WHEN status = 'permanent' THEN 1 ELSE 0 END) as permanent,
-        SUM(CASE WHEN status = 'archived' THEN 1 ELSE 0 END) as archived,
-        SUM(CASE WHEN status NOT IN ('fleeting', 'permanent', 'archived') THEN 1 ELSE 0 END) as other
+        COALESCE(SUM(CASE WHEN status = 'fleeting' THEN 1 ELSE 0 END), 0) as fleeting,
+        COALESCE(SUM(CASE WHEN status = 'permanent' THEN 1 ELSE 0 END), 0) as permanent,
+        COALESCE(SUM(CASE WHEN status = 'archived' THEN 1 ELSE 0 END), 0) as archived,
+        COALESCE(SUM(CASE WHEN status NOT IN ('fleeting', 'permanent', 'archived') THEN 1 ELSE 0 END), 0) as other
       FROM notes
     `);
 
@@ -1264,7 +1281,72 @@ export class NoteRepository {
     return result;
   }
 
+  recordToolInvocation(toolName: TelemetryToolName, argKind?: string, resultCount?: number): void {
+    if (!this.telemetryEnabled) return;
+    this.db.prepare(`
+      INSERT INTO tool_telemetry (session_id, tool_name, arg_kind, timestamp, result_count)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(this.sessionId, toolName, argKind ?? null, Date.now(), resultCount ?? null);
+  }
+
+  updateLastAccessed(noteIds: string[]): void {
+    if (!this.telemetryEnabled || noteIds.length === 0) return;
+    const uniqueIds = [...new Set(noteIds)];
+    const now = Date.now();
+    const update = this.db.prepare(`
+      UPDATE notes
+      SET access_count = COALESCE(access_count, 0) + 1,
+          last_accessed_at = ?
+      WHERE id = ?
+    `);
+    const transaction = this.db.transaction((ids: string[]) => {
+      for (const id of ids) update.run(now, id);
+    });
+    transaction(uniqueIds);
+  }
+
+  getTelemetryAggregates(days: number = 30): TelemetryAggregates {
+    const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
+    const counts = this.db.prepare(`
+      SELECT
+        COUNT(DISTINCT session_id) as sessions,
+        SUM(CASE WHEN tool_name = 'search' THEN 1 ELSE 0 END) as searches,
+        SUM(CASE WHEN tool_name = 'store' THEN 1 ELSE 0 END) as stores,
+        SUM(CASE WHEN tool_name = 'maintain' THEN 1 ELSE 0 END) as maintains
+      FROM tool_telemetry
+      WHERE timestamp >= ?
+    `).get(cutoff) as { sessions: number | null; searches: number | null; stores: number | null; maintains: number | null };
+
+    const storeRows = this.db.prepare(`
+      SELECT arg_kind, COUNT(*) as count
+      FROM tool_telemetry
+      WHERE timestamp >= ? AND tool_name = 'store' AND arg_kind IS NOT NULL
+      GROUP BY arg_kind
+    `).all(cutoff) as Array<{ arg_kind: string; count: number }>;
+    const storesByKind: Record<string, number> = {};
+    for (const row of storeRows) {
+      storesByKind[row.arg_kind] = row.count;
+    }
+
+    const durationRows = this.db.prepare(`
+      SELECT MAX(timestamp) - MIN(timestamp) as duration
+      FROM tool_telemetry
+      WHERE timestamp >= ?
+      GROUP BY session_id
+    `).all(cutoff) as Array<{ duration: number | null }>;
+
+    return {
+      sessions: counts.sessions ?? 0,
+      searches: counts.searches ?? 0,
+      stores: counts.stores ?? 0,
+      maintains: counts.maintains ?? 0,
+      storesByKind,
+      sessionDurations: durationRows.map(row => row.duration ?? 0),
+    };
+  }
+
   recordAccess(id: string): void {
+    if (!this.telemetryEnabled) return;
     const now = Date.now();
     this.db.prepare(`
       UPDATE notes

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -237,10 +237,6 @@ function formatTelemetryStats(repo: NoteRepository): string {
   output += `  Most-stored kind: ${mostStored ? `${mostStored[0]} (${mostStored[1]})` : 'none (0)'}\n`;
   output += `  Most-used action: ${mostUsedAction ? `${mostUsedAction[0]} (${mostUsedAction[1]})` : 'none (0)'}\n`;
   output += `  Avg session duration: ${formatTelemetryNumber(avgDurationMin)} min\n`;
-  output += '\n';
-  output += '  Search-to-store ratio interpretation:\n';
-  output += '    High capture (≥ 0.30): suggestions probably unnecessary\n';
-  output += '    Low capture (< 0.30):  detection-as-suggestion would help\n';
   return output;
 }
 

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -646,7 +646,9 @@ export function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConf
     related: args.related,
   });
 
-  repo.recordToolInvocation('store', args.kind, 1);
+  try { repo.recordToolInvocation('store', args.kind, 1); } catch (e) {
+    logToFile('WARN', 'Telemetry write failed in store', { error: e instanceof Error ? e.message : String(e) });
+  }
 
   const hashContent = args.summary || args.content || args.title;
   const hash = computeSimHash(hashContent);
@@ -746,8 +748,12 @@ export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedd
   }
 
   const accessedIds = [...(domainNote ? [domainNote.id] : []), ...results.map(note => note.id)];
-  repo.recordToolInvocation('search', undefined, accessedIds.length);
-  repo.updateLastAccessed(accessedIds);
+  try {
+    repo.recordToolInvocation('search', undefined, accessedIds.length);
+    repo.updateLastAccessed(accessedIds);
+  } catch (e) {
+    logToFile('WARN', 'Telemetry write failed in search', { error: e instanceof Error ? e.message : String(e) });
+  }
 
   if (results.length === 0 && !domainNote) {
     return 'No matching notes found. Try broader keywords or remove filters.' + clientWarning;
@@ -767,7 +773,9 @@ export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedd
 }
 
 export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, config: AppConfig, embeddingConfig?: EmbeddingConfig | null, currentVersion?: string): Promise<string> {
-  repo.recordToolInvocation('maintain', args.action);
+  try { repo.recordToolInvocation('maintain', args.action); } catch (e) {
+    logToFile('WARN', 'Telemetry write failed in maintain', { error: e instanceof Error ? e.message : String(e) });
+  }
   switch (args.action) {
     case 'stats': {
       const stats = repo.getStats();

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -205,12 +205,28 @@ function formatTelemetryNumber(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }
 
+function scheduleTelemetryWrite(label: string, fn: () => void): void {
+  queueMicrotask(() => {
+    try {
+      fn();
+    } catch (e) {
+      logToFile('WARN', `Telemetry write failed in ${label}`, { error: e instanceof Error ? e.message : String(e) });
+    }
+  });
+}
+
 function formatTelemetryStats(repo: NoteRepository): string {
   const telemetry = repo.getTelemetryAggregates(30);
   const avgSearches = telemetry.sessions > 0 ? telemetry.searches / telemetry.sessions : 0;
   const avgStores = telemetry.sessions > 0 ? telemetry.stores / telemetry.sessions : 0;
   const storeSearchRatio = telemetry.searches > 0 ? telemetry.stores / telemetry.searches : 0;
+  const avgDurationMs = telemetry.sessionDurations.length > 0
+    ? telemetry.sessionDurations.reduce((sum, duration) => sum + duration, 0) / telemetry.sessionDurations.length
+    : 0;
+  const avgDurationMin = avgDurationMs / 60000;
   const mostStored = Object.entries(telemetry.storesByKind)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0];
+  const mostUsedAction = Object.entries(telemetry.maintainByAction)
     .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0];
 
   let output = '\n## Tool Telemetry\n\n';
@@ -219,6 +235,8 @@ function formatTelemetryStats(repo: NoteRepository): string {
   output += `  Stores: ${telemetry.stores} (avg ${formatTelemetryNumber(avgStores)} per session)\n`;
   output += `  Store / search ratio: ${storeSearchRatio.toFixed(2)}\n`;
   output += `  Most-stored kind: ${mostStored ? `${mostStored[0]} (${mostStored[1]})` : 'none (0)'}\n`;
+  output += `  Most-used action: ${mostUsedAction ? `${mostUsedAction[0]} (${mostUsedAction[1]})` : 'none (0)'}\n`;
+  output += `  Avg session duration: ${formatTelemetryNumber(avgDurationMin)} min\n`;
   output += '\n';
   output += '  Search-to-store ratio interpretation:\n';
   output += '    High capture (≥ 0.30): suggestions probably unnecessary\n';
@@ -646,9 +664,7 @@ export function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConf
     related: args.related,
   });
 
-  try { repo.recordToolInvocation('store', args.kind, 1); } catch (e) {
-    logToFile('WARN', 'Telemetry write failed in store', { error: e instanceof Error ? e.message : String(e) });
-  }
+  scheduleTelemetryWrite('store', () => repo.recordToolInvocation('store', args.kind, 1));
 
   const hashContent = args.summary || args.content || args.title;
   const hash = computeSimHash(hashContent);
@@ -748,12 +764,8 @@ export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedd
   }
 
   const accessedIds = [...(domainNote ? [domainNote.id] : []), ...results.map(note => note.id)];
-  try {
-    repo.recordToolInvocation('search', undefined, accessedIds.length);
-    repo.updateLastAccessed(accessedIds);
-  } catch (e) {
-    logToFile('WARN', 'Telemetry write failed in search', { error: e instanceof Error ? e.message : String(e) });
-  }
+  scheduleTelemetryWrite('search invocation', () => repo.recordToolInvocation('search', undefined, accessedIds.length));
+  scheduleTelemetryWrite('search access update', () => repo.updateLastAccessed(accessedIds));
 
   if (results.length === 0 && !domainNote) {
     return 'No matching notes found. Try broader keywords or remove filters.' + clientWarning;
@@ -773,9 +785,7 @@ export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedd
 }
 
 export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, config: AppConfig, embeddingConfig?: EmbeddingConfig | null, currentVersion?: string): Promise<string> {
-  try { repo.recordToolInvocation('maintain', args.action); } catch (e) {
-    logToFile('WARN', 'Telemetry write failed in maintain', { error: e instanceof Error ? e.message : String(e) });
-  }
+  scheduleTelemetryWrite('maintain', () => repo.recordToolInvocation('maintain', args.action));
   switch (args.action) {
     case 'stats': {
       const stats = repo.getStats();
@@ -1503,7 +1513,7 @@ export function handleOverview(args: OverviewArgs, repo: NoteRepository, config?
   if (domainNote) {
     output += '### Domain\n';
     output += renderNoteForAgent(domainNote) + '\n\n';
-    try { repo.recordAccess(domainNote.id); } catch { /* non-fatal */ }
+    scheduleTelemetryWrite('overview access', () => repo.recordAccess(domainNote.id));
   }
 
   if (indexNote) {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -174,6 +174,7 @@ export interface MaintainArgs {
   filter?: 'fleeting' | 'permanent';
   days?: number;
   limit?: number;
+  telemetry?: boolean;
   dryRun?: boolean;
   model?: string;
 }
@@ -198,6 +199,31 @@ export interface OpenArgs {
 
 function sanitizeMetadata(value: string): string {
   return value.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function formatTelemetryNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function formatTelemetryStats(repo: NoteRepository): string {
+  const telemetry = repo.getTelemetryAggregates(30);
+  const avgSearches = telemetry.sessions > 0 ? telemetry.searches / telemetry.sessions : 0;
+  const avgStores = telemetry.sessions > 0 ? telemetry.stores / telemetry.sessions : 0;
+  const storeSearchRatio = telemetry.searches > 0 ? telemetry.stores / telemetry.searches : 0;
+  const mostStored = Object.entries(telemetry.storesByKind)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0];
+
+  let output = '\n## Tool Telemetry\n\n';
+  output += `Last 30 days (${telemetry.sessions} sessions):\n`;
+  output += `  Searches: ${telemetry.searches} (avg ${formatTelemetryNumber(avgSearches)} per session)\n`;
+  output += `  Stores: ${telemetry.stores} (avg ${formatTelemetryNumber(avgStores)} per session)\n`;
+  output += `  Store / search ratio: ${storeSearchRatio.toFixed(2)}\n`;
+  output += `  Most-stored kind: ${mostStored ? `${mostStored[0]} (${mostStored[1]})` : 'none (0)'}\n`;
+  output += '\n';
+  output += '  Search-to-store ratio interpretation:\n';
+  output += '    High capture (≥ 0.30): suggestions probably unnecessary\n';
+  output += '    Low capture (< 0.30):  detection-as-suggestion would help\n';
+  return output;
 }
 
 const MAX_HTML_BYTES = 5 * 1024 * 1024; // 5MB
@@ -620,6 +646,8 @@ export function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConf
     related: args.related,
   });
 
+  repo.recordToolInvocation('store', args.kind, 1);
+
   const hashContent = args.summary || args.content || args.title;
   const hash = computeSimHash(hashContent);
   repo.updateContentHash(result.id, hash);
@@ -717,6 +745,10 @@ export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedd
     }
   }
 
+  const accessedIds = [...(domainNote ? [domainNote.id] : []), ...results.map(note => note.id)];
+  repo.recordToolInvocation('search', undefined, accessedIds.length);
+  repo.updateLastAccessed(accessedIds);
+
   if (results.length === 0 && !domainNote) {
     return 'No matching notes found. Try broader keywords or remove filters.' + clientWarning;
   }
@@ -726,31 +758,16 @@ export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedd
 
   if (domainNote) {
     output += renderNoteForSearch(domainNote) + '\n';
-    try {
-      repo.recordAccess(domainNote.id);
-    } catch (error) {
-      logToFile('WARN', 'Failed to record access', {
-        noteId: domainNote.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
   }
 
   for (const note of results) {
     output += renderNoteForSearch(note) + '\n';
-    try {
-      repo.recordAccess(note.id);
-    } catch (error) {
-      logToFile('WARN', 'Failed to record access', {
-        noteId: note.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
   }
   return output + clientWarning;
 }
 
 export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, config: AppConfig, embeddingConfig?: EmbeddingConfig | null, currentVersion?: string): Promise<string> {
+  repo.recordToolInvocation('maintain', args.action);
   switch (args.action) {
     case 'stats': {
       const stats = repo.getStats();
@@ -846,6 +863,9 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         if (latest && isNewerVersion(currentVersion, latest)) {
           output += `\n**Update**: \`bunx open-zk-kb@latest install --client <name> --force\`\n`;
         }
+      }
+      if (args.telemetry) {
+        output += formatTelemetryStats(repo);
       }
       return output;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,10 @@ export interface NavigationConfig {
   overviewLogEntryLimit: number;
 }
 
+export interface TelemetryConfig {
+  enabled: boolean;
+}
+
 export interface AppConfig {
   logLevel: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
   vault: string;
@@ -72,6 +76,7 @@ export interface AppConfig {
   lifecycleDefaults: LifecycleDefaults;
   search: SearchConfig;
   navigation: NavigationConfig;
+  telemetry: TelemetryConfig;
 }
 
 // NOTE: NoteMetadata and StoreResult are defined in storage/NoteRepository.ts

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -80,6 +80,7 @@ describe('config.ts', () => {
     expect(cfg.lifecycle.promotionThreshold).toBe(2);
     expect(cfg.lifecycle.exemptKinds).toEqual(['personalization', 'decision']);
     expect(cfg.lifecycle.autoArchiveFleetingDays).toBe(90);
+    expect(cfg.telemetry.enabled).toBe(true);
   });
 
   it('reads vault path from YAML config', async () => {
@@ -105,6 +106,7 @@ describe('config.ts', () => {
     expect(cfg.lifecycle.exemptKinds).toEqual(['personalization', 'decision']);
     expect(cfg.lifecycle.autoArchiveFleetingDays).toBe(90);
     expect(cfg.vault).toBe(path.join(isolated.dataDir, 'open-zk-kb'));
+    expect(cfg.telemetry.enabled).toBe(true);
   });
 
   it('handles malformed YAML by returning defaults', async () => {
@@ -117,6 +119,27 @@ describe('config.ts', () => {
     expect(cfg.logLevel).toBe('INFO');
     expect(cfg.vault).toBe(path.join(isolated.dataDir, 'open-zk-kb'));
     expect(cfg.lifecycle.reviewAfterDays).toBe(14);
+    expect(cfg.telemetry.enabled).toBe(true);
+  });
+
+  it('reads telemetry opt-out config', async () => {
+    const isolated = createIsolatedConfigHome();
+    fs.writeFileSync(isolated.configPath, 'telemetry:\n  enabled: false\n', 'utf-8');
+
+    const configModule = await loadFreshConfigModule();
+    const cfg = configModule.getConfig();
+
+    expect(cfg.telemetry.enabled).toBe(false);
+  });
+
+  it('falls back to enabled telemetry for malformed telemetry config', async () => {
+    const isolated = createIsolatedConfigHome();
+    fs.writeFileSync(isolated.configPath, 'telemetry:\n  enabled: nope\n', 'utf-8');
+
+    const configModule = await loadFreshConfigModule();
+    const cfg = configModule.getConfig();
+
+    expect(cfg.telemetry.enabled).toBe(true);
   });
 
   it('returns null from getEmbeddingsConfig when section is missing', async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -80,7 +80,7 @@ describe('config.ts', () => {
     expect(cfg.lifecycle.promotionThreshold).toBe(2);
     expect(cfg.lifecycle.exemptKinds).toEqual(['personalization', 'decision']);
     expect(cfg.lifecycle.autoArchiveFleetingDays).toBe(90);
-    expect(cfg.telemetry.enabled).toBe(true);
+    expect(cfg.telemetry.enabled).toBe(false);
   });
 
   it('reads vault path from YAML config', async () => {
@@ -106,7 +106,7 @@ describe('config.ts', () => {
     expect(cfg.lifecycle.exemptKinds).toEqual(['personalization', 'decision']);
     expect(cfg.lifecycle.autoArchiveFleetingDays).toBe(90);
     expect(cfg.vault).toBe(path.join(isolated.dataDir, 'open-zk-kb'));
-    expect(cfg.telemetry.enabled).toBe(true);
+    expect(cfg.telemetry.enabled).toBe(false);
   });
 
   it('handles malformed YAML by returning defaults', async () => {
@@ -119,27 +119,27 @@ describe('config.ts', () => {
     expect(cfg.logLevel).toBe('INFO');
     expect(cfg.vault).toBe(path.join(isolated.dataDir, 'open-zk-kb'));
     expect(cfg.lifecycle.reviewAfterDays).toBe(14);
-    expect(cfg.telemetry.enabled).toBe(true);
+    expect(cfg.telemetry.enabled).toBe(false);
   });
 
-  it('reads telemetry opt-out config', async () => {
+  it('reads telemetry opt-in config', async () => {
     const isolated = createIsolatedConfigHome();
-    fs.writeFileSync(isolated.configPath, 'telemetry:\n  enabled: false\n', 'utf-8');
+    fs.writeFileSync(isolated.configPath, 'telemetry:\n  enabled: true\n', 'utf-8');
 
     const configModule = await loadFreshConfigModule();
     const cfg = configModule.getConfig();
 
-    expect(cfg.telemetry.enabled).toBe(false);
+    expect(cfg.telemetry.enabled).toBe(true);
   });
 
-  it('falls back to enabled telemetry for malformed telemetry config', async () => {
+  it('falls back to disabled telemetry for malformed telemetry config', async () => {
     const isolated = createIsolatedConfigHome();
     fs.writeFileSync(isolated.configPath, 'telemetry:\n  enabled: nope\n', 'utf-8');
 
     const configModule = await loadFreshConfigModule();
     const cfg = configModule.getConfig();
 
-    expect(cfg.telemetry.enabled).toBe(true);
+    expect(cfg.telemetry.enabled).toBe(false);
   });
 
   it('returns null from getEmbeddingsConfig when section is missing', async () => {

--- a/tests/coverage-boost.test.ts
+++ b/tests/coverage-boost.test.ts
@@ -473,7 +473,7 @@ describe('Embeddings API', () => {
 describe('NoteRepository — Coverage Boost', () => {
   let ctx: TestContext;
 
-  beforeEach(() => { ctx = createTestHarness(); });
+  beforeEach(() => { ctx = createTestHarness({ telemetryEnabled: true }); });
   afterEach(() => { cleanupTestHarness(ctx); });
 
   describe('extractTitle', () => {

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -13,7 +13,11 @@ export interface TestContext {
   config: AppConfig;
 }
 
-export function createTestHarness(): TestContext {
+export interface TestHarnessOptions {
+  telemetryEnabled?: boolean;
+}
+
+export function createTestHarness(options: TestHarnessOptions = {}): TestContext {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-test-'));
 
   const config: AppConfig = {
@@ -44,7 +48,7 @@ export function createTestHarness(): TestContext {
       overviewLogEntryLimit: 10,
     },
     telemetry: {
-      enabled: true,
+      enabled: options.telemetryEnabled ?? false,
     },
   };
 

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -43,9 +43,12 @@ export function createTestHarness(): TestContext {
       mocPreviewCount: 5,
       overviewLogEntryLimit: 10,
     },
+    telemetry: {
+      enabled: true,
+    },
   };
 
-  const engine = new NoteRepository(tempDir);
+  const engine = new NoteRepository(tempDir, { telemetryEnabled: config.telemetry.enabled });
 
   return { tempDir, engine, config };
 }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -12,7 +12,7 @@ describe('Knowledge Capture Integration Tests', () => {
   let context: TestContext;
 
   beforeEach(() => {
-    context = createTestHarness();
+    context = createTestHarness({ telemetryEnabled: true });
   });
 
   afterEach(() => {

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -263,7 +263,7 @@ describe('MCP Tool: knowledge-maintain', () => {
   };
 
   beforeEach(() => {
-    ctx = createTestHarness();
+    ctx = createTestHarness({ telemetryEnabled: true });
     ctx.engine.store('Pref 1', { title: 'P1', kind: 'personalization', status: 'permanent' });
     ctx.engine.store('Ref 1', { title: 'R1', kind: 'reference', status: 'fleeting' });
     ctx.engine.store('Dec 1', { title: 'D1', kind: 'decision', status: 'permanent' });

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -32,7 +32,7 @@ describe('schema.ts', () => {
     return Boolean(row);
   }
 
-  it('sets schema version 6 for a fresh database after initialize and repair', () => {
+  it('sets schema version 7 for a fresh database after initialize and repair', () => {
     const db = new Database(':memory:');
     const schema = new SchemaManager(db);
 
@@ -41,11 +41,11 @@ describe('schema.ts', () => {
 
     expect(result.valid).toBe(true);
     expect(result.needsRebuild).toBe(false);
-    expect(getUserVersion(db)).toBe(6);
+    expect(getUserVersion(db)).toBe(7);
     db.close();
   });
 
-  it('creates required tables notes, notes_fts, and note_links', () => {
+  it('creates required tables notes, notes_fts, note_links, and tool_telemetry', () => {
     const db = new Database(':memory:');
     const schema = new SchemaManager(db);
 
@@ -55,6 +55,7 @@ describe('schema.ts', () => {
     expect(tableExists(db, 'notes')).toBe(true);
     expect(tableExists(db, 'notes_fts')).toBe(true);
     expect(tableExists(db, 'note_links')).toBe(true);
+    expect(tableExists(db, 'tool_telemetry')).toBe(true);
     db.close();
   });
 
@@ -121,7 +122,7 @@ describe('schema.ts', () => {
 
     const columns = getColumns(db, 'notes');
     expect(columns).toContain('kind');
-    expect(getUserVersion(db)).toBe(6);
+    expect(getUserVersion(db)).toBe(7);
     db.close();
   });
 
@@ -156,7 +157,7 @@ describe('schema.ts', () => {
     const columns = getColumns(db, 'notes');
     expect(columns).toContain('summary');
     expect(columns).toContain('guidance');
-    expect(getUserVersion(db)).toBe(6);
+    expect(getUserVersion(db)).toBe(7);
     db.close();
   });
 
@@ -193,7 +194,7 @@ describe('schema.ts', () => {
     const columns = getColumns(db, 'notes');
     expect(columns).toContain('embedding');
     expect(columns).toContain('embedding_model');
-    expect(getUserVersion(db)).toBe(6);
+    expect(getUserVersion(db)).toBe(7);
     db.close();
   });
 
@@ -233,7 +234,7 @@ describe('schema.ts', () => {
     const columns = getColumns(db, 'notes');
     expect(columns).toContain('content_hash');
     expect(tableExists(db, 'capture_metrics')).toBe(false);
-    expect(getUserVersion(db)).toBe(6);
+    expect(getUserVersion(db)).toBe(7);
     db.close();
   });
 
@@ -272,7 +273,47 @@ describe('schema.ts', () => {
 
     const columns = getColumns(db, 'notes');
     expect(columns).toContain('lifecycle');
-    expect(getUserVersion(db)).toBe(6);
+    expect(getUserVersion(db)).toBe(7);
+    db.close();
+  });
+
+  it('migrates from v6 to v7: adds telemetry table and last_accessed_at when missing', () => {
+    const db = new Database(':memory:');
+
+    db.run(`
+      CREATE TABLE notes (
+        id TEXT PRIMARY KEY,
+        path TEXT UNIQUE,
+        title TEXT,
+        content TEXT,
+        kind TEXT DEFAULT 'observation',
+        status TEXT DEFAULT 'fleeting',
+        type TEXT DEFAULT 'atomic',
+        tags TEXT DEFAULT '[]',
+        context TEXT DEFAULT '',
+        created_at INTEGER,
+        updated_at INTEGER,
+        word_count INTEGER DEFAULT 0,
+        access_count INTEGER DEFAULT 0,
+        summary TEXT DEFAULT '',
+        guidance TEXT DEFAULT '',
+        embedding BLOB DEFAULT NULL,
+        embedding_model TEXT DEFAULT NULL,
+        content_hash TEXT DEFAULT NULL,
+        lifecycle TEXT DEFAULT 'living'
+      )
+    `);
+    db.run("CREATE VIRTUAL TABLE notes_fts USING fts5(note_id, title, content, tags, context, tokenize='porter')");
+    db.run('CREATE TABLE note_links (source_id TEXT, target_id TEXT, link_text TEXT, created_at INTEGER, PRIMARY KEY (source_id, target_id))');
+    db.run('PRAGMA user_version = 6');
+
+    const schema = new SchemaManager(db);
+    schema.checkAndRepair();
+
+    const columns = getColumns(db, 'notes');
+    expect(columns).toContain('last_accessed_at');
+    expect(tableExists(db, 'tool_telemetry')).toBe(true);
+    expect(getUserVersion(db)).toBe(7);
     db.close();
   });
 });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -115,8 +115,6 @@ describe('local tool telemetry', () => {
     expect(output).toContain('  Most-stored kind: observation (1)');
     expect(output).toContain('  Most-used action: stats (1)');
     expect(output).toContain('  Avg session duration:');
-    expect(output).toContain('  Search-to-store ratio interpretation:');
-    expect(output).toContain('    High capture (≥ 0.30): suggestions probably unnecessary');
-    expect(output).toContain('    Low capture (< 0.30):  detection-as-suggestion would help');
+    expect(output).not.toContain('interpretation');
   });
 });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { NoteRepository } from '../src/storage/NoteRepository.js';
+import { handleMaintain, handleSearch, handleStore } from '../src/tool-handlers.js';
+import type { AppConfig } from '../src/types.js';
+import { KIND_DEFAULT_LIFECYCLE } from '../src/types.js';
+
+interface TelemetryRow {
+  session_id: string;
+  tool_name: string;
+  arg_kind: string | null;
+  timestamp: number;
+  result_count: number | null;
+}
+
+class InspectableRepository extends NoteRepository {
+  telemetryRows(): TelemetryRow[] {
+    return this.db.prepare(`
+      SELECT session_id, tool_name, arg_kind, timestamp, result_count
+      FROM tool_telemetry
+      ORDER BY id
+    `).all() as TelemetryRow[];
+  }
+
+  setTelemetryTimestamp(index: number, timestamp: number): void {
+    const rows = this.db.prepare('SELECT id FROM tool_telemetry ORDER BY id').all() as Array<{ id: number }>;
+    const row = rows[index];
+    if (row) this.db.prepare('UPDATE tool_telemetry SET timestamp = ? WHERE id = ?').run(timestamp, row.id);
+  }
+
+  insertTelemetry(sessionId: string, toolName: string, argKind: string | null, timestamp: number, resultCount: number | null): void {
+    this.db.prepare(`
+      INSERT INTO tool_telemetry (session_id, tool_name, arg_kind, timestamp, result_count)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(sessionId, toolName, argKind, timestamp, resultCount);
+  }
+}
+
+interface TelemetryContext {
+  tempDir: string;
+  engine: InspectableRepository;
+  config: AppConfig;
+}
+
+function createTelemetryContext(telemetryEnabled: boolean = true): TelemetryContext {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-telemetry-test-'));
+  const config: AppConfig = {
+    logLevel: 'ERROR',
+    vault: tempDir,
+    lifecycle: {
+      reviewAfterDays: 14,
+      promotionThreshold: 2,
+      exemptKinds: ['personalization', 'decision'],
+      autoArchiveFleetingDays: 90,
+    },
+    lifecycleDefaults: {
+      defaultForKind: { ...KIND_DEFAULT_LIFECYCLE },
+      detectSnapshotFromSlug: true,
+    },
+    search: {
+      alwaysIncludeDomainNote: true,
+      excludeLogFromSearch: true,
+    },
+    navigation: {
+      enableProjectIndex: false,
+      enableProjectLog: false,
+      enableGlobalIndex: false,
+      enableGlobalLog: false,
+      enableReviewMoc: false,
+      mocSplitThreshold: 30,
+      mocPreviewCount: 5,
+      overviewLogEntryLimit: 10,
+    },
+    telemetry: {
+      enabled: telemetryEnabled,
+    },
+  };
+  return {
+    tempDir,
+    config,
+    engine: new InspectableRepository(tempDir, { telemetryEnabled }),
+  };
+}
+
+function cleanupTelemetryContext(ctx: TelemetryContext): void {
+  ctx.engine.close();
+  fs.rmSync(ctx.tempDir, { recursive: true, force: true });
+}
+
+describe('local tool telemetry', () => {
+  let ctx: TelemetryContext;
+
+  beforeEach(() => {
+    ctx = createTelemetryContext();
+  });
+
+  afterEach(() => {
+    cleanupTelemetryContext(ctx);
+  });
+
+  it('records counter rows with arg_kind and result_count for tool calls', async () => {
+    await handleStore({
+      title: 'Alpha Observation',
+      content: 'alpha telemetry content',
+      kind: 'observation',
+      summary: 'Alpha telemetry note',
+      guidance: 'Use as telemetry fixture',
+    }, ctx.engine, null, ctx.config);
+    handleSearch({ query: 'alpha' }, ctx.engine, null, ctx.config);
+    await handleMaintain({ action: 'stats' }, ctx.engine, ctx.config);
+
+    const rows = ctx.engine.telemetryRows();
+    expect(rows.map(row => row.tool_name)).toEqual(['store', 'search', 'maintain']);
+    expect(rows[0].arg_kind).toBe('observation');
+    expect(rows[0].result_count).toBe(1);
+    expect(rows[1].arg_kind).toBeNull();
+    expect(rows[1].result_count).toBe(1);
+    expect(rows[2].arg_kind).toBe('stats');
+    expect(rows[2].result_count).toBeNull();
+    expect(new Set(rows.map(row => row.session_id)).size).toBe(1);
+  });
+
+  it('updates last_accessed_at only for returned search results', () => {
+    const alpha = ctx.engine.store('alpha returned content', { title: 'Returned', kind: 'reference' });
+    const beta = ctx.engine.store('beta unrelated content', { title: 'Unrelated', kind: 'reference' });
+
+    handleSearch({ query: 'alpha' }, ctx.engine, null, ctx.config);
+
+    const accessed = ctx.engine.getById(alpha.id);
+    const unrelated = ctx.engine.getById(beta.id);
+    expect(accessed?.last_accessed_at).toBeNumber();
+    expect(accessed?.access_count).toBe(1);
+    expect(unrelated?.last_accessed_at).toBeNull();
+    expect(unrelated?.access_count).toBe(0);
+  });
+
+  it('disables telemetry rows and access tracking when opted out', () => {
+    cleanupTelemetryContext(ctx);
+    ctx = createTelemetryContext(false);
+    const stored = ctx.engine.store('private alpha content', { title: 'Private Alpha', kind: 'reference' });
+
+    handleSearch({ query: 'private alpha' }, ctx.engine, null, ctx.config);
+    ctx.engine.recordToolInvocation('store', 'reference', 1);
+    ctx.engine.updateLastAccessed([stored.id]);
+
+    expect(ctx.engine.telemetryRows()).toEqual([]);
+    const note = ctx.engine.getById(stored.id);
+    expect(note?.last_accessed_at).toBeNull();
+    expect(note?.access_count).toBe(0);
+  });
+
+  it('aggregates 30-day telemetry by session and stored kind', () => {
+    const now = Date.now();
+    const old = now - (31 * 24 * 60 * 60 * 1000);
+    ctx.engine.insertTelemetry('s1', 'search', null, now - 1000, 3);
+    ctx.engine.insertTelemetry('s1', 'store', 'observation', now - 500, 1);
+    ctx.engine.insertTelemetry('s2', 'store', 'observation', now - 400, 1);
+    ctx.engine.insertTelemetry('s2', 'store', 'decision', now - 300, 1);
+    ctx.engine.insertTelemetry('s2', 'maintain', 'stats', now - 200, null);
+    ctx.engine.insertTelemetry('old', 'search', null, old, 2);
+    ctx.engine.insertTelemetry('old', 'store', 'resource', old, 1);
+
+    const aggregates = ctx.engine.getTelemetryAggregates(30);
+
+    expect(aggregates.sessions).toBe(2);
+    expect(aggregates.searches).toBe(1);
+    expect(aggregates.stores).toBe(3);
+    expect(aggregates.maintains).toBe(1);
+    expect(aggregates.storesByKind).toEqual({ observation: 2, decision: 1 });
+    expect(aggregates.sessionDurations.length).toBe(2);
+  });
+
+  it('returns sensible zero aggregates for empty telemetry', () => {
+    expect(ctx.engine.getTelemetryAggregates(30)).toEqual({
+      sessions: 0,
+      searches: 0,
+      stores: 0,
+      maintains: 0,
+      storesByKind: {},
+      sessionDurations: [],
+    });
+  });
+
+  it('appends stats telemetry output with the expected shape', async () => {
+    ctx.engine.insertTelemetry('s1', 'search', null, Date.now() - 1000, 2);
+    ctx.engine.insertTelemetry('s1', 'store', 'observation', Date.now() - 500, 1);
+
+    const output = await handleMaintain({ action: 'stats', telemetry: true }, ctx.engine, ctx.config);
+
+    expect(output).toContain('Last 30 days (2 sessions):');
+    expect(output).toContain('  Searches: 1 (avg 0.5 per session)');
+    expect(output).toContain('  Stores: 1 (avg 0.5 per session)');
+    expect(output).toContain('  Store / search ratio: 1.00');
+    expect(output).toContain('  Most-stored kind: observation (1)');
+    expect(output).toContain('  Search-to-store ratio interpretation:');
+    expect(output).toContain('    High capture (≥ 0.30): suggestions probably unnecessary');
+    expect(output).toContain('    Low capture (< 0.30):  detection-as-suggestion would help');
+  });
+});

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,103 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { NoteRepository } from '../src/storage/NoteRepository.js';
 import { handleMaintain, handleSearch, handleStore } from '../src/tool-handlers.js';
-import type { AppConfig } from '../src/types.js';
-import { KIND_DEFAULT_LIFECYCLE } from '../src/types.js';
-
-interface TelemetryRow {
-  session_id: string;
-  tool_name: string;
-  arg_kind: string | null;
-  timestamp: number;
-  result_count: number | null;
-}
-
-class InspectableRepository extends NoteRepository {
-  telemetryRows(): TelemetryRow[] {
-    return this.db.prepare(`
-      SELECT session_id, tool_name, arg_kind, timestamp, result_count
-      FROM tool_telemetry
-      ORDER BY id
-    `).all() as TelemetryRow[];
-  }
-
-  setTelemetryTimestamp(index: number, timestamp: number): void {
-    const rows = this.db.prepare('SELECT id FROM tool_telemetry ORDER BY id').all() as Array<{ id: number }>;
-    const row = rows[index];
-    if (row) this.db.prepare('UPDATE tool_telemetry SET timestamp = ? WHERE id = ?').run(timestamp, row.id);
-  }
-
-  insertTelemetry(sessionId: string, toolName: string, argKind: string | null, timestamp: number, resultCount: number | null): void {
-    this.db.prepare(`
-      INSERT INTO tool_telemetry (session_id, tool_name, arg_kind, timestamp, result_count)
-      VALUES (?, ?, ?, ?, ?)
-    `).run(sessionId, toolName, argKind, timestamp, resultCount);
-  }
-}
-
-interface TelemetryContext {
-  tempDir: string;
-  engine: InspectableRepository;
-  config: AppConfig;
-}
-
-function createTelemetryContext(telemetryEnabled: boolean = true): TelemetryContext {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-telemetry-test-'));
-  const config: AppConfig = {
-    logLevel: 'ERROR',
-    vault: tempDir,
-    lifecycle: {
-      reviewAfterDays: 14,
-      promotionThreshold: 2,
-      exemptKinds: ['personalization', 'decision'],
-      autoArchiveFleetingDays: 90,
-    },
-    lifecycleDefaults: {
-      defaultForKind: { ...KIND_DEFAULT_LIFECYCLE },
-      detectSnapshotFromSlug: true,
-    },
-    search: {
-      alwaysIncludeDomainNote: true,
-      excludeLogFromSearch: true,
-    },
-    navigation: {
-      enableProjectIndex: false,
-      enableProjectLog: false,
-      enableGlobalIndex: false,
-      enableGlobalLog: false,
-      enableReviewMoc: false,
-      mocSplitThreshold: 30,
-      mocPreviewCount: 5,
-      overviewLogEntryLimit: 10,
-    },
-    telemetry: {
-      enabled: telemetryEnabled,
-    },
-  };
-  return {
-    tempDir,
-    config,
-    engine: new InspectableRepository(tempDir, { telemetryEnabled }),
-  };
-}
-
-function cleanupTelemetryContext(ctx: TelemetryContext): void {
-  ctx.engine.close();
-  fs.rmSync(ctx.tempDir, { recursive: true, force: true });
-}
+import { cleanupTestHarness, createTestHarness, sleep, type TestContext } from './harness.js';
 
 describe('local tool telemetry', () => {
-  let ctx: TelemetryContext;
+  let ctx: TestContext;
 
   beforeEach(() => {
-    ctx = createTelemetryContext();
+    ctx = createTestHarness({ telemetryEnabled: true });
   });
 
   afterEach(() => {
-    cleanupTelemetryContext(ctx);
+    cleanupTestHarness(ctx);
   });
 
   it('records counter rows with arg_kind and result_count for tool calls', async () => {
@@ -110,8 +23,9 @@ describe('local tool telemetry', () => {
     }, ctx.engine, null, ctx.config);
     handleSearch({ query: 'alpha' }, ctx.engine, null, ctx.config);
     await handleMaintain({ action: 'stats' }, ctx.engine, ctx.config);
+    await sleep(0);
 
-    const rows = ctx.engine.telemetryRows();
+    const rows = ctx.engine.getTelemetryRows();
     expect(rows.map(row => row.tool_name)).toEqual(['store', 'search', 'maintain']);
     expect(rows[0].arg_kind).toBe('observation');
     expect(rows[0].result_count).toBe(1);
@@ -122,11 +36,12 @@ describe('local tool telemetry', () => {
     expect(new Set(rows.map(row => row.session_id)).size).toBe(1);
   });
 
-  it('updates last_accessed_at only for returned search results', () => {
+  it('updates last_accessed_at only for returned search results', async () => {
     const alpha = ctx.engine.store('alpha returned content', { title: 'Returned', kind: 'reference' });
     const beta = ctx.engine.store('beta unrelated content', { title: 'Unrelated', kind: 'reference' });
 
     handleSearch({ query: 'alpha' }, ctx.engine, null, ctx.config);
+    await sleep(0);
 
     const accessed = ctx.engine.getById(alpha.id);
     const unrelated = ctx.engine.getById(beta.id);
@@ -137,39 +52,40 @@ describe('local tool telemetry', () => {
   });
 
   it('disables telemetry rows and access tracking when opted out', () => {
-    cleanupTelemetryContext(ctx);
-    ctx = createTelemetryContext(false);
+    cleanupTestHarness(ctx);
+    ctx = createTestHarness({ telemetryEnabled: false });
     const stored = ctx.engine.store('private alpha content', { title: 'Private Alpha', kind: 'reference' });
 
     handleSearch({ query: 'private alpha' }, ctx.engine, null, ctx.config);
     ctx.engine.recordToolInvocation('store', 'reference', 1);
     ctx.engine.updateLastAccessed([stored.id]);
 
-    expect(ctx.engine.telemetryRows()).toEqual([]);
+    expect(ctx.engine.getTelemetryRows()).toEqual([]);
     const note = ctx.engine.getById(stored.id);
     expect(note?.last_accessed_at).toBeNull();
     expect(note?.access_count).toBe(0);
   });
 
-  it('aggregates 30-day telemetry by session and stored kind', () => {
-    const now = Date.now();
-    const old = now - (31 * 24 * 60 * 60 * 1000);
-    ctx.engine.insertTelemetry('s1', 'search', null, now - 1000, 3);
-    ctx.engine.insertTelemetry('s1', 'store', 'observation', now - 500, 1);
-    ctx.engine.insertTelemetry('s2', 'store', 'observation', now - 400, 1);
-    ctx.engine.insertTelemetry('s2', 'store', 'decision', now - 300, 1);
-    ctx.engine.insertTelemetry('s2', 'maintain', 'stats', now - 200, null);
-    ctx.engine.insertTelemetry('old', 'search', null, old, 2);
-    ctx.engine.insertTelemetry('old', 'store', 'resource', old, 1);
+  it('aggregates 30-day telemetry by session, stored kind, and maintain action', async () => {
+    ctx.engine.recordToolInvocation('search', undefined, 3);
+    await sleep(2);
+    ctx.engine.recordToolInvocation('store', 'observation', 1);
+    ctx.engine.recordToolInvocation('store', 'observation', 1);
+    ctx.engine.recordToolInvocation('store', 'decision', 1);
+    ctx.engine.recordToolInvocation('maintain', 'stats');
+    ctx.engine.recordToolInvocation('maintain', 'stats');
+    ctx.engine.recordToolInvocation('maintain', 'review');
 
     const aggregates = ctx.engine.getTelemetryAggregates(30);
 
-    expect(aggregates.sessions).toBe(2);
+    expect(aggregates.sessions).toBe(1);
     expect(aggregates.searches).toBe(1);
     expect(aggregates.stores).toBe(3);
-    expect(aggregates.maintains).toBe(1);
+    expect(aggregates.maintains).toBe(3);
     expect(aggregates.storesByKind).toEqual({ observation: 2, decision: 1 });
-    expect(aggregates.sessionDurations.length).toBe(2);
+    expect(aggregates.maintainByAction).toEqual({ stats: 2, review: 1 });
+    expect(aggregates.sessionDurations.length).toBe(1);
+    expect(aggregates.sessionDurations[0]).toBeGreaterThanOrEqual(0);
   });
 
   it('returns sensible zero aggregates for empty telemetry', () => {
@@ -179,21 +95,26 @@ describe('local tool telemetry', () => {
       stores: 0,
       maintains: 0,
       storesByKind: {},
+      maintainByAction: {},
       sessionDurations: [],
     });
   });
 
   it('appends stats telemetry output with the expected shape', async () => {
-    ctx.engine.insertTelemetry('s1', 'search', null, Date.now() - 1000, 2);
-    ctx.engine.insertTelemetry('s1', 'store', 'observation', Date.now() - 500, 1);
+    ctx.engine.recordToolInvocation('search', undefined, 2);
+    await sleep(2);
+    ctx.engine.recordToolInvocation('store', 'observation', 1);
+    ctx.engine.recordToolInvocation('maintain', 'stats');
 
     const output = await handleMaintain({ action: 'stats', telemetry: true }, ctx.engine, ctx.config);
 
-    expect(output).toContain('Last 30 days (2 sessions):');
-    expect(output).toContain('  Searches: 1 (avg 0.5 per session)');
-    expect(output).toContain('  Stores: 1 (avg 0.5 per session)');
+    expect(output).toContain('Last 30 days (1 sessions):');
+    expect(output).toContain('  Searches: 1 (avg 1 per session)');
+    expect(output).toContain('  Stores: 1 (avg 1 per session)');
     expect(output).toContain('  Store / search ratio: 1.00');
     expect(output).toContain('  Most-stored kind: observation (1)');
+    expect(output).toContain('  Most-used action: stats (1)');
+    expect(output).toContain('  Avg session duration:');
     expect(output).toContain('  Search-to-store ratio interpretation:');
     expect(output).toContain('    High capture (≥ 0.30): suggestions probably unnecessary');
     expect(output).toContain('    Low capture (< 0.30):  detection-as-suggestion would help');


### PR DESCRIPTION
## Summary
- Add schema v7 with local `tool_telemetry` storage, indexes, and `last_accessed_at` migration safety.
- Record search/store/maintain tool invocation counters, update access metadata on search results, and expose 30-day telemetry aggregates via `knowledge-maintain stats` with `telemetry: true`.
- Add `telemetry.enabled` config flag (**disabled by default; opt-in via `telemetry.enabled: true`**), coverage for counters/aggregation/access tracking/opt-in/opt-out, and privacy documentation.

Closes #106

## Privacy posture
**Disabled by default — opt-in only.** Users get zero recording out of the box. Telemetry is local-only SQLite metadata and even when enabled it does **not** record:
- Note content
- Note bodies
- Search query strings
- Search result snippets
- File paths
- User identifiers, client identifiers, hostnames, or account names
- API keys, tokens, credentials, or other secrets

Comprehensive opt-out: `telemetry.enabled: false` (the default) disables both `tool_telemetry` rows and access metadata (`last_accessed_at` / `access_count`) because access timestamps are privacy-sensitive metadata.

> **Note**: This deviates from issue #106's original spec (which proposed `default: true`). Updated to `default: false` to align with the project's privacy-first posture — users explicitly enable telemetry when they want to inform decisions like #88 Phase 2. Issue body updated to match.

## Schema migration
- Bumps SQLite schema v6 → v7.
- Adds `tool_telemetry` plus timestamp/session indexes.
- Backward compatible for existing v6 databases; adds `last_accessed_at` if absent and indexes it.

## Test results
- `bun run build`: pass
- `bun run lint`: pass
- `bun test`: 772 pass, 39 skip, 0 fail
- LSP diagnostics: clean on changed files
- Manual checks: fresh DB v7 creation, v6 → v7 upgrade, opt-out (default) no-op recording, opt-in counter accuracy, and stats output shape verified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in local telemetry for tool invocation stats (disabled by default); maintenance stats now show 30-day telemetry aggregates.

* **Documentation**
  * Configuration guide and examples updated to document the telemetry option and behavior.

* **Database / Schema**
  * Migration adds local telemetry storage and last-access tracking fields.

* **Tests**
  * New telemetry test suite and updates to existing tests to cover telemetry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->