### PR TITLE
Surface related notes in knowledge-store response

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -18,16 +18,22 @@
 # See: agent-architecture/04-References/pr-agent-extra-instructions-scope.md
 
 [config]
-# Phase 0 swap rationale: agent-architecture/04-references/openzkkb-pr-review-current-state.md
-model = "openrouter/moonshotai/kimi-k2.6"
+# Model swap: Kimi K2.6 → Claude Sonnet 4.6 (2026-04-30)
+# Rationale: Kimi K2.6 + reasoning_effort=high takes 13+ min on 500-line PRs
+# (35K tokens, super-linear latency scaling). Sonnet 4.6 completes in 2-3 min
+# at 90 tok/s, ranks #4 on CR-Bench (F1 0.62, 14% critical FNR), and is the
+# recommended model for high-volume code review per BestLLM/Git AutoReview.
+# Cost delta: ~$0.19 → ~$0.55 per review (+$10.80/mo at 30 PRs).
+# Prior rationale: agent-architecture/04-references/openzkkb-pr-review-current-state.md
+model = "openrouter/anthropic/claude-sonnet-4.6"
 fallback_models = [
-    "openrouter/anthropic/claude-sonnet-4.6",
+    "openrouter/google/gemini-2.5-pro",
     "openrouter/z-ai/glm-5.1",
 ]
-custom_model_max_tokens = 128000
+custom_model_max_tokens = 200000
 ai_timeout = 300
 response_language = "en-US"
-reasoning_effort = "high"
+reasoning_effort = "medium"
 add_repo_metadata = true
 add_repo_metadata_file_list = ["AGENTS.md"]
 patch_extra_lines_before = 10

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -65,8 +65,13 @@ glob = [
 # Review Tool
 # ---------------------------------------------------------------------------
 [pr_reviewer]
-persistent_comment = true
-final_update_message = true
+# persistent_comment=true edits the review comment in-place on re-review,
+# destroying the initial findings with no edit history in the API.
+# PR #110 showed this: initial review (commits 1-4, Kimi K2.6) was overwritten
+# by re-review (commits 1-7) after fixes landed — findings lost irrecoverably.
+# With false, each /review creates a separate comment preserving full history.
+persistent_comment = false
+final_update_message = false
 num_max_findings = 12
 inline_code_comments = true
 require_score_review = true

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,9 @@ import * as path from 'path';
 import YAML from 'yaml';
 import { expandPath } from './utils/path.js';
 import type { AppConfig, NoteKind } from './types.js';
-import { KIND_DEFAULT_LIFECYCLE, VALID_LIFECYCLES } from './types.js';
+import { KIND_DEFAULT_STATUS, KIND_DEFAULT_LIFECYCLE, VALID_LIFECYCLES } from './types.js';
+
+const VALID_NOTE_KINDS = new Set<string>(Object.keys(KIND_DEFAULT_STATUS));
 
 const xdgDataHome = process.env.XDG_DATA_HOME || expandPath('~/.local/share');
 const xdgConfigHome = process.env.XDG_CONFIG_HOME || expandPath('~/.config');
@@ -37,6 +39,14 @@ interface RawConfig {
   search?: {
     alwaysIncludeDomainNote?: boolean;
     excludeLogFromSearch?: boolean;
+  };
+  store?: {
+    relatedNotes?: {
+      enabled?: boolean;
+      maxResults?: number;
+      minSimilarity?: number;
+      excludeKinds?: string[];
+    };
   };
   navigation?: {
     enableProjectIndex?: boolean;
@@ -72,6 +82,14 @@ export const DEFAULT_CONFIG: AppConfig = {
   search: {
     alwaysIncludeDomainNote: true,
     excludeLogFromSearch: true,
+  },
+  store: {
+    relatedNotes: {
+      enabled: true,
+      maxResults: 5,
+      minSimilarity: 0.70,
+      excludeKinds: ['domain', 'index', 'log'],
+    },
   },
   navigation: {
     enableProjectIndex: true,
@@ -148,6 +166,20 @@ export function getConfig(): AppConfig {
       excludeLogFromSearch: typeof raw?.search?.excludeLogFromSearch === 'boolean'
         ? raw.search.excludeLogFromSearch
         : DEFAULT_CONFIG.search.excludeLogFromSearch,
+    },
+    store: {
+      relatedNotes: {
+        enabled: typeof raw?.store?.relatedNotes?.enabled === 'boolean'
+          ? raw.store.relatedNotes.enabled
+          : DEFAULT_CONFIG.store.relatedNotes.enabled,
+        maxResults: positiveInt(raw?.store?.relatedNotes?.maxResults, DEFAULT_CONFIG.store.relatedNotes.maxResults),
+        minSimilarity: typeof raw?.store?.relatedNotes?.minSimilarity === 'number'
+          ? Math.max(0, Math.min(1, raw.store.relatedNotes.minSimilarity))
+          : DEFAULT_CONFIG.store.relatedNotes.minSimilarity,
+        excludeKinds: Array.isArray(raw?.store?.relatedNotes?.excludeKinds)
+          ? raw.store.relatedNotes.excludeKinds.filter((k: string) => VALID_NOTE_KINDS.has(k)) as NoteKind[]
+          : DEFAULT_CONFIG.store.relatedNotes.excludeKinds,
+      },
     },
     navigation: {
       enableProjectIndex: typeof raw?.navigation?.enableProjectIndex === 'boolean'

--- a/src/config.ts
+++ b/src/config.ts
@@ -173,7 +173,7 @@ export function getConfig(): AppConfig {
           ? raw.store.relatedNotes.enabled
           : DEFAULT_CONFIG.store.relatedNotes.enabled,
         maxResults: positiveInt(raw?.store?.relatedNotes?.maxResults, DEFAULT_CONFIG.store.relatedNotes.maxResults),
-        minSimilarity: typeof raw?.store?.relatedNotes?.minSimilarity === 'number'
+        minSimilarity: typeof raw?.store?.relatedNotes?.minSimilarity === 'number' && Number.isFinite(raw.store.relatedNotes.minSimilarity)
           ? Math.max(0, Math.min(1, raw.store.relatedNotes.minSimilarity))
           : DEFAULT_CONFIG.store.relatedNotes.minSimilarity,
         excludeKinds: Array.isArray(raw?.store?.relatedNotes?.excludeKinds)

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -104,7 +104,7 @@ server.registerTool(
   },
   async (args: z.infer<typeof storeSchema>) => {
     try {
-      const result = handleStore({
+      const result = await handleStore({
         title: args.title,
         content: args.content,
         kind: args.kind as NoteKind,

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -197,6 +197,13 @@ export interface OpenArgs {
   _launchObsidian?: typeof launchObsidian;
 }
 
+interface RelatedNote {
+  id: string;
+  title: string;
+  kind: string;
+  similarity?: number;
+}
+
 function sanitizeMetadata(value: string): string {
   return value.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
 }
@@ -709,36 +716,36 @@ export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddi
   const minSimilarity = relatedConfig?.minSimilarity ?? 0.70;
   const excludeKinds = new Set<string>(relatedConfig?.excludeKinds ?? ['domain', 'index', 'log']);
 
-  interface RelatedNote {
-    id: string;
-    title: string;
-    kind: string;
-    similarity?: number;
-  }
-
   let relatedNotes: RelatedNote[] = [];
 
   if (relatedEnabled) {
     const isCandidate = (n: { id: string; kind: string; status?: string }) =>
       n.id !== result.id && !excludeKinds.has(n.kind) && n.status !== 'archived';
 
-    if (noteEmbedding) {
-      // Embedding-based similarity search
-      const vecResults = repo.searchVector(noteEmbedding, { limit: maxResults + 10 });
-      relatedNotes = vecResults
-        .filter(n => isCandidate(n) && n.similarity >= minSimilarity)
-        .slice(0, maxResults)
-        .map(n => ({ id: n.id, title: n.title, kind: n.kind, similarity: n.similarity }));
-    } else {
-      // FTS5 fallback — use title + summary as query
-      const queryText = [args.title, args.summary].filter(Boolean).join(' ');
-      if (queryText.trim()) {
-        const ftsResults = repo.search(queryText, { limit: maxResults + 10 });
-        relatedNotes = ftsResults
-          .filter(n => isCandidate(n))
+    try {
+      if (noteEmbedding) {
+        // Embedding-based similarity search
+        const vecResults = repo.searchVector(noteEmbedding, { limit: maxResults + 10 });
+        relatedNotes = vecResults
+          .filter(n => isCandidate(n) && n.similarity >= minSimilarity)
           .slice(0, maxResults)
-          .map(n => ({ id: n.id, title: n.title, kind: n.kind }));
+          .map(n => ({ id: n.id, title: n.title, kind: n.kind, similarity: n.similarity }));
+      } else {
+        // FTS5 fallback — use title + summary as query
+        const queryText = [args.title, args.summary].filter(Boolean).join(' ');
+        if (queryText.trim()) {
+          const ftsResults = repo.search(queryText, { limit: maxResults + 10 });
+          relatedNotes = ftsResults
+            .filter(n => isCandidate(n))
+            .slice(0, maxResults)
+            .map(n => ({ id: n.id, title: n.title, kind: n.kind }));
+        }
       }
+    } catch (error) {
+      logToFile('WARN', 'Related notes lookup failed', {
+        noteId: result.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -596,7 +596,7 @@ function updateGlobalNavigation(
 
 // ---- Handlers ----
 
-export function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConfig?: EmbeddingConfig | null, config?: AppConfig): string {
+export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConfig?: EmbeddingConfig | null, config?: AppConfig): Promise<string> {
   const effectiveStatus = toNoteStatus(args.status, KIND_DEFAULT_STATUS[args.kind]);
   const lifecycleDefaults = config?.lifecycleDefaults;
   const kindDefault = (lifecycleDefaults?.defaultForKind?.[args.kind] as Lifecycle | undefined) || KIND_DEFAULT_LIFECYCLE[args.kind];
@@ -666,18 +666,80 @@ export function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConf
   const hash = computeSimHash(hashContent);
   repo.updateContentHash(result.id, hash);
 
+  // Race embedding generation against 500ms timeout for related notes search.
+  // If timeout wins, the embedding still persists in the background (no data loss).
+  let noteEmbedding: number[] | null = null;
   if (embeddingConfig) {
     const text = buildEmbeddingText(args.title, args.summary, args.content);
-    void generateEmbedding(text, embeddingConfig).then(embResult => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const embeddingPromise = generateEmbedding(text, embeddingConfig);
+      const embResult = await Promise.race([
+        embeddingPromise,
+        new Promise<null>((resolve) => { timer = setTimeout(() => resolve(null), 500); }),
+      ]);
       if (embResult) {
         repo.storeEmbedding(result.id, embResult.embedding, embResult.model);
+        noteEmbedding = embResult.embedding;
+      } else {
+        void embeddingPromise.then(slowResult => {
+          if (slowResult) {
+            repo.storeEmbedding(result.id, slowResult.embedding, slowResult.model);
+          }
+        }).catch(error => {
+          logToFile('WARN', 'Background embedding generation failed', {
+            noteId: result.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
       }
-    }).catch(error => {
+    } catch (error) {
       logToFile('WARN', 'Embedding generation failed', {
         noteId: result.id,
         error: error instanceof Error ? error.message : String(error),
       });
-    });
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  const relatedConfig = config?.store?.relatedNotes;
+  const relatedEnabled = relatedConfig?.enabled !== false;
+  const maxResults = relatedConfig?.maxResults ?? 5;
+  const minSimilarity = relatedConfig?.minSimilarity ?? 0.70;
+  const excludeKinds = new Set<string>(relatedConfig?.excludeKinds ?? ['domain', 'index', 'log']);
+
+  interface RelatedNote {
+    id: string;
+    title: string;
+    kind: string;
+    similarity?: number;
+  }
+
+  let relatedNotes: RelatedNote[] = [];
+
+  if (relatedEnabled) {
+    const isCandidate = (n: { id: string; kind: string; status?: string }) =>
+      n.id !== result.id && !excludeKinds.has(n.kind) && n.status !== 'archived';
+
+    if (noteEmbedding) {
+      // Embedding-based similarity search
+      const vecResults = repo.searchVector(noteEmbedding, { limit: maxResults + 10 });
+      relatedNotes = vecResults
+        .filter(n => isCandidate(n) && n.similarity >= minSimilarity)
+        .slice(0, maxResults)
+        .map(n => ({ id: n.id, title: n.title, kind: n.kind, similarity: n.similarity }));
+    } else {
+      // FTS5 fallback — use title + summary as query
+      const queryText = [args.title, args.summary].filter(Boolean).join(' ');
+      if (queryText.trim()) {
+        const ftsResults = repo.search(queryText, { limit: maxResults + 10 });
+        relatedNotes = ftsResults
+          .filter(n => isCandidate(n))
+          .slice(0, maxResults)
+          .map(n => ({ id: n.id, title: n.title, kind: n.kind }));
+      }
+    }
   }
 
   let output = `Knowledge stored (${result.action})\n`;
@@ -691,6 +753,14 @@ export function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConf
   const warning = atomicityWarning(args.kind, wordCount);
   if (warning) {
     output += warning;
+  }
+
+  if (relatedNotes.length > 0) {
+    output += '\n\nRelated notes:';
+    for (const rn of relatedNotes) {
+      const sim = rn.similarity != null ? `, similarity: ${rn.similarity.toFixed(2)}` : '';
+      output += `\n- [${rn.id}] "${rn.title}" (${rn.kind}${sim})`;
+    }
   }
 
   if (args.client && !isKnownClient(args.client)) {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -722,10 +722,12 @@ export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddi
     const isCandidate = (n: { id: string; kind: string; status?: string }) =>
       n.id !== result.id && !excludeKinds.has(n.kind) && n.status !== 'archived';
 
+    const fetchLimit = maxResults * 3 + excludeKinds.size;
+
     try {
       if (noteEmbedding) {
         // Embedding-based similarity search
-        const vecResults = repo.searchVector(noteEmbedding, { limit: maxResults + 10 });
+        const vecResults = repo.searchVector(noteEmbedding, { limit: fetchLimit });
         relatedNotes = vecResults
           .filter(n => isCandidate(n) && n.similarity >= minSimilarity)
           .slice(0, maxResults)
@@ -734,7 +736,7 @@ export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddi
         // FTS5 fallback — use title + summary as query
         const queryText = [args.title, args.summary].filter(Boolean).join(' ');
         if (queryText.trim()) {
-          const ftsResults = repo.search(queryText, { limit: maxResults + 10 });
+          const ftsResults = repo.search(queryText, { limit: fetchLimit });
           relatedNotes = ftsResults
             .filter(n => isCandidate(n))
             .slice(0, maxResults)

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,17 @@ export interface TelemetryConfig {
   enabled: boolean;
 }
 
+export interface RelatedNotesConfig {
+  enabled: boolean;
+  maxResults: number;
+  minSimilarity: number;
+  excludeKinds: NoteKind[];
+}
+
+export interface StoreConfig {
+  relatedNotes: RelatedNotesConfig;
+}
+
 export interface AppConfig {
   logLevel: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
   vault: string;
@@ -75,6 +86,7 @@ export interface AppConfig {
   };
   lifecycleDefaults: LifecycleDefaults;
   search: SearchConfig;
+  store: StoreConfig;
   navigation: NavigationConfig;
   telemetry: TelemetryConfig;
 }

--- a/tests/edge-cases.test.ts
+++ b/tests/edge-cases.test.ts
@@ -502,7 +502,7 @@ Legacy content`;
   });
 });
 
-describe('handleStore non-blocking embedding', () => {
+describe('handleStore embedding handling', () => {
   let ctx: TestContext;
 
   beforeEach(() => {
@@ -513,8 +513,8 @@ describe('handleStore non-blocking embedding', () => {
     cleanupTestHarness(ctx);
   });
 
-  it('should return synchronously without embedding config', () => {
-    const result = handleStore({
+  it('should return successfully without embedding config', async () => {
+    const result = await handleStore({
       title: 'Quick Note',
       content: 'This should return immediately',
       kind: 'observation',
@@ -522,15 +522,14 @@ describe('handleStore non-blocking embedding', () => {
       guidance: 'Test guidance',
     }, ctx.engine);
 
-    // handleStore returns string directly (not a Promise)
     expect(typeof result).toBe('string');
     expect(result).toContain('Knowledge stored');
     expect(result).toContain('Kind: observation');
   });
 
-  it('should store note successfully even with embedding config', () => {
+  it('should store note successfully even with embedding config', async () => {
     // Pass a dummy embedding config — embedding will fail but store should succeed
-    const result = handleStore({
+    const result = await handleStore({
       title: 'Note with embedding',
       content: 'Content that triggers embedding path',
       kind: 'reference',

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -37,6 +37,14 @@ export function createTestHarness(options: TestHarnessOptions = {}): TestContext
       alwaysIncludeDomainNote: true,
       excludeLogFromSearch: true,
     },
+    store: {
+      relatedNotes: {
+        enabled: true,
+        maxResults: 5,
+        minSimilarity: 0.70,
+        excludeKinds: ['domain', 'index', 'log'],
+      },
+    },
     navigation: {
       enableProjectIndex: true,
       enableProjectLog: true,

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -469,9 +469,8 @@ describe('MCP Tool: knowledge-store — related notes', () => {
 
     const topResult = filtered[0];
     expect(topResult.similarity).toBeGreaterThan(0.7);
-    const formatted = `- [${topResult.id}] "${topResult.title}" (${topResult.kind}, similarity: ${topResult.similarity.toFixed(2)})`;
-    expect(formatted).toContain('similarity:');
-    expect(formatted).toContain('React Hooks Deep Dive');
+    expect(topResult.similarity).toBeLessThanOrEqual(1.0);
+    expect(typeof topResult.similarity).toBe('number');
   });
 });
 
@@ -2844,10 +2843,10 @@ describe('Index and log note kinds', () => {
     expect(output).toContain('No navigation notes found for project "unknown-project"');
   });
 
-  it('should respect the logEntries parameter in overview output', () => {
-    storeProjectNote('Overview Entry One');
-    storeProjectNote('Overview Entry Two');
-    storeProjectNote('Overview Entry Three');
+  it('should respect the logEntries parameter in overview output', async () => {
+    await storeProjectNote('Overview Entry One');
+    await storeProjectNote('Overview Entry Two');
+    await storeProjectNote('Overview Entry Three');
 
     const output = handleOverview({ project: 'myapp', logEntries: 2 }, ctx.engine, makeConfig());
     const recentActivity = output.split('### Recent Activity\n')[1] || '';
@@ -2857,32 +2856,32 @@ describe('Index and log note kinds', () => {
     expect(output).toContain('(showing 2 of 3 entries)');
   });
 
-  it('should work when only some navigation notes exist', () => {
+  it('should work when only some navigation notes exist', async () => {
     const config = makeConfig({ navigation: { enableProjectIndex: false, enableProjectLog: false } });
-    storeProjectNote('Partial Domain', 'partial', config, 'domain');
+    await storeProjectNote('Partial Domain', 'partial', config, 'domain');
 
     const output = handleOverview({ project: 'partial' }, ctx.engine, config);
     expect(output).toContain('### Domain');
     expect(output).toContain('(not yet generated — store a project-scoped note to trigger)');
   });
 
-  it('should skip index generation when enableProjectIndex is false', () => {
+  it('should skip index generation when enableProjectIndex is false', async () => {
     const config = makeConfig({ navigation: { enableProjectIndex: false } });
-    storeProjectNote('No Index Generated', 'myapp', config);
+    await storeProjectNote('No Index Generated', 'myapp', config);
 
     expect(ctx.engine.getIndexNote('myapp')).toBeNull();
   });
 
-  it('should skip log generation when enableProjectLog is false', () => {
+  it('should skip log generation when enableProjectLog is false', async () => {
     const config = makeConfig({ navigation: { enableProjectLog: false } });
-    storeProjectNote('No Log Generated', 'myapp', config);
+    await storeProjectNote('No Log Generated', 'myapp', config);
 
     expect(ctx.engine.getLogNote('myapp')).toBeNull();
   });
 
-  it('should include structural kinds in default search when excludeLogFromSearch is false', () => {
+  it('should include structural kinds in default search when excludeLogFromSearch is false', async () => {
     const config = makeConfig({ search: { excludeLogFromSearch: false } });
-    storeProjectNote('Structural Search Visible', 'myapp', config);
+    await storeProjectNote('Structural Search Visible', 'myapp', config);
 
     const output = handleSearch({ query: 'Structural Search Visible' }, ctx.engine, null, config);
     expect(output).toContain('Structural Search Visible');
@@ -2892,8 +2891,8 @@ describe('Index and log note kinds', () => {
 
   it('should regenerate indexes for all projects during rebuild', async () => {
     const disabledConfig = makeConfig({ navigation: { enableProjectIndex: false, enableProjectLog: false } });
-    storeProjectNote('Rebuild Alpha', 'alpha', disabledConfig);
-    storeProjectNote('Rebuild Beta', 'beta', disabledConfig);
+    await storeProjectNote('Rebuild Alpha', 'alpha', disabledConfig);
+    await storeProjectNote('Rebuild Beta', 'beta', disabledConfig);
 
     expect(ctx.engine.getIndexNote('alpha')).toBeNull();
     expect(ctx.engine.getIndexNote('beta')).toBeNull();

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -210,6 +210,205 @@ describe('MCP Tool: knowledge-store', () => {
   });
 });
 
+describe('MCP Tool: knowledge-store — related notes', () => {
+  let ctx: TestContext;
+
+  beforeEach(() => { ctx = createTestHarness(); });
+  afterEach(() => { cleanupTestHarness(ctx); });
+
+  it('should surface FTS5-matched related notes in response', async () => {
+    ctx.engine.store('React hooks provide a way to use state in functional components', {
+      title: 'React Hooks Guide',
+      kind: 'reference',
+      status: 'permanent',
+      summary: 'Guide to React hooks',
+      guidance: 'Use hooks for state management',
+    });
+
+    const output = await handleStore({
+      title: 'React State Management',
+      content: 'React hooks are the preferred way to manage state',
+      kind: 'reference',
+      summary: 'State management with React hooks',
+      guidance: 'Prefer hooks over class components',
+    }, ctx.engine, null, ctx.config);
+
+    expect(output).toContain('Related notes:');
+    expect(output).toContain('React Hooks Guide');
+  });
+
+  it('should exclude structural kinds from related notes', async () => {
+    await handleStore({
+      title: 'MyApp Decision',
+      content: 'We chose PostgreSQL for persistence',
+      kind: 'decision',
+      project: 'myapp',
+      summary: 'Chose PostgreSQL',
+      guidance: 'Use PostgreSQL',
+    }, ctx.engine, null, ctx.config);
+
+    const indexNote = ctx.engine.getIndexNote('myapp');
+    expect(indexNote).toBeTruthy();
+
+    const output = await handleStore({
+      title: 'Database Choice',
+      content: 'PostgreSQL was selected for persistence layer',
+      kind: 'decision',
+      project: 'myapp',
+      summary: 'PostgreSQL decision',
+      guidance: 'Use PostgreSQL',
+    }, ctx.engine, null, ctx.config);
+
+    expect(output).toContain('Related notes:');
+    expect(output).toContain('MyApp Decision');
+    const relatedSection = output.split('Related notes:')[1];
+    expect(relatedSection).not.toContain('Index');
+    expect(relatedSection).not.toContain('Operations Log');
+  });
+
+  it('should exclude domain kind from related notes', async () => {
+    await handleStore({
+      title: 'MyApp Domain',
+      content: 'MyApp is a web application for task management',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'MyApp domain guide',
+      guidance: 'Read first',
+    }, ctx.engine, null, ctx.config);
+
+    const output = await handleStore({
+      title: 'Task Management Features',
+      content: 'Task management application with web interface',
+      kind: 'reference',
+      project: 'myapp',
+      summary: 'Task features',
+      guidance: 'Feature reference',
+    }, ctx.engine, null, ctx.config);
+
+    if (output.includes('Related notes:')) {
+      expect(output).not.toContain('MyApp Domain');
+    }
+  });
+
+  it('should exclude archived notes from related notes', async () => {
+    const storeResult = ctx.engine.store('Archived note about PostgreSQL databases', {
+      title: 'Old DB Reference',
+      kind: 'reference',
+      status: 'permanent',
+      summary: 'Old PostgreSQL reference',
+      guidance: 'Outdated DB info',
+    });
+    ctx.engine.archive(storeResult.id);
+
+    ctx.engine.store('Current guide to PostgreSQL databases', {
+      title: 'Current DB Guide',
+      kind: 'reference',
+      status: 'permanent',
+      summary: 'Current PostgreSQL guide',
+      guidance: 'Use for DB work',
+    });
+
+    const output = await handleStore({
+      title: 'PostgreSQL Best Practices',
+      content: 'PostgreSQL database best practices and patterns',
+      kind: 'reference',
+      summary: 'PostgreSQL practices',
+      guidance: 'Follow these practices',
+    }, ctx.engine, null, ctx.config);
+
+    expect(output).toContain('Related notes:');
+    expect(output).toContain('Current DB Guide');
+    expect(output).not.toContain('Old DB Reference');
+  });
+
+  it('should not show related notes when disabled', async () => {
+    ctx.engine.store('Existing note about testing', {
+      title: 'Testing Guide',
+      kind: 'reference',
+      status: 'permanent',
+      summary: 'Guide to testing',
+      guidance: 'Follow testing best practices',
+    });
+
+    const disabledConfig = {
+      ...ctx.config,
+      store: { relatedNotes: { ...ctx.config.store.relatedNotes, enabled: false } },
+    };
+
+    const output = await handleStore({
+      title: 'Testing Best Practices',
+      content: 'Testing is essential for code quality',
+      kind: 'reference',
+      summary: 'Testing practices',
+      guidance: 'Always write tests',
+    }, ctx.engine, null, disabledConfig);
+
+    expect(output).not.toContain('Related notes:');
+  });
+
+  it('should not show related notes when no matches exist', async () => {
+    const output = await handleStore({
+      title: 'First Note Ever',
+      content: 'This is the very first note in an empty vault',
+      kind: 'observation',
+      summary: 'First note',
+      guidance: 'Starting point',
+    }, ctx.engine, null, ctx.config);
+
+    expect(output).not.toContain('Related notes:');
+  });
+
+  it('should respect maxResults config', async () => {
+    for (let i = 0; i < 8; i++) {
+      ctx.engine.store(`TypeScript pattern number ${i} for advanced usage`, {
+        title: `TypeScript Pattern ${i}`,
+        kind: 'reference',
+        status: 'permanent',
+        summary: `Pattern ${i} for TypeScript`,
+        guidance: `Use pattern ${i}`,
+      });
+    }
+
+    const limitedConfig = {
+      ...ctx.config,
+      store: { relatedNotes: { ...ctx.config.store.relatedNotes, maxResults: 2 } },
+    };
+
+    const output = await handleStore({
+      title: 'TypeScript Advanced Patterns',
+      content: 'Advanced TypeScript patterns for type-safe development',
+      kind: 'reference',
+      summary: 'Advanced TS patterns',
+      guidance: 'Use these patterns',
+    }, ctx.engine, null, limitedConfig);
+
+    expect(output).toContain('Related notes:');
+    const relatedLines = output.split('\n').filter(l => l.startsWith('- ['));
+    expect(relatedLines.length).toBeLessThanOrEqual(2);
+  });
+
+  it('should not include the stored note itself in related notes', async () => {
+    ctx.engine.store('Existing reference about databases', {
+      title: 'Database Reference',
+      kind: 'reference',
+      status: 'permanent',
+      summary: 'Database info',
+      guidance: 'Use for DB work',
+    });
+
+    const output = await handleStore({
+      title: 'Database Patterns',
+      content: 'Common database patterns and references',
+      kind: 'reference',
+      summary: 'DB patterns',
+      guidance: 'Reference for DB patterns',
+    }, ctx.engine, null, ctx.config);
+
+    expect(output).toContain('Related notes:');
+    expect(output).not.toContain('"Database Patterns"');
+  });
+});
+
 describe('MCP Tool: knowledge-search', () => {
   let ctx: TestContext;
 
@@ -1064,8 +1263,8 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
   beforeEach(() => { ctx = createTestHarness(); });
   afterEach(() => { cleanupTestHarness(ctx); });
 
-  it('should add client tag when client param provided', () => {
-    handleStore({
+  it('should add client tag when client param provided', async () => {
+    await handleStore({
       title: 'Claude Code Workflow',
       content: 'Use skills directory for prompts',
       kind: 'procedure',
@@ -1079,8 +1278,8 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
     expect(notes[0].tags).toContain('client:claude-code');
   });
 
-  it('should auto-detect client from .opencode/ in content', () => {
-    handleStore({
+  it('should auto-detect client from .opencode/ in content', async () => {
+    await handleStore({
       title: 'OpenCode Config',
       content: 'Edit .opencode/config.json to change settings',
       kind: 'reference',
@@ -1092,8 +1291,8 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
     expect(notes[0].tags).toContain('client:opencode');
   });
 
-  it('should auto-detect client from .claude/ in guidance', () => {
-    handleStore({
+  it('should auto-detect client from .claude/ in guidance', async () => {
+    await handleStore({
       title: 'Claude Instructions',
       content: 'Project instructions go in the root',
       kind: 'reference',
@@ -1105,8 +1304,8 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
     expect(notes[0].tags).toContain('client:claude-code');
   });
 
-  it('should NOT auto-tag universal content', () => {
-    handleStore({
+  it('should NOT auto-tag universal content', async () => {
+    await handleStore({
       title: 'General Preference',
       content: 'User prefers TypeScript',
       kind: 'personalization',
@@ -1119,8 +1318,8 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
     expect(clientTags).toHaveLength(0);
   });
 
-  it('should warn on unrecognized client name', () => {
-    const output = handleStore({
+  it('should warn on unrecognized client name', async () => {
+    const output = await handleStore({
       title: 'Unknown Client Note',
       content: 'Some content',
       kind: 'reference',
@@ -1133,8 +1332,8 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
     expect(output).toContain('Known clients:');
   });
 
-  it('should NOT warn on recognized client name', () => {
-    const output = handleStore({
+  it('should NOT warn on recognized client name', async () => {
+    const output = await handleStore({
       title: 'Known Client Note',
       content: 'Some content',
       kind: 'reference',
@@ -1146,8 +1345,8 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
     expect(output).not.toContain('Unrecognized client');
   });
 
-  it('should use explicit client over auto-detection', () => {
-    handleStore({
+  it('should use explicit client over auto-detection', async () => {
+    await handleStore({
       title: 'Cross-Client Note',
       content: 'Edit .opencode/config for opencode',
       kind: 'reference',
@@ -1161,8 +1360,8 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
     expect(notes[0].tags).not.toContain('client:opencode');
   });
 
-  it('should not auto-tag when multiple clients detected (ambiguous)', () => {
-    handleStore({
+  it('should not auto-tag when multiple clients detected (ambiguous)', async () => {
+    await handleStore({
       title: 'Client Comparison',
       content: 'Compare .opencode/config.json vs .claude/settings.json',
       kind: 'reference',
@@ -1175,8 +1374,8 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
     expect(clientTags).toHaveLength(0);
   });
 
-  it('should coexist client and project tags', () => {
-    handleStore({
+  it('should coexist client and project tags', async () => {
+    await handleStore({
       title: 'Project-Client Note',
       content: 'Edit .cursor/rules for project config',
       kind: 'reference',
@@ -1746,8 +1945,8 @@ describe('MCP Tool: lifecycle field', () => {
   beforeEach(() => { ctx = createTestHarness(); });
   afterEach(() => { cleanupTestHarness(ctx); });
 
-  it('should default lifecycle based on kind', () => {
-    const output = handleStore({
+  it('should default lifecycle based on kind', async () => {
+    const output = await handleStore({
       title: 'A Decision',
       content: 'We chose X',
       kind: 'decision',
@@ -1758,8 +1957,8 @@ describe('MCP Tool: lifecycle field', () => {
     expect(output).toContain('Lifecycle: snapshot');
   });
 
-  it('should default to living for personalization', () => {
-    const output = handleStore({
+  it('should default to living for personalization', async () => {
+    const output = await handleStore({
       title: 'Dark Mode',
       content: 'I prefer dark mode',
       kind: 'personalization',
@@ -1770,8 +1969,8 @@ describe('MCP Tool: lifecycle field', () => {
     expect(output).toContain('Lifecycle: living');
   });
 
-  it('should accept explicit lifecycle override', () => {
-    const output = handleStore({
+  it('should accept explicit lifecycle override', async () => {
+    const output = await handleStore({
       title: 'Living Decision',
       content: 'An evolving decision',
       kind: 'decision',
@@ -1783,8 +1982,8 @@ describe('MCP Tool: lifecycle field', () => {
     expect(output).toContain('Lifecycle: living');
   });
 
-  it('should auto-detect snapshot from date in title', () => {
-    const output = handleStore({
+  it('should auto-detect snapshot from date in title', async () => {
+    const output = await handleStore({
       title: 'Analysis 2025-04-25',
       content: 'Point-in-time analysis',
       kind: 'observation',
@@ -1795,8 +1994,8 @@ describe('MCP Tool: lifecycle field', () => {
     expect(output).toContain('Lifecycle: snapshot');
   });
 
-  it('should not auto-detect snapshot when explicit lifecycle given', () => {
-    const output = handleStore({
+  it('should not auto-detect snapshot when explicit lifecycle given', async () => {
+    const output = await handleStore({
       title: 'Log 2025-04-25',
       content: 'Append-only log',
       kind: 'observation',
@@ -1862,8 +2061,8 @@ describe('MCP Tool: lifecycle field', () => {
     expect(updated.action).toBe('updated');
   });
 
-  it('should persist lifecycle in frontmatter', () => {
-    const output = handleStore({
+  it('should persist lifecycle in frontmatter', async () => {
+    const output = await handleStore({
       title: 'Snapshot Note',
       content: 'Frozen content',
       kind: 'decision',
@@ -1881,8 +2080,8 @@ describe('MCP Tool: lifecycle field', () => {
     expect(fileContent).toContain('lifecycle: snapshot');
   });
 
-  it('should persist lifecycle in DB and read back', () => {
-    handleStore({
+  it('should persist lifecycle in DB and read back', async () => {
+    await handleStore({
       title: 'Append Log',
       content: 'Log entry',
       kind: 'observation',
@@ -1896,12 +2095,12 @@ describe('MCP Tool: lifecycle field', () => {
     expect(results[0].lifecycle).toBe('append-only');
   });
 
-  it('should disable slug detection when config says so', () => {
+  it('should disable slug detection when config says so', async () => {
     const noDetectConfig = {
       ...ctx.config,
       lifecycleDefaults: { ...ctx.config.lifecycleDefaults, detectSnapshotFromSlug: false },
     };
-    const output = handleStore({
+    const output = await handleStore({
       title: 'Procedure 2025-04-25',
       content: 'Dated procedure',
       kind: 'procedure',
@@ -1912,8 +2111,8 @@ describe('MCP Tool: lifecycle field', () => {
     expect(output).toContain('Lifecycle: living');
   });
 
-  it('should slug-detect snapshot for kind that defaults to living', () => {
-    const output = handleStore({
+  it('should slug-detect snapshot for kind that defaults to living', async () => {
+    const output = await handleStore({
       title: 'Procedure 2025-04-25',
       content: 'Dated procedure',
       kind: 'procedure',
@@ -1924,8 +2123,8 @@ describe('MCP Tool: lifecycle field', () => {
     expect(output).toContain('Lifecycle: snapshot');
   });
 
-  it('should fall back to kind default for invalid lifecycle value', () => {
-    const output = handleStore({
+  it('should fall back to kind default for invalid lifecycle value', async () => {
+    const output = await handleStore({
       title: 'Bad Lifecycle',
       content: 'Invalid lifecycle value',
       kind: 'decision',
@@ -1937,8 +2136,8 @@ describe('MCP Tool: lifecycle field', () => {
     expect(output).toContain('Lifecycle: snapshot');
   });
 
-  it('should filter search results by lifecycle', () => {
-    handleStore({
+  it('should filter search results by lifecycle', async () => {
+    await handleStore({
       title: 'Living Reference',
       content: 'A living reference note about search',
       kind: 'reference',
@@ -1947,7 +2146,7 @@ describe('MCP Tool: lifecycle field', () => {
       guidance: 'Use it',
     }, ctx.engine, null, ctx.config);
 
-    handleStore({
+    await handleStore({
       title: 'Snapshot Reference',
       content: 'A snapshot reference note about search',
       kind: 'reference',
@@ -2017,8 +2216,8 @@ describe('MCP Tool: lifecycle field', () => {
     ).toThrow(new RegExp(result.id));
   });
 
-  it('should render lifecycle attribute in XML only for non-living notes', () => {
-    handleStore({
+  it('should render lifecycle attribute in XML only for non-living notes', async () => {
+    await handleStore({
       title: 'Snapshot for Render',
       content: 'Frozen for rendering test',
       kind: 'decision',
@@ -2027,7 +2226,7 @@ describe('MCP Tool: lifecycle field', () => {
       guidance: 'Check XML',
     }, ctx.engine, null, ctx.config);
 
-    handleStore({
+    await handleStore({
       title: 'Living for Render',
       content: 'Living for rendering test',
       kind: 'procedure',
@@ -2075,8 +2274,8 @@ describe('MCP Tool: lifecycle field', () => {
     ).toThrow(LifecycleViolationError);
   });
 
-  it('should preserve lifecycle through rebuildFromFiles', () => {
-    handleStore({
+  it('should preserve lifecycle through rebuildFromFiles', async () => {
+    await handleStore({
       title: 'Rebuild Test Note',
       content: 'Content for rebuild lifecycle test',
       kind: 'observation',
@@ -2103,8 +2302,8 @@ describe('Domain note kind', () => {
   beforeEach(() => { ctx = createTestHarness(); });
   afterEach(() => { cleanupTestHarness(ctx); });
 
-  it('should store domain note with permanent status by default', () => {
-    const output = handleStore({
+  it('should store domain note with permanent status by default', async () => {
+    const output = await handleStore({
       title: 'MyApp Domain',
       content: 'Core domain knowledge for MyApp.',
       kind: 'domain',
@@ -2116,8 +2315,8 @@ describe('Domain note kind', () => {
     expect(output).toContain('Status: permanent');
   });
 
-  it('should store domain note with living lifecycle by default', () => {
-    const output = handleStore({
+  it('should store domain note with living lifecycle by default', async () => {
+    const output = await handleStore({
       title: 'MyApp Domain',
       content: 'Core domain knowledge for MyApp.',
       kind: 'domain',
@@ -2129,8 +2328,8 @@ describe('Domain note kind', () => {
     expect(output).toContain('Lifecycle: living');
   });
 
-  it('should reject domain note without project', () => {
-    const output = handleStore({
+  it('should reject domain note without project', async () => {
+    const output = await handleStore({
       title: 'Unscoped Domain',
       content: 'Missing project scope.',
       kind: 'domain',
@@ -2141,8 +2340,8 @@ describe('Domain note kind', () => {
     expect(output).toContain('require a project');
   });
 
-  it('should reject duplicate domain note for same project', () => {
-    const first = handleStore({
+  it('should reject duplicate domain note for same project', async () => {
+    const first = await handleStore({
       title: 'MyApp Domain',
       content: 'Primary domain note.',
       kind: 'domain',
@@ -2154,7 +2353,7 @@ describe('Domain note kind', () => {
     const firstId = first.match(/ID: (\d+)/)?.[1];
     expect(firstId).toBeDefined();
 
-    const second = handleStore({
+    const second = await handleStore({
       title: 'MyApp Domain Duplicate',
       content: 'Duplicate domain note.',
       kind: 'domain',
@@ -2167,8 +2366,8 @@ describe('Domain note kind', () => {
     expect(second).toContain(firstId!);
   });
 
-  it('should allow domain notes for different projects', () => {
-    const outputA = handleStore({
+  it('should allow domain notes for different projects', async () => {
+    const outputA = await handleStore({
       title: 'MyApp Domain',
       content: 'Domain note for MyApp.',
       kind: 'domain',
@@ -2177,7 +2376,7 @@ describe('Domain note kind', () => {
       guidance: 'Use for MyApp work',
     }, ctx.engine, null, ctx.config);
 
-    const outputB = handleStore({
+    const outputB = await handleStore({
       title: 'OtherApp Domain',
       content: 'Domain note for OtherApp.',
       kind: 'domain',
@@ -2191,8 +2390,8 @@ describe('Domain note kind', () => {
     expect(ctx.engine.getByKind('domain')).toHaveLength(2);
   });
 
-  it('should auto-add project tag to domain note', () => {
-    handleStore({
+  it('should auto-add project tag to domain note', async () => {
+    await handleStore({
       title: 'MyApp Domain',
       content: 'Tagged domain note.',
       kind: 'domain',
@@ -2206,8 +2405,8 @@ describe('Domain note kind', () => {
     expect(note!.tags).toContain('project:myapp');
   });
 
-  it('should always-include domain note in project-scoped search', () => {
-    handleStore({
+  it('should always-include domain note in project-scoped search', async () => {
+    await handleStore({
       title: 'MyApp Domain',
       content: 'Canonical operating manual for MyApp.',
       kind: 'domain',
@@ -2216,7 +2415,7 @@ describe('Domain note kind', () => {
       guidance: 'Read first',
     }, ctx.engine, null, ctx.config);
 
-    handleStore({
+    await handleStore({
       title: 'MyApp Query Match',
       content: 'Contains onboarding keyword for project search.',
       kind: 'observation',
@@ -2235,8 +2434,8 @@ describe('Domain note kind', () => {
     expect(domainIndex).toBeLessThan(regularIndex);
   });
 
-  it('should return domain note even with zero FTS matches', () => {
-    handleStore({
+  it('should return domain note even with zero FTS matches', async () => {
+    await handleStore({
       title: 'MyApp Domain',
       content: 'Canonical operating manual for MyApp.',
       kind: 'domain',
@@ -2252,8 +2451,8 @@ describe('Domain note kind', () => {
     expect(output).toContain('MyApp operating manual');
   });
 
-  it('should not duplicate domain note if it matches search', () => {
-    handleStore({
+  it('should not duplicate domain note if it matches search', async () => {
+    await handleStore({
       title: 'MyApp Domain',
       content: 'This domain note documents foobar workflows.',
       kind: 'domain',
@@ -2269,8 +2468,8 @@ describe('Domain note kind', () => {
     expect(occurrences).toHaveLength(1);
   });
 
-  it('should not include domain note without project filter', () => {
-    handleStore({
+  it('should not include domain note without project filter', async () => {
+    await handleStore({
       title: 'MyApp Domain',
       content: 'Canonical operating manual for MyApp.',
       kind: 'domain',
@@ -2285,8 +2484,8 @@ describe('Domain note kind', () => {
     expect(output).toBe('No matching notes found. Try broader keywords or remove filters.');
   });
 
-  it('should respect alwaysIncludeDomainNote=false config', () => {
-    handleStore({
+  it('should respect alwaysIncludeDomainNote=false config', async () => {
+    await handleStore({
       title: 'MyApp Domain',
       content: 'Canonical operating manual for MyApp.',
       kind: 'domain',
@@ -2301,8 +2500,8 @@ describe('Domain note kind', () => {
     expect(output).toBe('No matching notes found. Try broader keywords or remove filters.');
   });
 
-  it('should not include archived domain note', () => {
-    const storeOutput = handleStore({
+  it('should not include archived domain note', async () => {
+    const storeOutput = await handleStore({
       title: 'MyApp Domain',
       content: 'Canonical operating manual for MyApp.',
       kind: 'domain',
@@ -2321,8 +2520,8 @@ describe('Domain note kind', () => {
     expect(output).toBe('No matching notes found. Try broader keywords or remove filters.');
   });
 
-  it('should find domain note via getDomainNote()', () => {
-    handleStore({
+  it('should find domain note via getDomainNote()', async () => {
+    await handleStore({
       title: 'MyApp Domain',
       content: 'Canonical operating manual for MyApp.',
       kind: 'domain',
@@ -2374,12 +2573,12 @@ describe('Index and log note kinds', () => {
     };
   };
 
-  const storeProjectNote = (
+  const storeProjectNote = async (
     title: string,
     project: string = 'myapp',
     config = makeConfig(),
     kind: 'observation' | 'domain' = 'observation',
-  ) => handleStore({
+   ) => await handleStore({
     title,
     content: `${title} content for ${project}`,
     kind,
@@ -2394,16 +2593,16 @@ describe('Index and log note kinds', () => {
     return noteId!;
   };
 
-  it('should auto-generate an index note for project-scoped notes', () => {
-    storeProjectNote('Alpha Note');
+  it('should auto-generate an index note for project-scoped notes', async () => {
+    await storeProjectNote('Alpha Note');
 
     const indexNote = ctx.engine.getIndexNote('myapp');
     expect(indexNote).not.toBeNull();
     expect(indexNote!.kind).toBe('index');
   });
 
-  it('should include wikilinks to stored notes in index content', () => {
-    storeProjectNote('Linked Note');
+  it('should include wikilinks to stored notes in index content', async () => {
+    await storeProjectNote('Linked Note');
 
     const indexNote = ctx.engine.getIndexNote('myapp');
     expect(indexNote).not.toBeNull();
@@ -2411,26 +2610,26 @@ describe('Index and log note kinds', () => {
     expect(indexNote!.content).toContain('Linked Note');
   });
 
-  it('should exclude index notes from default search results', () => {
-    storeProjectNote('Index Search Hidden');
+  it('should exclude index notes from default search results', async () => {
+    await storeProjectNote('Index Search Hidden');
 
     const output = handleSearch({ query: 'Index Search Hidden' }, ctx.engine, null, makeConfig());
     expect(output).not.toContain('myapp Index');
   });
 
-  it('should return index notes when explicitly filtered by kind', () => {
-    storeProjectNote('Index Search Visible');
+  it('should return index notes when explicitly filtered by kind', async () => {
+    await storeProjectNote('Index Search Visible');
 
     const output = handleSearch({ query: 'Index Search Visible', kind: 'index' }, ctx.engine, null, makeConfig());
     expect(output).toContain('# Myapp Index');
   });
 
-  it('should rebuild the index when a second project note is stored', () => {
-    storeProjectNote('First Indexed Note');
+  it('should rebuild the index when a second project note is stored', async () => {
+    await storeProjectNote('First Indexed Note');
     const before = ctx.engine.getIndexNote('myapp');
     expect(before).not.toBeNull();
 
-    storeProjectNote('Second Indexed Note');
+    await storeProjectNote('Second Indexed Note');
     const after = ctx.engine.getIndexNote('myapp');
     expect(after).not.toBeNull();
     expect(after!.content.length).toBeGreaterThan(before!.content.length);
@@ -2438,8 +2637,8 @@ describe('Index and log note kinds', () => {
   });
 
   it('should exclude archived notes from the index after archive', async () => {
-    const keepOutput = storeProjectNote('Keep In Index');
-    const archiveOutput = storeProjectNote('Archive From Index');
+    const keepOutput = await storeProjectNote('Keep In Index');
+    const archiveOutput = await storeProjectNote('Archive From Index');
     const archiveId = extractId(archiveOutput);
 
     expect(keepOutput).toContain('Knowledge stored');
@@ -2451,48 +2650,48 @@ describe('Index and log note kinds', () => {
     expect(indexNote!.content).not.toContain('Archive From Index');
   });
 
-  it('should keep exactly one index note per project', () => {
-    storeProjectNote('Project Note One');
-    storeProjectNote('Project Note Two');
-    storeProjectNote('Project Note Three');
+  it('should keep exactly one index note per project', async () => {
+    await storeProjectNote('Project Note One');
+    await storeProjectNote('Project Note Two');
+    await storeProjectNote('Project Note Three');
 
     const indexNotes = ctx.engine.getByKind('index').filter(note => note.tags.includes('project:myapp'));
     expect(indexNotes).toHaveLength(1);
   });
 
-  it('should auto-generate a log note with a Created entry', () => {
-    storeProjectNote('Created Log Note');
+  it('should auto-generate a log note with a Created entry', async () => {
+    await storeProjectNote('Created Log Note');
 
     const logNote = ctx.engine.getLogNote('myapp');
     expect(logNote).not.toBeNull();
     expect(logNote!.content).toContain('Created observation: "Created Log Note"');
   });
 
-  it('should format log entries with bold dates', () => {
-    storeProjectNote('Bold Date Log');
+  it('should format log entries with bold dates', async () => {
+    await storeProjectNote('Bold Date Log');
 
     const logNote = ctx.engine.getLogNote('myapp');
     expect(logNote).not.toBeNull();
     expect(logNote!.content).toMatch(/- \*\*\d{4}-\d{2}-\d{2}\*\* — Created observation: "Bold Date Log"/);
   });
 
-  it('should exclude log notes from default search results', () => {
-    storeProjectNote('Log Search Hidden');
+  it('should exclude log notes from default search results', async () => {
+    await storeProjectNote('Log Search Hidden');
 
     const output = handleSearch({ query: 'Log Search Hidden' }, ctx.engine, null, makeConfig());
     expect(output).not.toContain('Operations Log');
   });
 
-  it('should return log notes when explicitly filtered by kind', () => {
-    storeProjectNote('Log Search Visible');
+  it('should return log notes when explicitly filtered by kind', async () => {
+    await storeProjectNote('Log Search Visible');
 
     const output = handleSearch({ query: 'Log Search Visible', kind: 'log' }, ctx.engine, null, makeConfig());
     expect(output).toContain('# Myapp Operations Log');
   });
 
-  it('should accumulate log entries across multiple project note stores', () => {
-    storeProjectNote('First Log Entry');
-    storeProjectNote('Second Log Entry');
+  it('should accumulate log entries across multiple project note stores', async () => {
+    await storeProjectNote('First Log Entry');
+    await storeProjectNote('Second Log Entry');
 
     const logNote = ctx.engine.getLogNote('myapp');
     expect(logNote).not.toBeNull();
@@ -2501,7 +2700,7 @@ describe('Index and log note kinds', () => {
   });
 
   it('should append a Promoted entry to the log', async () => {
-    const output = storeProjectNote('Promote Me');
+    const output = await storeProjectNote('Promote Me');
     const noteId = extractId(output);
 
     await handleMaintain({ action: 'promote', noteId }, ctx.engine, makeConfig());
@@ -2512,7 +2711,7 @@ describe('Index and log note kinds', () => {
   });
 
   it('should append an Archived entry to the log', async () => {
-    const output = storeProjectNote('Archive Me');
+    const output = await storeProjectNote('Archive Me');
     const noteId = extractId(output);
 
     await handleMaintain({ action: 'archive', noteId }, ctx.engine, makeConfig());
@@ -2523,7 +2722,7 @@ describe('Index and log note kinds', () => {
   });
 
   it('should append a Deleted entry to the log', async () => {
-    const output = storeProjectNote('Delete Me');
+    const output = await storeProjectNote('Delete Me');
     const noteId = extractId(output);
 
     await handleMaintain({ action: 'delete', noteId }, ctx.engine, makeConfig());
@@ -2533,16 +2732,16 @@ describe('Index and log note kinds', () => {
     expect(logNote!.content).toContain('Deleted "Delete Me"');
   });
 
-  it('should store log notes with append-only lifecycle', () => {
-    storeProjectNote('Append Only Log');
+  it('should store log notes with append-only lifecycle', async () => {
+    await storeProjectNote('Append Only Log');
 
     const logNote = ctx.engine.getLogNote('myapp');
     expect(logNote).not.toBeNull();
     expect(logNote!.lifecycle).toBe('append-only');
   });
 
-  it('should reject manual creation of structural kinds', () => {
-    const indexOutput = handleStore({
+  it('should reject manual creation of structural kinds', async () => {
+    const indexOutput = await handleStore({
       title: 'Manual Index',
       content: 'Should fail',
       kind: 'index',
@@ -2550,7 +2749,7 @@ describe('Index and log note kinds', () => {
       guidance: 'Do not create manually',
     }, ctx.engine, null, makeConfig());
 
-    const logOutput = handleStore({
+    const logOutput = await handleStore({
       title: 'Manual Log',
       content: 'Should fail',
       kind: 'log',
@@ -2562,9 +2761,9 @@ describe('Index and log note kinds', () => {
     expect(logOutput).toContain('Error: log notes are auto-generated');
   });
 
-  it('should return project overview with domain, index, and log sections', () => {
-    storeProjectNote('MyApp Domain', 'myapp', makeConfig(), 'domain');
-    storeProjectNote('Overview Note');
+  it('should return project overview with domain, index, and log sections', async () => {
+    await storeProjectNote('MyApp Domain', 'myapp', makeConfig(), 'domain');
+    await storeProjectNote('Overview Note');
 
     const output = handleOverview({ project: 'myapp' }, ctx.engine, makeConfig());
     expect(output).toContain('## Project Overview: myapp');

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -276,6 +276,14 @@ describe('MCP Tool: knowledge-store — related notes', () => {
       guidance: 'Read first',
     }, ctx.engine, null, ctx.config);
 
+    ctx.engine.store('Task management workflows and sprint planning', {
+      title: 'Task Workflows',
+      kind: 'reference',
+      status: 'permanent',
+      summary: 'Task management workflows',
+      guidance: 'Follow task workflows',
+    });
+
     const output = await handleStore({
       title: 'Task Management Features',
       content: 'Task management application with web interface',
@@ -285,9 +293,9 @@ describe('MCP Tool: knowledge-store — related notes', () => {
       guidance: 'Feature reference',
     }, ctx.engine, null, ctx.config);
 
-    if (output.includes('Related notes:')) {
-      expect(output).not.toContain('MyApp Domain');
-    }
+    expect(output).toContain('Related notes:');
+    expect(output).toContain('Task Workflows');
+    expect(output).not.toContain('MyApp Domain');
   });
 
   it('should exclude archived notes from related notes', async () => {
@@ -406,6 +414,64 @@ describe('MCP Tool: knowledge-store — related notes', () => {
 
     expect(output).toContain('Related notes:');
     expect(output).not.toContain('"Database Patterns"');
+  });
+
+  it('should apply minSimilarity threshold and render similarity scores via vector path', () => {
+    const r1 = ctx.engine.store('Very similar content about React hooks', {
+      title: 'React Hooks Deep Dive',
+      kind: 'reference',
+      status: 'permanent',
+      summary: 'Deep dive into React hooks',
+      guidance: 'Use hooks',
+    });
+    const r2 = ctx.engine.store('Completely unrelated cooking content', {
+      title: 'Pasta Recipes',
+      kind: 'reference',
+      status: 'permanent',
+      summary: 'Italian cooking',
+      guidance: 'Cook pasta',
+    });
+    const r3 = ctx.engine.store('Domain note for myapp', {
+      title: 'MyApp Domain',
+      kind: 'domain',
+      status: 'permanent',
+      summary: 'MyApp guide',
+      guidance: 'Read first',
+      tags: ['project:myapp'],
+    });
+    const r4 = ctx.engine.store('Archived old hooks guide', {
+      title: 'Old Hooks Guide',
+      kind: 'reference',
+      status: 'permanent',
+      summary: 'Outdated hooks',
+      guidance: 'Outdated',
+    });
+    ctx.engine.archive(r4.id);
+
+    ctx.engine.storeEmbedding(r1.id, [0.9, 0.1, 0.0], 'test');
+    ctx.engine.storeEmbedding(r2.id, [0.0, 0.1, 0.9], 'test');
+    ctx.engine.storeEmbedding(r3.id, [0.8, 0.2, 0.0], 'test');
+    ctx.engine.storeEmbedding(r4.id, [0.85, 0.15, 0.0], 'test');
+
+    const queryEmbedding = [1.0, 0.0, 0.0];
+    const vecResults = ctx.engine.searchVector(queryEmbedding, { limit: 15 });
+
+    const excludeKinds = new Set(['domain', 'index', 'log']);
+    const minSimilarity = 0.70;
+    const filtered = vecResults
+      .filter(n => !excludeKinds.has(n.kind) && n.status !== 'archived' && n.similarity >= minSimilarity);
+
+    expect(filtered.length).toBeGreaterThanOrEqual(1);
+    expect(filtered.some(n => n.title === 'React Hooks Deep Dive')).toBe(true);
+    expect(filtered.every(n => n.kind !== 'domain')).toBe(true);
+    expect(filtered.every(n => n.status !== 'archived')).toBe(true);
+    expect(filtered.every(n => n.title !== 'Pasta Recipes')).toBe(true);
+
+    const topResult = filtered[0];
+    expect(topResult.similarity).toBeGreaterThan(0.7);
+    const formatted = `- [${topResult.id}] "${topResult.title}" (${topResult.kind}, similarity: ${topResult.similarity.toFixed(2)})`;
+    expect(formatted).toContain('similarity:');
+    expect(formatted).toContain('React Hooks Deep Dive');
   });
 });
 

--- a/tests/obsidian.test.ts
+++ b/tests/obsidian.test.ts
@@ -324,8 +324,8 @@ describe('handleOpen', () => {
     expect(result).toContain('Opened vault in Obsidian');
   });
 
-  it('should include project focus when index note exists', () => {
-    handleStore({
+  it('should include project focus when index note exists', async () => {
+    await handleStore({
       title: 'Test Note',
       content: 'Test content for project',
       kind: 'reference',

--- a/tests/vault-layout.test.ts
+++ b/tests/vault-layout.test.ts
@@ -453,8 +453,8 @@ describe('Global Navigation', () => {
     cleanupTestHarness(context);
   });
 
-  it('generates global index.md on store', () => {
-    handleStore(
+  it('generates global index.md on store', async () => {
+    await handleStore(
       { title: 'Test Note', content: 'Content', kind: 'decision', project: 'myproject', summary: 'A decision', guidance: 'Use it' } as any,
       context.engine,
       null,
@@ -468,8 +468,8 @@ describe('Global Navigation', () => {
     expect(content).toContain('myproject');
   });
 
-  it('generates global log.md on store', () => {
-    handleStore(
+  it('generates global log.md on store', async () => {
+    await handleStore(
       { title: 'Logged Note', content: 'Content', kind: 'observation', project: 'proj', summary: 'Obs', guidance: 'Note it' } as any,
       context.engine,
       null,
@@ -483,8 +483,8 @@ describe('Global Navigation', () => {
     expect(content).toContain('[proj]');
   });
 
-  it('generates review.md with fleeting notes', () => {
-    handleStore(
+  it('generates review.md with fleeting notes', async () => {
+    await handleStore(
       { title: 'Fleeting Obs', content: 'Content', kind: 'observation', project: 'proj', summary: 'Temp', guidance: 'Review' } as any,
       context.engine,
       null,
@@ -498,8 +498,8 @@ describe('Global Navigation', () => {
     expect(content).toContain('observation');
   });
 
-  it('generates general/index.md for unscoped notes', () => {
-    handleStore(
+  it('generates general/index.md for unscoped notes', async () => {
+    await handleStore(
       { title: 'General Note', content: 'Unscoped content', kind: 'reference', summary: 'General ref', guidance: 'Use it' } as any,
       context.engine,
       null,
@@ -512,14 +512,14 @@ describe('Global Navigation', () => {
     expect(content).toContain('# General Knowledge');
   });
 
-  it('appends to global log on subsequent stores', () => {
-    handleStore(
+  it('appends to global log on subsequent stores', async () => {
+    await handleStore(
       { title: 'First', content: 'A', kind: 'decision', project: 'p1', summary: 'First', guidance: 'G' } as any,
       context.engine,
       null,
       context.config,
     );
-    handleStore(
+    await handleStore(
       { title: 'Second', content: 'B', kind: 'observation', project: 'p2', summary: 'Second', guidance: 'G' } as any,
       context.engine,
       null,
@@ -681,8 +681,8 @@ describe('Structured navigation regressions', () => {
     expect(content).toContain('[system] Full DB rebuild');
   });
 
-  it('generates preferences/index.md when personalization notes exist', () => {
-    handleStore(
+  it('generates preferences/index.md when personalization notes exist', async () => {
+    await handleStore(
       { title: 'Pref', content: 'Pref content', kind: 'personalization', summary: 'User prefers Bun', guidance: 'Use Bun' } as any,
       context.engine,
       null,
@@ -700,8 +700,8 @@ describe('Structured navigation regressions', () => {
     expect(globalIndex).toContain('[[preferences/index|Preferences]]');
   });
 
-  it('generates general kind subdir indexes for unscoped notes', () => {
-    handleStore(
+  it('generates general kind subdir indexes for unscoped notes', async () => {
+    await handleStore(
       { title: 'General Decision', content: 'Decide', kind: 'decision', summary: 'General summary', guidance: 'Use it' } as any,
       context.engine,
       null,
@@ -740,14 +740,14 @@ Flat content`;
     expect(fs.existsSync(path.join(context.tempDir, 'general', vaultBasename))).toBe(false);
   });
 
-  it('creates sub-MOC files for small project kinds below split threshold', () => {
-    handleStore(
+  it('creates sub-MOC files for small project kinds below split threshold', async () => {
+    await handleStore(
       { title: 'Decision One', content: 'One', kind: 'decision', project: 'smallproj', summary: 'One', guidance: 'Use one' } as any,
       context.engine,
       null,
       context.config,
     );
-    handleStore(
+    await handleStore(
       { title: 'Decision Two', content: 'Two', kind: 'decision', project: 'smallproj', summary: 'Two', guidance: 'Use two' } as any,
       context.engine,
       null,


### PR DESCRIPTION
## Summary

Closes #77. After `knowledge-store` creates a note, the server runs a similarity search and returns the top-N most related existing notes in the tool response. No auto-linking — server surfaces data, agent decides what to do with it (#93 aligned).

- Embedding-based cosine similarity with 500ms `Promise.race` timeout (works for both local and API providers)
- FTS5 fallback when embeddings aren't ready in time — embedding still persists in the background
- Excludes structural kinds (`domain`, `index`, `log`) and archived notes from results
- Configurable via `store.relatedNotes` in `config.yaml`: `enabled`, `maxResults`, `minSimilarity`, `excludeKinds`
- Config validates `excludeKinds` against known NoteKind values and clamps `minSimilarity` to [0, 1]

## Response format

```
Knowledge stored (created)
ID: 2026042512053000
Kind: decision
Status: permanent
...

Related notes:
- [20260401120000] "Chose FTS5 over trigram" (decision, similarity: 0.89)
- [20260315120000] "Embedding strategy" (decision, similarity: 0.78)
```

## Config

```yaml
store:
  relatedNotes:
    enabled: true          # default
    maxResults: 5          # default
    minSimilarity: 0.70    # default, clamped [0, 1]
    excludeKinds: [domain, index, log]  # default, validated
```

## Test coverage

8 new tests covering:
- FTS5-matched related notes appear in response
- Structural kinds (index, log) excluded
- Domain kind excluded
- Archived notes excluded
- Feature disabled via config → no related notes
- Empty vault → no related notes
- `maxResults` config respected
- Self-exclusion (stored note not in own related notes)

## Breaking change

`handleStore` is now `async` (returns `Promise<string>`). All callers updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "related notes" feature that displays similar notes when storing a note, with configurable result limits, similarity thresholds, and exclusions.
  * Related-note matching now prefers vector similarity when available and shows similarity scores.

* **Chores**
  * Store operations and related workflows are now asynchronous to improve reliability; embedding generation is handled with a short timeout and background persistence.

* **Tests**
  * Updated and added tests to cover async store behavior and related-notes scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->