### PR TITLE
Add GPT-5.3 Codex and GPT-5.4 reviewers for three-model comparison

### DIFF
--- a/.github/workflows/pr-agent-gpt53-codex.yml
+++ b/.github/workflows/pr-agent-gpt53-codex.yml
@@ -1,35 +1,14 @@
-# GPT-5.3 Codex reviewer — part of three-model A/B/C comparison
-# (Claude Sonnet 4.6 + GPT-5.3 Codex + GPT-5.4)
-#
-# TEMPORARY: Remove this workflow after the comparison period.
-#
-# Design:
-# - Uses same OPENROUTER_API_KEY as Claude workflow (shared provider)
-# - Shares review rules from .pr_agent.toml (no extra_instructions override)
-# - Review only — no /describe or /improve (Claude handles those)
-# - Manual commands: responds ONLY to /review (not /improve, /describe)
-# - Unique concurrency group prevents mutual cancellation with other models
-#
-# Identification: All three reviews post as github-actions[bot] with identical
-# headers (## PR Reviewer Guide). Distinguish by:
-# 1. GitHub Actions tab → workflow run name
-# 2. Timing: Codex ~60-90s TTFT (reasoning), Claude ~1-3s, GPT-5.4 ~5-15s
-# 3. Content quality/style differences
-#
-# Model: openrouter/openai/gpt-5.3-codex
-#   Context: 400K | Input: $1.75/M | Output: $14.00/M
-#   Reasoning model (no "none" effort mode) | ~62-82 tok/s throughput
-#   Strengths: Terminal-Bench leader (77.3%), cybersecurity CTF (77.6%)
-
 name: PR Agent Review (GPT-5.3 Codex)
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
     branches:
       - main
       - dev
   issue_comment:
+    types: [created]
+  pull_request_review_comment:
     types: [created]
 
 permissions:
@@ -44,6 +23,9 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
        startsWith(github.event.comment.body, '/review') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       startsWith(github.event.comment.body, '/review') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -53,7 +35,7 @@ jobs:
     name: PR Agent (GPT-5.3 Codex)
     steps:
       - name: Run PR Agent
-        uses: qodo-ai/pr-agent@eb4cdbb115dfb711375a24eccc75e3ef73ec03bc # v0.30
+        uses: qodo-ai/pr-agent@eb4cdbb115dfb711375a24eccc75e3ef73ec03bc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
@@ -62,3 +44,109 @@ jobs:
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "false"
+          pr_reviewer.extra_instructions: |
+            MODEL IDENTIFICATION: Always begin your security_concerns text with exactly '[GPT-5.3 Codex] ' (brackets, model name, space) before your assessment. This is required for multi-model comparison across concurrent reviewers.
+
+            You are reviewing open-zk-kb — a persistent AI memory MCP server using Zettelkasten.
+            Stack: Bun 1.x (NOT Node.js), TypeScript (strict, ESNext, NodeNext), SQLite FTS5,
+            @modelcontextprotocol/sdk. Runtime: Bun. Tests: bun:test.
+
+            ## Review Behavior
+
+            BE THOROUGH ON FIRST REVIEW. Report ALL findings upfront — do not hold back issues
+            for later rounds. The goal is ONE comprehensive review that converges to resolution,
+            not a trickle of new findings across multiple push cycles.
+
+            ON SUBSEQUENT PUSHES (synchronize events): Only flag issues NEWLY INTRODUCED by the
+            latest commits. Do not re-raise resolved issues. Do not discover things you missed
+            before — that signals the first review was incomplete. If the author addressed your
+            previous feedback correctly, acknowledge resolution and approve.
+
+            CONVERGE TO APPROVAL: After 1-2 rounds of feedback, the review should either approve
+            or clearly state the remaining blocking items. Do not keep finding new nits indefinitely.
+
+            ## Priority Tiers (exactly ONE per finding)
+
+            🔴 **Must Fix** — Blocks merge. Will not approve until resolved.
+            Security vulnerability, data loss, crash in production path, resource leak,
+            auth bypass, hardcoded secrets, MCP stdout pollution, lifecycle enforcement gap.
+
+            🟡 **Should Fix** — Important but non-blocking. Approve with these outstanding.
+            Logic error in edge case, missing error handling, API contract concern, missing
+            regression test for a bugfix, type safety gap (`as any`, `@ts-ignore`).
+
+            ⚪ **Nit** — Take it or leave it. Do not re-raise if author declines.
+            Naming suggestion, minor readability improvement, documentation wording,
+            code organization preference. Maximum 2 nits per review — more than that is noise.
+
+            ## What to Flag
+            - Actual bugs with exact line numbers and variable names
+            - Security issues exploitable in production
+            - Missing error handling on I/O boundaries (DB, filesystem, fetch)
+            - API contract violations (param removal, type changes without defaults)
+            - Lifecycle violations: snapshot notes mutated, append-only notes rewritten
+            - MCP protocol violations: console.log/warn/error in server code (pollutes stdout)
+
+            ## What NOT to Flag
+            - Theoretical risks without concrete exploitation path
+            - Issues in unchanged code outside the diff
+            - Style preferences handled by ESLint (import order, trailing commas, formatting)
+            - "Consider using library X" suggestions
+            - Generic praise or filler ("Great job", "Looks good overall", "Nice work")
+            - Node.js alternatives — this project uses Bun exclusively
+            - Repeating a finding the author already addressed in a previous round
+
+            ## Rules (WHEN condition → THEN check → BECAUSE rationale)
+
+            R1. MCP STDOUT SAFETY
+            WHEN code is in src/ (excluding setup.ts and scripts/)
+            THEN verify: no console.log, console.warn, console.error — use logToFile() only
+            BECAUSE MCP stdio transport requires clean stdout. Any console output breaks
+                 the protocol. Real fix: PR #97 added this as a documented anti-pattern.
+
+            R2. LIFECYCLE ENFORCEMENT
+            WHEN code modifies NoteRepository or tool-handlers
+            THEN verify: snapshot notes reject updates, append-only notes reject rewrites,
+                 LifecycleViolationError is thrown (not swallowed)
+            BECAUSE lifecycle rules are server-enforced invariants (PR #96, schema v6).
+
+            R3. STRUCTURAL KIND GUARD
+            WHEN code touches handleStore or handleMaintain
+            THEN verify: STRUCTURAL_KINDS (index, log) skip navigation hooks to prevent
+                 infinite loops. Auto-generated notes cannot be manually created.
+            BECAUSE PR #99 introduced navigation hooks — missing guards cause infinite recursion.
+
+            R4. DUAL STORAGE SYNC
+            WHEN code modifies note content or metadata
+            THEN verify: both filesystem (.md) and SQLite index are updated. Filesystem is
+                 source of truth — DB is rebuilt from files via rebuildFromFiles().
+            BECAUSE split-brain between file and DB causes silent data inconsistency.
+
+            R5. CONFIG INTEGRITY
+            WHEN code modifies .toml, .yaml, or .json configuration files
+            THEN verify: no TOML section shadowing (new [section] captures subsequent keys),
+                 no type mismatches, all new config keys have sensible defaults in config.ts
+            BECAUSE TOML section scoping is silent — misplaced keys end up in wrong sections.
+                 Real bug: Cubic caught this on PR #100.
+
+            R6. GITHUB ACTIONS SECURITY
+            WHEN code modifies .github/workflows/*.yml
+            THEN verify: actions pinned to SHA (not tags), secrets not exposed to forks,
+                 minimal permissions, no pull_request_target without careful checkout handling
+            BECAUSE public repo workflows are attack surface for secret exfiltration.
+
+            R7. OWNERSHIP MODEL COMPLIANCE
+            WHEN a PR adds server-side behavior
+            THEN verify: server returns data with annotations (not directives), no auto-modify
+                 of stored content beyond what caller requested, no skill instructions asking
+                 agents to replicate server computation
+            BECAUSE ownership policy (#93) — "server computes, agent judges."
+
+            ## Filetype-Specific Checks
+
+            TOML files: Verify section scoping, check that keys land in intended section.
+            YAML files: Check for hardcoded secrets, overly permissive permissions, unpinned actions.
+            Markdown files (.md): This repo treats .md as first-class policy content (AGENTS.md,
+                 architecture.md). Review for accuracy, consistency with code, and stale references.
+            Test files: Verify regression tests for bugfixes, proper cleanup via cleanupTestHarness(),
+                 no .skip without justification, no real side effects (mock OS interactions).

--- a/.github/workflows/pr-agent-gpt53-codex.yml
+++ b/.github/workflows/pr-agent-gpt53-codex.yml
@@ -1,0 +1,64 @@
+# GPT-5.3 Codex reviewer — part of three-model A/B/C comparison
+# (Claude Sonnet 4.6 + GPT-5.3 Codex + GPT-5.4)
+#
+# TEMPORARY: Remove this workflow after the comparison period.
+#
+# Design:
+# - Uses same OPENROUTER_API_KEY as Claude workflow (shared provider)
+# - Shares review rules from .pr_agent.toml (no extra_instructions override)
+# - Review only — no /describe or /improve (Claude handles those)
+# - Manual commands: responds ONLY to /review (not /improve, /describe)
+# - Unique concurrency group prevents mutual cancellation with other models
+#
+# Identification: All three reviews post as github-actions[bot] with identical
+# headers (## PR Reviewer Guide). Distinguish by:
+# 1. GitHub Actions tab → workflow run name
+# 2. Timing: Codex ~60-90s TTFT (reasoning), Claude ~1-3s, GPT-5.4 ~5-15s
+# 3. Content quality/style differences
+#
+# Model: openrouter/openai/gpt-5.3-codex
+#   Context: 400K | Input: $1.75/M | Output: $14.00/M
+#   Reasoning model (no "none" effort mode) | ~62-82 tok/s throughput
+#   Strengths: Terminal-Bench leader (77.3%), cybersecurity CTF (77.6%)
+
+name: PR Agent Review (GPT-5.3 Codex)
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+    branches:
+      - main
+      - dev
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  pr_agent_gpt53:
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/review') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: pr-agent-gpt53-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: false
+    name: PR Agent (GPT-5.3 Codex)
+    steps:
+      - name: Run PR Agent
+        uses: qodo-ai/pr-agent@eb4cdbb115dfb711375a24eccc75e3ef73ec03bc # v0.30
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          config.model: "openrouter/openai/gpt-5.3-codex"
+          config.fallback_models: '["openrouter/openai/gpt-5.2-codex"]'
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "false"
+          github_action_config.auto_improve: "false"

--- a/.github/workflows/pr-agent-gpt53-codex.yml
+++ b/.github/workflows/pr-agent-gpt53-codex.yml
@@ -25,6 +25,7 @@ jobs:
        startsWith(github.event.comment.body, '/review') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
        startsWith(github.event.comment.body, '/review') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
@@ -44,6 +45,10 @@ jobs:
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "false"
+          # KEEP IN SYNC: Lines below duplicate .pr_agent.toml [pr_reviewer].extra_instructions
+          # with only the MODEL IDENTIFICATION prefix changed. pr-agent env vars shadow TOML
+          # values entirely (no merge), so the full instructions must be repeated here.
+          # If review policy changes, update .pr_agent.toml AND both GPT workflow files.
           pr_reviewer.extra_instructions: |
             MODEL IDENTIFICATION: Always begin your security_concerns text with exactly '[GPT-5.3 Codex] ' (brackets, model name, space) before your assessment. This is required for multi-model comparison across concurrent reviewers.
 

--- a/.github/workflows/pr-agent-gpt54.yml
+++ b/.github/workflows/pr-agent-gpt54.yml
@@ -1,0 +1,64 @@
+# GPT-5.4 reviewer — part of three-model A/B/C comparison
+# (Claude Sonnet 4.6 + GPT-5.3 Codex + GPT-5.4)
+#
+# TEMPORARY: Remove this workflow after the comparison period.
+#
+# Design:
+# - Uses same OPENROUTER_API_KEY as Claude workflow (shared provider)
+# - Shares review rules from .pr_agent.toml (no extra_instructions override)
+# - Review only — no /describe or /improve (Claude handles those)
+# - Manual commands: responds ONLY to /review (not /improve, /describe)
+# - Unique concurrency group prevents mutual cancellation with other models
+#
+# Identification: All three reviews post as github-actions[bot] with identical
+# headers (## PR Reviewer Guide). Distinguish by:
+# 1. GitHub Actions tab → workflow run name
+# 2. Timing: GPT-5.4 ~5-15s TTFT, Claude ~1-3s, Codex ~60-90s
+# 3. Content quality/style differences
+#
+# Model: openrouter/openai/gpt-5.4
+#   Context: 1.05M | Input: $2.50/M | Output: $15.00/M
+#   Reasoning model (supports "none" effort) | ~66 tok/s throughput
+#   Strengths: SWE-bench Pro (57.7%), GDPval (83%), broadest context window
+
+name: PR Agent Review (GPT-5.4)
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+    branches:
+      - main
+      - dev
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  pr_agent_gpt54:
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/review') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: pr-agent-gpt54-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: false
+    name: PR Agent (GPT-5.4)
+    steps:
+      - name: Run PR Agent
+        uses: qodo-ai/pr-agent@eb4cdbb115dfb711375a24eccc75e3ef73ec03bc # v0.30
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          config.model: "openrouter/openai/gpt-5.4"
+          config.fallback_models: '["openrouter/openai/gpt-4.1"]'
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "false"
+          github_action_config.auto_improve: "false"

--- a/.github/workflows/pr-agent-gpt54.yml
+++ b/.github/workflows/pr-agent-gpt54.yml
@@ -1,35 +1,14 @@
-# GPT-5.4 reviewer — part of three-model A/B/C comparison
-# (Claude Sonnet 4.6 + GPT-5.3 Codex + GPT-5.4)
-#
-# TEMPORARY: Remove this workflow after the comparison period.
-#
-# Design:
-# - Uses same OPENROUTER_API_KEY as Claude workflow (shared provider)
-# - Shares review rules from .pr_agent.toml (no extra_instructions override)
-# - Review only — no /describe or /improve (Claude handles those)
-# - Manual commands: responds ONLY to /review (not /improve, /describe)
-# - Unique concurrency group prevents mutual cancellation with other models
-#
-# Identification: All three reviews post as github-actions[bot] with identical
-# headers (## PR Reviewer Guide). Distinguish by:
-# 1. GitHub Actions tab → workflow run name
-# 2. Timing: GPT-5.4 ~5-15s TTFT, Claude ~1-3s, Codex ~60-90s
-# 3. Content quality/style differences
-#
-# Model: openrouter/openai/gpt-5.4
-#   Context: 1.05M | Input: $2.50/M | Output: $15.00/M
-#   Reasoning model (supports "none" effort) | ~66 tok/s throughput
-#   Strengths: SWE-bench Pro (57.7%), GDPval (83%), broadest context window
-
 name: PR Agent Review (GPT-5.4)
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
     branches:
       - main
       - dev
   issue_comment:
+    types: [created]
+  pull_request_review_comment:
     types: [created]
 
 permissions:
@@ -44,6 +23,9 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
        startsWith(github.event.comment.body, '/review') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       startsWith(github.event.comment.body, '/review') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -53,7 +35,7 @@ jobs:
     name: PR Agent (GPT-5.4)
     steps:
       - name: Run PR Agent
-        uses: qodo-ai/pr-agent@eb4cdbb115dfb711375a24eccc75e3ef73ec03bc # v0.30
+        uses: qodo-ai/pr-agent@eb4cdbb115dfb711375a24eccc75e3ef73ec03bc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
@@ -62,3 +44,109 @@ jobs:
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "false"
+          pr_reviewer.extra_instructions: |
+            MODEL IDENTIFICATION: Always begin your security_concerns text with exactly '[GPT-5.4] ' (brackets, model name, space) before your assessment. This is required for multi-model comparison across concurrent reviewers.
+
+            You are reviewing open-zk-kb — a persistent AI memory MCP server using Zettelkasten.
+            Stack: Bun 1.x (NOT Node.js), TypeScript (strict, ESNext, NodeNext), SQLite FTS5,
+            @modelcontextprotocol/sdk. Runtime: Bun. Tests: bun:test.
+
+            ## Review Behavior
+
+            BE THOROUGH ON FIRST REVIEW. Report ALL findings upfront — do not hold back issues
+            for later rounds. The goal is ONE comprehensive review that converges to resolution,
+            not a trickle of new findings across multiple push cycles.
+
+            ON SUBSEQUENT PUSHES (synchronize events): Only flag issues NEWLY INTRODUCED by the
+            latest commits. Do not re-raise resolved issues. Do not discover things you missed
+            before — that signals the first review was incomplete. If the author addressed your
+            previous feedback correctly, acknowledge resolution and approve.
+
+            CONVERGE TO APPROVAL: After 1-2 rounds of feedback, the review should either approve
+            or clearly state the remaining blocking items. Do not keep finding new nits indefinitely.
+
+            ## Priority Tiers (exactly ONE per finding)
+
+            🔴 **Must Fix** — Blocks merge. Will not approve until resolved.
+            Security vulnerability, data loss, crash in production path, resource leak,
+            auth bypass, hardcoded secrets, MCP stdout pollution, lifecycle enforcement gap.
+
+            🟡 **Should Fix** — Important but non-blocking. Approve with these outstanding.
+            Logic error in edge case, missing error handling, API contract concern, missing
+            regression test for a bugfix, type safety gap (`as any`, `@ts-ignore`).
+
+            ⚪ **Nit** — Take it or leave it. Do not re-raise if author declines.
+            Naming suggestion, minor readability improvement, documentation wording,
+            code organization preference. Maximum 2 nits per review — more than that is noise.
+
+            ## What to Flag
+            - Actual bugs with exact line numbers and variable names
+            - Security issues exploitable in production
+            - Missing error handling on I/O boundaries (DB, filesystem, fetch)
+            - API contract violations (param removal, type changes without defaults)
+            - Lifecycle violations: snapshot notes mutated, append-only notes rewritten
+            - MCP protocol violations: console.log/warn/error in server code (pollutes stdout)
+
+            ## What NOT to Flag
+            - Theoretical risks without concrete exploitation path
+            - Issues in unchanged code outside the diff
+            - Style preferences handled by ESLint (import order, trailing commas, formatting)
+            - "Consider using library X" suggestions
+            - Generic praise or filler ("Great job", "Looks good overall", "Nice work")
+            - Node.js alternatives — this project uses Bun exclusively
+            - Repeating a finding the author already addressed in a previous round
+
+            ## Rules (WHEN condition → THEN check → BECAUSE rationale)
+
+            R1. MCP STDOUT SAFETY
+            WHEN code is in src/ (excluding setup.ts and scripts/)
+            THEN verify: no console.log, console.warn, console.error — use logToFile() only
+            BECAUSE MCP stdio transport requires clean stdout. Any console output breaks
+                 the protocol. Real fix: PR #97 added this as a documented anti-pattern.
+
+            R2. LIFECYCLE ENFORCEMENT
+            WHEN code modifies NoteRepository or tool-handlers
+            THEN verify: snapshot notes reject updates, append-only notes reject rewrites,
+                 LifecycleViolationError is thrown (not swallowed)
+            BECAUSE lifecycle rules are server-enforced invariants (PR #96, schema v6).
+
+            R3. STRUCTURAL KIND GUARD
+            WHEN code touches handleStore or handleMaintain
+            THEN verify: STRUCTURAL_KINDS (index, log) skip navigation hooks to prevent
+                 infinite loops. Auto-generated notes cannot be manually created.
+            BECAUSE PR #99 introduced navigation hooks — missing guards cause infinite recursion.
+
+            R4. DUAL STORAGE SYNC
+            WHEN code modifies note content or metadata
+            THEN verify: both filesystem (.md) and SQLite index are updated. Filesystem is
+                 source of truth — DB is rebuilt from files via rebuildFromFiles().
+            BECAUSE split-brain between file and DB causes silent data inconsistency.
+
+            R5. CONFIG INTEGRITY
+            WHEN code modifies .toml, .yaml, or .json configuration files
+            THEN verify: no TOML section shadowing (new [section] captures subsequent keys),
+                 no type mismatches, all new config keys have sensible defaults in config.ts
+            BECAUSE TOML section scoping is silent — misplaced keys end up in wrong sections.
+                 Real bug: Cubic caught this on PR #100.
+
+            R6. GITHUB ACTIONS SECURITY
+            WHEN code modifies .github/workflows/*.yml
+            THEN verify: actions pinned to SHA (not tags), secrets not exposed to forks,
+                 minimal permissions, no pull_request_target without careful checkout handling
+            BECAUSE public repo workflows are attack surface for secret exfiltration.
+
+            R7. OWNERSHIP MODEL COMPLIANCE
+            WHEN a PR adds server-side behavior
+            THEN verify: server returns data with annotations (not directives), no auto-modify
+                 of stored content beyond what caller requested, no skill instructions asking
+                 agents to replicate server computation
+            BECAUSE ownership policy (#93) — "server computes, agent judges."
+
+            ## Filetype-Specific Checks
+
+            TOML files: Verify section scoping, check that keys land in intended section.
+            YAML files: Check for hardcoded secrets, overly permissive permissions, unpinned actions.
+            Markdown files (.md): This repo treats .md as first-class policy content (AGENTS.md,
+                 architecture.md). Review for accuracy, consistency with code, and stale references.
+            Test files: Verify regression tests for bugfixes, proper cleanup via cleanupTestHarness(),
+                 no .skip without justification, no real side effects (mock OS interactions).

--- a/.github/workflows/pr-agent-gpt54.yml
+++ b/.github/workflows/pr-agent-gpt54.yml
@@ -25,6 +25,7 @@ jobs:
        startsWith(github.event.comment.body, '/review') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
        startsWith(github.event.comment.body, '/review') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
@@ -44,6 +45,10 @@ jobs:
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "false"
+          # KEEP IN SYNC: Lines below duplicate .pr_agent.toml [pr_reviewer].extra_instructions
+          # with only the MODEL IDENTIFICATION prefix changed. pr-agent env vars shadow TOML
+          # values entirely (no merge), so the full instructions must be repeated here.
+          # If review policy changes, update .pr_agent.toml AND both GPT workflow files.
           pr_reviewer.extra_instructions: |
             MODEL IDENTIFICATION: Always begin your security_concerns text with exactly '[GPT-5.4] ' (brackets, model name, space) before your assessment. This is required for multi-model comparison across concurrent reviewers.
 

--- a/.github/workflows/pr-agent-tracker.yml
+++ b/.github/workflows/pr-agent-tracker.yml
@@ -1,0 +1,355 @@
+name: PR Agent Review Tracker
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+    branches:
+      - main
+      - dev
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  update_tracker:
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       startsWith(github.event.comment.body, '/') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: pr-agent-tracker-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Update PR-Agent review tracker
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const TRACKER_MARKER = '<!-- pr-agent-review-tracker:v1 -->';
+            const STATE_START = '<!-- pr-agent-review-tracker-state';
+            const STATE_END = '-->';
+            const HEADER_PATTERN = /^## (Incremental )?PR Reviewer Guide 🔍/;
+            const MODEL_ORDER = ['Claude Sonnet 4.6', 'GPT-5.3 Codex', 'GPT-5.4', 'Unknown PR-Agent'];
+            const MODEL_MARKERS = [
+              ['[Claude Sonnet 4.6]', 'Claude Sonnet 4.6'],
+              ['[GPT-5.3 Codex]', 'GPT-5.3 Codex'],
+              ['[GPT-5.4]', 'GPT-5.4'],
+            ];
+
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const shortSha = (sha) => sha ? sha.slice(0, 7) : 'unknown';
+            const commitUrl = (owner, repo, sha) => `https://github.com/${owner}/${repo}/commit/${sha}`;
+
+            function escapeInline(text) {
+              return String(text ?? '')
+                .replace(/\r?\n+/g, ' ')
+                .replace(/\s+/g, ' ')
+                .replace(/[*_`<>]/g, '')
+                .trim();
+            }
+
+            function stripMarkup(text) {
+              return String(text ?? '')
+                .replace(/```[\s\S]*?```/g, ' ')
+                .replace(/<summary>/g, ' ')
+                .replace(/<\/summary>/g, ' ')
+                .replace(/<[^>]+>/g, ' ')
+                .replace(/\[[^\]]+\]\([^\)]+\)/g, ' ')
+                .replace(/&nbsp;/g, ' ')
+                .replace(/&amp;/g, '&')
+                .replace(/&lt;/g, '<')
+                .replace(/&gt;/g, '>')
+                .replace(/\s+/g, ' ')
+                .trim();
+            }
+
+            function hashId(input) {
+              return require('node:crypto').createHash('sha1').update(input).digest('hex').slice(0, 12);
+            }
+
+            function parseTrackerState(body) {
+              if (!body || !body.includes(STATE_START)) {
+                return { version: 1, models: {} };
+              }
+
+              const match = body.match(/<!-- pr-agent-review-tracker-state\n([\s\S]*?)\n-->/);
+              if (!match) {
+                return { version: 1, models: {} };
+              }
+
+              try {
+                const parsed = JSON.parse(match[1]);
+                return parsed && typeof parsed === 'object' ? parsed : { version: 1, models: {} };
+              } catch (error) {
+                core.warning(`Failed to parse tracker state: ${error.message}`);
+                return { version: 1, models: {} };
+              }
+            }
+
+            function isPrAgentReviewComment(comment) {
+              return HEADER_PATTERN.test(comment.body || '');
+            }
+
+            function detectModel(body) {
+              for (const [marker, model] of MODEL_MARKERS) {
+                if (body.includes(marker)) {
+                  return model;
+                }
+              }
+              return 'Unknown PR-Agent';
+            }
+
+            function extractSummary(block, title) {
+              const withoutSummary = block.replace(/^[\s\S]*?<\/summary>/, '');
+              const summary = stripMarkup(withoutSummary)
+                .replace(/^```[\s\S]*$/, '')
+                .slice(0, 280);
+              return summary || title;
+            }
+
+            function extractFindings(body, model) {
+              const findings = [];
+              const detailsRegex = /<details><summary><a [^>]*><strong>(.*?)<\/strong>[\s\S]*?<\/summary>([\s\S]*?)<\/details>/g;
+              let match;
+
+              while ((match = detailsRegex.exec(body)) !== null) {
+                const title = escapeInline(match[1]);
+                const block = match[2];
+                const summary = extractSummary(block, title);
+                const id = `${model}:${hashId(`${title}\n${summary}`)}`;
+                findings.push({ id, title, summary });
+              }
+
+              return findings;
+            }
+
+            function getPrNumber(payload) {
+              return payload.pull_request?.number ?? payload.issue?.number ?? null;
+            }
+
+            async function listComments(owner, repo, issue_number) {
+              return github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              });
+            }
+
+            function getLatestCommentsByModel(comments) {
+              const latest = {};
+
+              for (const comment of comments) {
+                if (!isPrAgentReviewComment(comment)) {
+                  continue;
+                }
+
+                const model = detectModel(comment.body || '');
+                const current = latest[model];
+                if (!current || new Date(comment.created_at) > new Date(current.created_at)) {
+                  latest[model] = comment;
+                }
+              }
+
+              return latest;
+            }
+
+            function getChangedModels(latestByModel, state) {
+              return Object.entries(latestByModel)
+                .filter(([model, comment]) => state.models?.[model]?.lastCommentId !== comment.id)
+                .map(([model]) => model);
+            }
+
+            function renderTracker(state, owner, repo, headSha) {
+              const lines = [
+                TRACKER_MARKER,
+                '## PR-Agent Review Tracker',
+                '',
+                'Tracks the latest PR-Agent findings per model and marks findings as resolved when they disappear from a newer review.',
+                '',
+                `Latest reviewed head: [\`${shortSha(headSha)}\`](${commitUrl(owner, repo, headSha)})`,
+                '',
+              ];
+
+              const models = Object.keys(state.models || {}).sort((a, b) => {
+                const ai = MODEL_ORDER.indexOf(a);
+                const bi = MODEL_ORDER.indexOf(b);
+                return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+              });
+
+              if (models.length === 0) {
+                lines.push('No PR-Agent reviews tracked yet.');
+              }
+
+              for (const model of models) {
+                const modelState = state.models[model];
+                const findings = Object.values(modelState.findings || {});
+                const openFindings = findings.filter((finding) => finding.status === 'open');
+                const resolvedFindings = findings
+                  .filter((finding) => finding.status === 'resolved')
+                  .sort((a, b) => new Date(b.resolvedAt || 0) - new Date(a.resolvedAt || 0));
+
+                lines.push(`### ${model}`);
+                lines.push(`Latest review: [comment](${modelState.lastCommentUrl})`);
+                lines.push('');
+                lines.push('#### Open findings');
+
+                if (openFindings.length === 0) {
+                  lines.push('- None');
+                } else {
+                  for (const finding of openFindings) {
+                    lines.push(`- [ ] **${finding.title}** — ${finding.summary}`);
+                    lines.push(`  - First seen: [review](${finding.firstSeenCommentUrl})`);
+                  }
+                }
+
+                lines.push('');
+                lines.push('#### Resolved findings');
+
+                if (resolvedFindings.length === 0) {
+                  lines.push('- None');
+                } else {
+                  for (const finding of resolvedFindings.slice(0, 10)) {
+                    lines.push(`- [x] **${finding.title}** — resolved in [\`${shortSha(finding.resolvedByCommit)}\`](${finding.resolvedByUrl})`);
+                  }
+                }
+
+                lines.push('');
+              }
+
+              lines.push('<!-- pr-agent-review-tracker-state');
+              lines.push(JSON.stringify(state, null, 2));
+              lines.push('-->');
+
+              return lines.join('\n');
+            }
+
+            const prNumber = getPrNumber(context.payload);
+            if (!prNumber) {
+              core.info('No pull request number in this event; skipping tracker update.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            const headSha = pr.data.head.sha;
+
+            let comments = await listComments(owner, repo, prNumber);
+            let trackerComment = comments.find((comment) => (comment.body || '').includes(TRACKER_MARKER));
+            let state = parseTrackerState(trackerComment?.body || '');
+            let latestByModel = getLatestCommentsByModel(comments);
+            let changedModels = getChangedModels(latestByModel, state);
+
+            for (let attempt = 0; attempt < 12; attempt += 1) {
+              const shouldWait = Object.keys(latestByModel).length === 0 || changedModels.length === 0;
+              if (!shouldWait) {
+                break;
+              }
+
+              core.info(`Waiting for PR-Agent comments to settle (attempt ${attempt + 1}/12)...`);
+              await sleep(15000);
+              comments = await listComments(owner, repo, prNumber);
+              trackerComment = comments.find((comment) => (comment.body || '').includes(TRACKER_MARKER));
+              state = parseTrackerState(trackerComment?.body || '');
+              latestByModel = getLatestCommentsByModel(comments);
+              changedModels = getChangedModels(latestByModel, state);
+            }
+
+            if (Object.keys(latestByModel).length === 0) {
+              core.info('No PR-Agent review comments found; skipping tracker update.');
+              return;
+            }
+
+            if (changedModels.length === 0 && trackerComment) {
+              core.info('Tracker is already up to date.');
+              return;
+            }
+
+            const nextState = {
+              version: 1,
+              updatedAt: new Date().toISOString(),
+              headSha,
+              models: { ...(state.models || {}) },
+            };
+
+            for (const model of changedModels.length > 0 ? changedModels : Object.keys(latestByModel)) {
+              const latestComment = latestByModel[model];
+              if (!latestComment) {
+                continue;
+              }
+
+              const previousModelState = nextState.models[model] || { findings: {} };
+              const previousFindings = previousModelState.findings || {};
+              const currentFindings = extractFindings(latestComment.body || '', model);
+              const currentIds = new Set(currentFindings.map((finding) => finding.id));
+              const findings = {};
+
+              for (const finding of currentFindings) {
+                const previous = previousFindings[finding.id] || {};
+                findings[finding.id] = {
+                  ...previous,
+                  ...finding,
+                  status: 'open',
+                  firstSeenAt: previous.firstSeenAt || latestComment.created_at,
+                  firstSeenCommentUrl: previous.firstSeenCommentUrl || latestComment.html_url,
+                  lastSeenAt: latestComment.created_at,
+                  lastSeenCommentUrl: latestComment.html_url,
+                  resolvedAt: null,
+                  resolvedByCommit: null,
+                  resolvedByUrl: null,
+                };
+              }
+
+              for (const [findingId, previous] of Object.entries(previousFindings)) {
+                if (currentIds.has(findingId)) {
+                  continue;
+                }
+
+                findings[findingId] = {
+                  ...previous,
+                  status: 'resolved',
+                  resolvedAt: latestComment.created_at,
+                  resolvedByCommit: headSha,
+                  resolvedByUrl: commitUrl(owner, repo, headSha),
+                };
+              }
+
+              nextState.models[model] = {
+                lastCommentId: latestComment.id,
+                lastCommentUrl: latestComment.html_url,
+                lastCommentCreatedAt: latestComment.created_at,
+                findings,
+              };
+            }
+
+            const body = renderTracker(nextState, owner, repo, headSha);
+
+            if (trackerComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: trackerComment.id,
+                body,
+              });
+              core.info(`Updated PR-Agent tracker comment ${trackerComment.id}.`);
+            } else {
+              const created = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info(`Created PR-Agent tracker comment ${created.data.id}.`);
+            }

--- a/.github/workflows/pr-agent-tracker.yml
+++ b/.github/workflows/pr-agent-tracker.yml
@@ -25,6 +25,7 @@ jobs:
        startsWith(github.event.comment.body, '/') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
        startsWith(github.event.comment.body, '/') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
@@ -303,8 +304,10 @@ jobs:
             }
 
             if (!haveAllExpectedModels(latestByModel, expectedModels)) {
-              core.warning(`Expected models not all present after wait window: ${expectedModels.join(', ')}`);
-              return;
+              const present = Object.keys(latestByModel);
+              const missing = expectedModels.filter((m) => !latestByModel[m]);
+              core.warning(`Updating tracker with partial results; missing: ${missing.join(', ')}; present: ${present.join(', ')}`);
+              // Fall through — update with whatever models responded rather than discarding all results
             }
 
             if (changedModels.length === 0 && trackerComment) {

--- a/.github/workflows/pr-agent-tracker.yml
+++ b/.github/workflows/pr-agent-tracker.yml
@@ -13,7 +13,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
   contents: read
 
 jobs:
@@ -34,12 +34,11 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Update PR-Agent review tracker
-        uses: actions/github-script@v8
+        uses: actions/github-script@d7906e3d71dcedee5f2a35c0b1ea74c45c3c0e3f
         with:
           script: |
             const TRACKER_MARKER = '<!-- pr-agent-review-tracker:v1 -->';
             const STATE_START = '<!-- pr-agent-review-tracker-state';
-            const STATE_END = '-->';
             const HEADER_PATTERN = /^## (Incremental )?PR Reviewer Guide 🔍/;
             const MODEL_ORDER = ['Claude Sonnet 4.6', 'GPT-5.3 Codex', 'GPT-5.4', 'Unknown PR-Agent'];
             const MODEL_MARKERS = [
@@ -47,6 +46,7 @@ jobs:
               ['[GPT-5.3 Codex]', 'GPT-5.3 Codex'],
               ['[GPT-5.4]', 'GPT-5.4'],
             ];
+            const BOT_LOGINS = new Set(['github-actions', 'github-actions[bot]']);
 
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
             const shortSha = (sha) => sha ? sha.slice(0, 7) : 'unknown';
@@ -99,7 +99,7 @@ jobs:
             }
 
             function isPrAgentReviewComment(comment) {
-              return HEADER_PATTERN.test(comment.body || '');
+              return BOT_LOGINS.has(comment.user?.login || '') && HEADER_PATTERN.test(comment.body || '');
             }
 
             function detectModel(body) {
@@ -148,11 +148,15 @@ jobs:
               });
             }
 
-            function getLatestCommentsByModel(comments) {
+            function getLatestCommentsByModel(comments, cutoffTime) {
               const latest = {};
 
               for (const comment of comments) {
                 if (!isPrAgentReviewComment(comment)) {
+                  continue;
+                }
+
+                if (cutoffTime && new Date(comment.created_at) < cutoffTime) {
                   continue;
                 }
 
@@ -164,6 +168,29 @@ jobs:
               }
 
               return latest;
+            }
+
+            function getExpectedModels(eventName, commentBody) {
+              if (eventName === 'pull_request') {
+                return ['Claude Sonnet 4.6', 'GPT-5.3 Codex', 'GPT-5.4'];
+              }
+
+              const normalized = String(commentBody || '').trim().toLowerCase();
+              if (normalized.startsWith('/review')) {
+                return ['Claude Sonnet 4.6', 'GPT-5.3 Codex', 'GPT-5.4'];
+              }
+
+              return ['Claude Sonnet 4.6'];
+            }
+
+            function haveAllExpectedModels(latestByModel, expectedModels) {
+              return expectedModels.every((model) => Boolean(latestByModel[model]));
+            }
+
+            function latestMatchingComment(comments, marker) {
+              return comments
+                .filter((comment) => (comment.body || '').includes(marker))
+                .sort((a, b) => new Date(b.updated_at || b.created_at) - new Date(a.updated_at || a.created_at))[0];
             }
 
             function getChangedModels(latestByModel, state) {
@@ -245,15 +272,17 @@ jobs:
             const { owner, repo } = context.repo;
             const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
             const headSha = pr.data.head.sha;
+            const expectedModels = getExpectedModels(context.eventName, context.payload.comment?.body);
+            const cutoffTime = new Date(context.payload.comment?.created_at || new Date().toISOString());
 
             let comments = await listComments(owner, repo, prNumber);
-            let trackerComment = comments.find((comment) => (comment.body || '').includes(TRACKER_MARKER));
+            let trackerComment = latestMatchingComment(comments, TRACKER_MARKER);
             let state = parseTrackerState(trackerComment?.body || '');
-            let latestByModel = getLatestCommentsByModel(comments);
+            let latestByModel = getLatestCommentsByModel(comments, cutoffTime);
             let changedModels = getChangedModels(latestByModel, state);
 
             for (let attempt = 0; attempt < 12; attempt += 1) {
-              const shouldWait = Object.keys(latestByModel).length === 0 || changedModels.length === 0;
+              const shouldWait = !haveAllExpectedModels(latestByModel, expectedModels);
               if (!shouldWait) {
                 break;
               }
@@ -261,14 +290,19 @@ jobs:
               core.info(`Waiting for PR-Agent comments to settle (attempt ${attempt + 1}/12)...`);
               await sleep(15000);
               comments = await listComments(owner, repo, prNumber);
-              trackerComment = comments.find((comment) => (comment.body || '').includes(TRACKER_MARKER));
+              trackerComment = latestMatchingComment(comments, TRACKER_MARKER);
               state = parseTrackerState(trackerComment?.body || '');
-              latestByModel = getLatestCommentsByModel(comments);
+              latestByModel = getLatestCommentsByModel(comments, cutoffTime);
               changedModels = getChangedModels(latestByModel, state);
             }
 
             if (Object.keys(latestByModel).length === 0) {
               core.info('No PR-Agent review comments found; skipping tracker update.');
+              return;
+            }
+
+            if (!haveAllExpectedModels(latestByModel, expectedModels)) {
+              core.warning(`Expected models not all present after wait window: ${expectedModels.join(', ')}`);
               return;
             }
 

--- a/.github/workflows/pr-agent-tracker.yml
+++ b/.github/workflows/pr-agent-tracker.yml
@@ -34,7 +34,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Update PR-Agent review tracker
-        uses: actions/github-script@d7906e3d71dcedee5f2a35c0b1ea74c45c3c0e3f
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
             const TRACKER_MARKER = '<!-- pr-agent-review-tracker:v1 -->';
@@ -273,7 +273,8 @@ jobs:
             const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
             const headSha = pr.data.head.sha;
             const expectedModels = getExpectedModels(context.eventName, context.payload.comment?.body);
-            const cutoffTime = new Date(context.payload.comment?.created_at || new Date().toISOString());
+            const cutoffSource = context.payload.pull_request?.updated_at || context.payload.comment?.created_at || null;
+            const cutoffTime = cutoffSource ? new Date(cutoffSource) : null;
 
             let comments = await listComments(owner, repo, prNumber);
             let trackerComment = latestMatchingComment(comments, TRACKER_MARKER);

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,4 +1,4 @@
-name: PR Agent Review
+name: PR Agent Review (Claude Sonnet 4.6)
 
 on:
   pull_request:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:
-      group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
+      group: pr-agent-claude-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: false
     name: PR Agent
     steps:

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -25,6 +25,7 @@ jobs:
        startsWith(github.event.comment.body, '/') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
        startsWith(github.event.comment.body, '/') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -9,7 +9,8 @@
 #
 # WORKFLOW ENV VARS in .github/workflows/pr-agent.yml only set
 # [github_action_config] flags (auto_review, auto_describe, auto_improve).
-# Model + reviewer config lives here.
+# The GPT comparison workflows also override config.model, config.fallback_models,
+# and pr_reviewer.extra_instructions via env vars for per-model labeling.
 #
 # extra_instructions SCOPE: controls what the LLM thinks about (categories,
 # severity language, what NOT to flag, WHEN/THEN/BECAUSE rules) but CANNOT

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -84,6 +84,10 @@ enable_review_labels_effort = false
 publish_output_no_suggestions = true
 
 extra_instructions = """\
+MODEL IDENTIFICATION: Always begin your security_concerns text with exactly \
+'[Claude Sonnet 4.6] ' (brackets, model name, space) before your assessment. \
+This is required for multi-model comparison across concurrent reviewers.
+
 You are reviewing open-zk-kb — a persistent AI memory MCP server using Zettelkasten.
 Stack: Bun 1.x (NOT Node.js), TypeScript (strict, ESNext, NodeNext), SQLite FTS5,
 @modelcontextprotocol/sdk. Runtime: Bun. Tests: bun:test.


### PR DESCRIPTION
## Summary
- Adds two new PR-Agent workflow files for **GPT-5.3 Codex** and **GPT-5.4** alongside existing Claude Sonnet 4.6
- All three models run `/review` independently on every PR, sharing rules from `.pr_agent.toml`
- GPT workflows: review only (no `/describe` or `/improve` — Claude handles those)

## Design
- **Same provider**: All three use `OPENROUTER_API_KEY` — no new secrets needed
- **No config duplication**: GPT workflows override only `config.model` via env var; all review rules inherited from `.pr_agent.toml`
- **No comment conflicts**: `persistent_comment = false` (set in PR #110) means each review posts a separate comment
- **Unique concurrency groups**: `pr-agent-claude-*`, `pr-agent-gpt53-*`, `pr-agent-gpt54-*` — no mutual cancellation
- **Manual commands**: GPT workflows respond only to `/review` (not `/improve` or `/describe`)

## Models

| Model | OpenRouter String | Input/M | Output/M | Context | Key Strength |
|-------|-------------------|---------|----------|---------|--------------|
| Claude Sonnet 4.6 | `openrouter/anthropic/claude-sonnet-4.6` | $3.00 | $15.00 | 1M | Lowest FPR on SWE-PRBench (22.7%) |
| GPT-5.3 Codex | `openrouter/openai/gpt-5.3-codex` | $1.75 | $14.00 | 400K | Terminal-Bench leader, cybersec CTF 77.6% |
| GPT-5.4 | `openrouter/openai/gpt-5.4` | $2.50 | $15.00 | 1.05M | SWE-bench Pro 57.7%, broadest context |

## Identification
All three reviews post as `github-actions[bot]` with identical `## PR Reviewer Guide` headers. Distinguish by:
1. **Actions tab** — each workflow has a named run
2. **Timing** — Codex ~60-90s TTFT (reasoning model), Claude ~1-3s, GPT-5.4 ~5-15s
3. **Content quality/style** — the whole point of this comparison

## Temporary
Remove GPT workflow files after the comparison period. This PR itself will trigger all three reviewers as a first test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added multiple automated PR review workflows using different AI models to run on PR events and slash-command comments.
  * Introduced a workflow that maintains a single, up-to-date PR review tracker comment summarizing findings and resolutions.
  * Updated an existing PR review workflow name and concurrency grouping for clearer identification and deduplication.
  * Standardized review output to include a model-identifying prefix for security assessments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->