### PR TITLE
Add OpenCode plugin for guaranteed session-start context injection (#88)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,8 @@ Thumbs.db
 .sisyphus/
 CONTEXT_*.md
 
+# Local test workspace (isolated OpenCode sessions for plugin dev)
+.test-workspace/
+
 # Runtime artifacts
 NoteRepository

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/mcp-server.d.ts",
       "import": "./dist/mcp-server.js"
+    },
+    "./server": {
+      "types": "./dist/opencode-plugin/index.d.ts",
+      "import": "./dist/opencode-plugin/index.js"
     }
   },
   "sideEffects": false,

--- a/src/opencode-plugin/context.ts
+++ b/src/opencode-plugin/context.ts
@@ -12,8 +12,9 @@ export interface KbContext {
 
 export function createReadonlyRepo(vaultOverride?: string): NoteRepository | null {
   try {
+    const testVault = process.env.NODE_ENV === 'test' ? process.env.__OPEN_ZK_KB_TEST_VAULT : undefined;
     const vault = vaultOverride
-      || process.env.__OPEN_ZK_KB_TEST_VAULT
+      || testVault
       || getConfig().vault;
     return new NoteRepository(vault, { readonly: true });
   } catch {
@@ -24,9 +25,7 @@ export function createReadonlyRepo(vaultOverride?: string): NoteRepository | nul
 
 export function fetchKbContext(repo: NoteRepository, project: string): KbContext {
   const tag = `project:${project}`;
-  const projectNotes = repo.getByTag(tag, 20);
-
-  const domainNote = projectNotes.find(n => (n.kind as string) === 'domain') ?? null;
+  const domainNote = repo.getDomainNote(project);
 
   const ftsQuery = domainNote
     ? `${domainNote.title} ${domainNote.summary || ''}`
@@ -35,12 +34,15 @@ export function fetchKbContext(repo: NoteRepository, project: string): KbContext
   let recentNotes = repo.search(ftsQuery, {
     tags: [tag],
     status: 'permanent' as const,
-    limit: 5,
+    limit: 6,
   });
 
   if (domainNote) {
     recentNotes = recentNotes.filter(n => n.id !== domainNote.id);
   }
+
+  recentNotes = recentNotes.filter(n => n.kind !== 'index' && n.kind !== 'log');
+  recentNotes = recentNotes.slice(0, 5);
 
   return { domainNote, recentNotes, project };
 }

--- a/src/opencode-plugin/context.ts
+++ b/src/opencode-plugin/context.ts
@@ -1,0 +1,72 @@
+import { NoteRepository } from '../storage/NoteRepository.js';
+import { renderNoteForAgent } from '../prompts.js';
+import { getConfig } from '../config.js';
+import { logToFile } from '../logger.js';
+import type { NoteMetadata } from '../storage/NoteRepository.js';
+
+export interface KbContext {
+  domainNote: NoteMetadata | null;
+  recentNotes: NoteMetadata[];
+  project: string;
+}
+
+export function createReadonlyRepo(vaultOverride?: string): NoteRepository | null {
+  try {
+    const vault = vaultOverride
+      || process.env.__OPEN_ZK_KB_TEST_VAULT
+      || getConfig().vault;
+    return new NoteRepository(vault, { readonly: true });
+  } catch {
+    logToFile('WARN', 'opencode-plugin: failed to open read-only repository');
+    return null;
+  }
+}
+
+export function fetchKbContext(repo: NoteRepository, project: string): KbContext {
+  const tag = `project:${project}`;
+  const projectNotes = repo.getByTag(tag, 20);
+
+  const domainNote = projectNotes.find(n => (n.kind as string) === 'domain') ?? null;
+
+  const ftsQuery = domainNote
+    ? `${domainNote.title} ${domainNote.summary || ''}`
+    : project;
+
+  let recentNotes = repo.search(ftsQuery, {
+    tags: [tag],
+    status: 'permanent' as const,
+    limit: 5,
+  });
+
+  if (domainNote) {
+    recentNotes = recentNotes.filter(n => n.id !== domainNote.id);
+  }
+
+  return { domainNote, recentNotes, project };
+}
+
+export function formatContext(ctx: KbContext): string {
+  const parts: string[] = [];
+
+  parts.push(`## Knowledge Base Context (project: ${ctx.project})\n`);
+
+  if (ctx.domainNote) {
+    parts.push('### Domain Note');
+    parts.push(renderNoteForAgent(ctx.domainNote));
+    parts.push('');
+  }
+
+  if (ctx.recentNotes.length > 0) {
+    parts.push('### Key Notes');
+    for (const note of ctx.recentNotes) {
+      parts.push(renderNoteForAgent(note));
+    }
+    parts.push('');
+  }
+
+  if (!ctx.domainNote && ctx.recentNotes.length === 0) {
+    return '';
+  }
+
+  return parts.join('\n');
+}

--- a/src/opencode-plugin/index.ts
+++ b/src/opencode-plugin/index.ts
@@ -1,0 +1,6 @@
+import { createKbPlugin } from './plugin.js';
+
+export default {
+  id: 'open-zk-kb',
+  server: createKbPlugin(),
+};

--- a/src/opencode-plugin/plugin.ts
+++ b/src/opencode-plugin/plugin.ts
@@ -69,7 +69,7 @@ export function createKbPlugin(): (ctx: PluginContext) => Promise<PluginHooks> {
         if (event.type === 'session.created') {
           const info = event.properties?.info as { id?: string } | undefined;
           const sessionID = info?.id;
-          if (!sessionID || !repo) return;
+          if (!sessionID) return;
 
           try {
             const kbContext = fetchKbContext(repo, project);
@@ -121,8 +121,6 @@ export function createKbPlugin(): (ctx: PluginContext) => Promise<PluginHooks> {
         input: CompactingInput,
         output: CompactingOutput,
       ): Promise<void> => {
-        if (!repo) return;
-
         try {
           const kbContext = fetchKbContext(repo, project);
           const formatted = formatContext(kbContext);

--- a/src/opencode-plugin/plugin.ts
+++ b/src/opencode-plugin/plugin.ts
@@ -1,0 +1,151 @@
+import { logToFile } from '../logger.js';
+import { detectProject } from './project-detect.js';
+import { createReadonlyRepo, fetchKbContext, formatContext } from './context.js';
+
+export interface PluginContext {
+  client: { app: { log(options: { body: Record<string, unknown> }): void } };
+  directory: string;
+}
+
+interface EventInput {
+  event: { type: string; properties?: Record<string, unknown> };
+}
+
+interface SystemTransformInput {
+  sessionID?: string;
+  model: { id: string; providerID: string };
+}
+
+interface SystemTransformOutput {
+  system: string[];
+}
+
+interface CompactingInput {
+  sessionID: string;
+}
+
+interface CompactingOutput {
+  context: string[];
+  prompt?: string;
+}
+
+export interface PluginHooks {
+  event: (input: EventInput) => Promise<void>;
+  'experimental.chat.system.transform': (input: SystemTransformInput, output: SystemTransformOutput) => Promise<void>;
+  'experimental.session.compacting': (input: CompactingInput, output: CompactingOutput) => Promise<void>;
+}
+
+type LogLevel = 'INFO' | 'WARN' | 'ERROR';
+
+function log(ctx: PluginContext, level: LogLevel, message: string, extra?: Record<string, unknown>): void {
+  try {
+    ctx.client.app.log({ body: { service: 'open-zk-kb', level, message, extra } });
+  } catch {
+    logToFile(level, `opencode-plugin: ${message}`, extra);
+  }
+}
+
+export function createKbPlugin(): (ctx: PluginContext) => Promise<PluginHooks> {
+  return async (ctx: PluginContext): Promise<PluginHooks> => {
+    const project = detectProject(ctx.directory);
+    if (!project) {
+      log(ctx, 'INFO', 'no project detected, plugin inactive', { directory: ctx.directory });
+      return createNoopHooks();
+    }
+
+    const repo = createReadonlyRepo();
+    if (!repo) {
+      log(ctx, 'INFO', 'no vault found, plugin inactive');
+      return createNoopHooks();
+    }
+
+    const injectedSessions = new Set<string>();
+    const contextCache = new Map<string, string>();
+
+    log(ctx, 'INFO', 'plugin active', { project, directory: ctx.directory });
+
+    return {
+      event: async ({ event }: EventInput): Promise<void> => {
+        if (event.type === 'session.created') {
+          const info = event.properties?.info as { id?: string } | undefined;
+          const sessionID = info?.id;
+          if (!sessionID || !repo) return;
+
+          try {
+            const kbContext = fetchKbContext(repo, project);
+            const formatted = formatContext(kbContext);
+            if (formatted) {
+              contextCache.set(sessionID, formatted);
+              injectedSessions.add(sessionID);
+              log(ctx, 'INFO', 'context pre-fetched', {
+                sessionID,
+                project,
+                hasDomain: !!kbContext.domainNote,
+                noteCount: kbContext.recentNotes.length,
+              });
+            }
+          } catch (e) {
+            log(ctx, 'WARN', 'context pre-fetch failed', {
+              sessionID,
+              error: e instanceof Error ? e.constructor.name : 'unknown',
+            });
+          }
+        }
+
+        if (event.type === 'session.deleted') {
+          const info = event.properties?.info as { id?: string } | undefined;
+          const sessionID = info?.id;
+          if (sessionID) {
+            injectedSessions.delete(sessionID);
+            contextCache.delete(sessionID);
+          }
+        }
+      },
+
+      'experimental.chat.system.transform': async (
+        input: SystemTransformInput,
+        output: SystemTransformOutput,
+      ): Promise<void> => {
+        const sessionID = input.sessionID;
+        if (!sessionID || !injectedSessions.has(sessionID)) return;
+
+        const cached = contextCache.get(sessionID);
+        if (cached) {
+          output.system.push(cached);
+          injectedSessions.delete(sessionID);
+          contextCache.delete(sessionID);
+        }
+      },
+
+      'experimental.session.compacting': async (
+        input: CompactingInput,
+        output: CompactingOutput,
+      ): Promise<void> => {
+        if (!repo) return;
+
+        try {
+          const kbContext = fetchKbContext(repo, project);
+          const formatted = formatContext(kbContext);
+          if (formatted) {
+            output.context.push(formatted);
+            injectedSessions.add(input.sessionID);
+            contextCache.set(input.sessionID, formatted);
+          }
+        } catch (e) {
+          log(ctx, 'WARN', 'compaction context injection failed', {
+            sessionID: input.sessionID,
+            error: e instanceof Error ? e.constructor.name : 'unknown',
+          });
+        }
+      },
+    };
+  };
+}
+
+function createNoopHooks(): PluginHooks {
+  return {
+    event: async () => {},
+    'experimental.chat.system.transform': async () => {},
+    'experimental.session.compacting': async () => {},
+  };
+}

--- a/src/opencode-plugin/project-detect.ts
+++ b/src/opencode-plugin/project-detect.ts
@@ -1,0 +1,25 @@
+import * as path from 'path';
+
+/**
+ * Derive a project tag from a working directory path.
+ *
+ * Heuristic: the deepest directory component under ~/dev/ becomes
+ * the project name. For paths outside ~/dev/, falls back to the
+ * basename of the directory itself.
+ *
+ * Returns null if the directory is a home directory or root.
+ */
+export function detectProject(directory: string): string | null {
+  const home = process.env.HOME || '';
+  if (!home || directory === home || directory === '/') return null;
+
+  const devDir = path.join(home, 'dev');
+  if (directory.startsWith(devDir + '/')) {
+    const relative = directory.slice(devDir.length + 1);
+    const topLevel = relative.split('/')[0];
+    if (topLevel) return topLevel;
+  }
+
+  const basename = path.basename(directory);
+  return basename || null;
+}

--- a/src/opencode-plugin/project-detect.ts
+++ b/src/opencode-plugin/project-detect.ts
@@ -3,23 +3,30 @@ import * as path from 'path';
 /**
  * Derive a project tag from a working directory path.
  *
- * Heuristic: the deepest directory component under ~/dev/ becomes
+ * Heuristic: the top-level directory component under ~/dev/ becomes
  * the project name. For paths outside ~/dev/, falls back to the
  * basename of the directory itself.
  *
- * Returns null if the directory is a home directory or root.
+ * Returns null if the directory is a home directory, ~/dev itself, or root.
  */
 export function detectProject(directory: string): string | null {
   const home = process.env.HOME || '';
-  if (!home || directory === home || directory === '/') return null;
+  if (!home) return null;
 
-  const devDir = path.join(home, 'dev');
-  if (directory.startsWith(devDir + '/')) {
-    const relative = directory.slice(devDir.length + 1);
+  const normalized = path.resolve(directory);
+  const normalizedHome = path.resolve(home);
+
+  if (normalized === normalizedHome || normalized === '/') return null;
+
+  const devDir = path.join(normalizedHome, 'dev');
+  if (normalized === devDir) return null;
+
+  if (normalized.startsWith(devDir + '/')) {
+    const relative = normalized.slice(devDir.length + 1);
     const topLevel = relative.split('/')[0];
     if (topLevel) return topLevel;
   }
 
-  const basename = path.basename(directory);
+  const basename = path.basename(normalized);
   return basename || null;
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -657,7 +657,7 @@ export function install(args: InstallArgs): string {
 
   const existing = getNestedValue(config, clientConfig.mcpPath);
 
-  if (clientConfig.pluginPackage) {
+  if (clientConfig.pluginPackage && !args.dryRun) {
     const plugins = Array.isArray(config['plugin']) ? config['plugin'] as string[] : [];
     if (!plugins.includes(clientConfig.pluginPackage)) {
       plugins.push(clientConfig.pluginPackage);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -47,6 +47,8 @@ export interface ClientConfig {
   instructionSize?: InstructionSize;
   /** Path where a Claude Code skill directory should be installed (e.g. ~/.claude/skills/open-zk-kb) */
   skillPath?: string;
+  /** npm package name to register in the client's plugin array (OpenCode only) */
+  pluginPackage?: string;
 }
 
 export const CLIENT_CONFIGS: Record<McpClient, ClientConfig> = {
@@ -58,6 +60,7 @@ export const CLIENT_CONFIGS: Record<McpClient, ClientConfig> = {
     mcpFormat: 'opencode',
     agentDocsPath: path.join(xdgConfigHome, 'opencode', 'AGENTS.md'),
     instructionSize: 'full',
+    pluginPackage: 'open-zk-kb',
   },
   'claude-code': {
     name: 'Claude Code',
@@ -670,6 +673,14 @@ export function install(args: InstallArgs): string {
   }
   
   setNestedValue(config, clientConfig.mcpPath, mcpEntry);
+
+  if (clientConfig.pluginPackage) {
+    const plugins = Array.isArray(config['plugin']) ? config['plugin'] as string[] : [];
+    if (!plugins.includes(clientConfig.pluginPackage)) {
+      plugins.push(clientConfig.pluginPackage);
+    }
+    config['plugin'] = plugins;
+  }
   
   const configDir = path.dirname(clientConfig.configPath);
   if (!fs.existsSync(configDir)) {
@@ -794,6 +805,18 @@ export function uninstall(args: UninstallArgs): string {
   }
   
   deleteNestedValue(config, clientConfig.mcpPath);
+
+  if (clientConfig.pluginPackage && Array.isArray(config['plugin'])) {
+    const plugins = config['plugin'] as string[];
+    const idx = plugins.indexOf(clientConfig.pluginPackage);
+    if (idx !== -1) {
+      plugins.splice(idx, 1);
+    }
+    if (plugins.length === 0) {
+      delete config['plugin'];
+    }
+  }
+
   fs.writeFileSync(clientConfig.configPath, JSON.stringify(config, null, 2));
 
   // Remove skill or agent docs depending on client

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -656,6 +656,17 @@ export function install(args: InstallArgs): string {
   }
 
   const existing = getNestedValue(config, clientConfig.mcpPath);
+
+  if (clientConfig.pluginPackage) {
+    const plugins = Array.isArray(config['plugin']) ? config['plugin'] as string[] : [];
+    if (!plugins.includes(clientConfig.pluginPackage)) {
+      plugins.push(clientConfig.pluginPackage);
+      config['plugin'] = plugins;
+      fs.mkdirSync(path.dirname(clientConfig.configPath), { recursive: true });
+      fs.writeFileSync(clientConfig.configPath, JSON.stringify(config, null, 2));
+    }
+  }
+
   if (existing && !args.force) {
     return `Already installed for ${clientConfig.name}. Use --force to overwrite.`;
   }
@@ -673,14 +684,6 @@ export function install(args: InstallArgs): string {
   }
   
   setNestedValue(config, clientConfig.mcpPath, mcpEntry);
-
-  if (clientConfig.pluginPackage) {
-    const plugins = Array.isArray(config['plugin']) ? config['plugin'] as string[] : [];
-    if (!plugins.includes(clientConfig.pluginPackage)) {
-      plugins.push(clientConfig.pluginPackage);
-    }
-    config['plugin'] = plugins;
-  }
   
   const configDir = path.dirname(clientConfig.configPath);
   if (!fs.existsSync(configDir)) {

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -118,11 +118,12 @@ export class NoteRepository {
   private readonly sessionId: string;
   private readonly telemetryEnabled: boolean;
 
-  constructor(docsPath: string = '~/.local/share/open-zk-kb', options: { telemetryEnabled?: boolean } = {}) {
+  constructor(docsPath: string = '~/.local/share/open-zk-kb', options: { telemetryEnabled?: boolean; readonly?: boolean } = {}) {
     try {
-      // Telemetry is configured once per repository/MCP connection. Opt-out disables both
-      // tool_telemetry inserts and note access metadata writes for privacy consistency.
-      this.telemetryEnabled = options.telemetryEnabled === true;
+      const isReadonly = options.readonly === true;
+
+      // Read-only mode forces telemetry off.
+      this.telemetryEnabled = isReadonly ? false : options.telemetryEnabled === true;
       this.sessionId = crypto.randomUUID();
       const originalPath = docsPath;
       this.docsPath = expandPath(docsPath);
@@ -135,6 +136,16 @@ export class NoteRepository {
       }
 
       this.dbPath = path.join(this.docsPath, '.index', 'knowledge.db');
+
+      if (isReadonly) {
+        if (!fs.existsSync(this.dbPath)) {
+          throw new Error(`Database not found at ${this.dbPath} — vault may not be initialized`);
+        }
+        this.db = new Database(this.dbPath, { readonly: true });
+        this.schemaManager = new SchemaManager(this.db);
+        return;
+      }
+
       const dbDir = path.dirname(this.dbPath);
 
       try {
@@ -1860,8 +1871,8 @@ export class NoteRepository {
   }
 }
 
-export function createNoteRepository(docsPath?: string): NoteRepository {
-  return new NoteRepository(docsPath);
+export function createNoteRepository(docsPath?: string, options?: { telemetryEnabled?: boolean; readonly?: boolean }): NoteRepository {
+  return new NoteRepository(docsPath, options);
 }
 
 export default createNoteRepository;

--- a/tests/docker/plugin-verify-test.ts
+++ b/tests/docker/plugin-verify-test.ts
@@ -1,0 +1,178 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { NoteRepository } from '../../src/storage/NoteRepository.js';
+import { detectProject } from '../../src/opencode-plugin/project-detect.js';
+import { fetchKbContext, formatContext } from '../../src/opencode-plugin/context.js';
+import { createKbPlugin } from '../../src/opencode-plugin/plugin.js';
+
+async function run() {
+  let passed = 0;
+  let failed = 0;
+
+  const check = (name: string, ok: boolean, detail?: string) => {
+    if (ok) { console.log(`  ✅ ${name}`); passed++; }
+    else { console.log(`  ❌ ${name}${detail ? `: ${detail}` : ''}`); failed++; }
+  };
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-verify-'));
+
+  try {
+    const repo = new NoteRepository(tmpDir);
+
+    repo.store('Domain: test-workspace conventions and scope', {
+      title: 'test-workspace domain',
+      kind: 'domain' as any,
+      status: 'permanent',
+      tags: ['project:test-workspace'],
+      summary: 'Test workspace for plugin verification',
+      guidance: 'Follow test conventions',
+    });
+
+    repo.store('Chose FTS5 for plugin search', {
+      title: 'FTS5 search decision',
+      kind: 'decision',
+      status: 'permanent',
+      tags: ['project:test-workspace', 'architecture'],
+      summary: 'Plugin uses FTS5 only',
+      guidance: 'No embeddings in plugin',
+    });
+
+    repo.store('User prefers Bun over Node', {
+      title: 'Bun runtime preference',
+      kind: 'personalization',
+      status: 'permanent',
+      tags: ['project:test-workspace', 'runtime'],
+      summary: 'Bun is required runtime',
+      guidance: 'Always use bun commands',
+    });
+
+    repo.close();
+
+    // 1. Project detection
+    const project = detectProject(`${os.homedir()}/dev/test-workspace`);
+    check('detectProject extracts project from ~/dev/ path', project === 'test-workspace');
+
+    const noProject = detectProject('/');
+    check('detectProject returns null for root', noProject === null);
+
+    // 2. Readonly NoteRepository
+    const readonlyRepo = new NoteRepository(tmpDir, { readonly: true });
+    check('readonly repo opens existing DB', readonlyRepo !== null);
+
+    const projectNotes = readonlyRepo.getByTag('project:test-workspace');
+    const domain = projectNotes.find(n => (n.kind as string) === 'domain') ?? null;
+    check('readonly repo finds domain note', domain !== null && (domain.kind as string) === 'domain');
+
+    const results = readonlyRepo.search('FTS5', { tags: ['project:test-workspace'] });
+    check('readonly repo search returns results', results.length > 0);
+    readonlyRepo.close();
+
+    // 3. Readonly repo throws on missing DB
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-empty-'));
+    let threw = false;
+    try { new NoteRepository(emptyDir, { readonly: true }); }
+    catch { threw = true; }
+    check('readonly repo throws for missing DB', threw);
+    fs.rmSync(emptyDir, { recursive: true, force: true });
+
+    // 4. Context fetching
+    const readRepo2 = new NoteRepository(tmpDir, { readonly: true });
+    const ctx = fetchKbContext(readRepo2, 'test-workspace');
+    check('fetchKbContext finds domain note', ctx.domainNote !== null);
+    check('fetchKbContext returns project notes', ctx.recentNotes.length > 0);
+    check('fetchKbContext excludes domain from recent', !ctx.recentNotes.some(n => n.id === ctx.domainNote?.id));
+    readRepo2.close();
+
+    // 5. Context formatting
+    const formatted = formatContext(ctx);
+    check('formatContext produces non-empty output', formatted.length > 0);
+    check('formatContext includes project header', formatted.includes('project: test-workspace'));
+    check('formatContext includes domain section', formatted.includes('Domain Note'));
+    check('formatContext contains XML note tags', formatted.includes('<note'));
+
+    const emptyFormatted = formatContext({ domainNote: null, recentNotes: [], project: 'empty' });
+    check('formatContext returns empty for no notes', emptyFormatted === '');
+
+    // 6. Plugin lifecycle — noop when no project
+    const noopFactory = createKbPlugin();
+    const noopHooks = await noopFactory({ directory: '/', client: { app: { log: () => {} } } });
+    const noopOutput = { system: [] as string[] };
+    await noopHooks['experimental.chat.system.transform'](
+      { sessionID: 'ses_noop', model: { id: 'test', providerID: 'test' } },
+      noopOutput,
+    );
+    check('noop plugin injects nothing', noopOutput.system.length === 0);
+
+    // 7. Plugin lifecycle — inject on session.created → system.transform
+    process.env.__OPEN_ZK_KB_TEST_VAULT = tmpDir;
+    const factory = createKbPlugin();
+    const hooks = await factory({
+      directory: `${os.homedir()}/dev/test-workspace`,
+      client: { app: { log: () => {} } },
+    });
+    delete process.env.__OPEN_ZK_KB_TEST_VAULT;
+
+    await hooks.event({
+      event: { type: 'session.created', properties: { info: { id: 'ses_inject' } } },
+    });
+
+    const injectOutput = { system: [] as string[] };
+    await hooks['experimental.chat.system.transform'](
+      { sessionID: 'ses_inject', model: { id: 'test', providerID: 'test' } },
+      injectOutput,
+    );
+    check('plugin injects context after session.created', injectOutput.system.length > 0);
+    check('injected context contains KB header', (injectOutput.system[0] || '').includes('Knowledge Base Context'));
+
+    // 8. Inject-once (consumed marker)
+    const secondOutput = { system: [] as string[] };
+    await hooks['experimental.chat.system.transform'](
+      { sessionID: 'ses_inject', model: { id: 'test', providerID: 'test' } },
+      secondOutput,
+    );
+    check('second transform call injects nothing (consumed)', secondOutput.system.length === 0);
+
+    // 9. Compaction re-injects + resets marker
+    const compactOutput = { context: [] as string[] };
+    await hooks['experimental.session.compacting']({ sessionID: 'ses_inject' }, compactOutput);
+    check('compaction pushes context', compactOutput.context.length > 0);
+
+    const postCompactOutput = { system: [] as string[] };
+    await hooks['experimental.chat.system.transform'](
+      { sessionID: 'ses_inject', model: { id: 'test', providerID: 'test' } },
+      postCompactOutput,
+    );
+    check('post-compaction transform re-injects', postCompactOutput.system.length > 0);
+
+    // 10. Session cleanup
+    await hooks.event({
+      event: { type: 'session.deleted', properties: { info: { id: 'ses_inject' } } },
+    });
+    const deletedOutput = { system: [] as string[] };
+    await hooks['experimental.chat.system.transform'](
+      { sessionID: 'ses_inject', model: { id: 'test', providerID: 'test' } },
+      deletedOutput,
+    );
+    check('deleted session injects nothing', deletedOutput.system.length === 0);
+
+    // 11. Module shape verification
+    const pluginModule = await import('../../dist/opencode-plugin/index.js');
+    const defaultExport = pluginModule.default;
+    check('module has default export', defaultExport !== undefined);
+    check('default export has id', defaultExport?.id === 'open-zk-kb');
+    check('default export has server function', typeof defaultExport?.server === 'function');
+
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  console.log(`PLUGIN_RESULT:${passed}:${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch((err) => {
+  console.error(`Fatal: ${err}`);
+  console.log('PLUGIN_RESULT:0:99');
+  process.exit(1);
+});

--- a/tests/docker/plugin-verify-test.ts
+++ b/tests/docker/plugin-verify-test.ts
@@ -22,7 +22,7 @@ async function run() {
 
     repo.store('Domain: test-workspace conventions and scope', {
       title: 'test-workspace domain',
-      kind: 'domain' as any,
+      kind: 'domain',
       status: 'permanent',
       tags: ['project:test-workspace'],
       summary: 'Test workspace for plugin verification',
@@ -60,9 +60,8 @@ async function run() {
     const readonlyRepo = new NoteRepository(tmpDir, { readonly: true });
     check('readonly repo opens existing DB', readonlyRepo !== null);
 
-    const projectNotes = readonlyRepo.getByTag('project:test-workspace');
-    const domain = projectNotes.find(n => (n.kind as string) === 'domain') ?? null;
-    check('readonly repo finds domain note', domain !== null && (domain.kind as string) === 'domain');
+    const domain = readonlyRepo.getDomainNote('test-workspace');
+    check('readonly repo finds domain note', domain !== null && domain.kind === 'domain');
 
     const results = readonlyRepo.search('FTS5', { tags: ['project:test-workspace'] });
     check('readonly repo search returns results', results.length > 0);
@@ -105,6 +104,7 @@ async function run() {
     check('noop plugin injects nothing', noopOutput.system.length === 0);
 
     // 7. Plugin lifecycle — inject on session.created → system.transform
+    process.env.NODE_ENV = 'test';
     process.env.__OPEN_ZK_KB_TEST_VAULT = tmpDir;
     const factory = createKbPlugin();
     const hooks = await factory({
@@ -112,6 +112,7 @@ async function run() {
       client: { app: { log: () => {} } },
     });
     delete process.env.__OPEN_ZK_KB_TEST_VAULT;
+    delete process.env.NODE_ENV;
 
     await hooks.event({
       event: { type: 'session.created', properties: { info: { id: 'ses_inject' } } },

--- a/tests/docker/smoke-test.sh
+++ b/tests/docker/smoke-test.sh
@@ -474,7 +474,25 @@ fi
 bun run src/setup.ts uninstall --client cursor >/dev/null 2>&1 || true
 echo ""
 
-# ─── 18. npm pack produces valid package ───
+# ─── 18. OpenCode plugin hook verification ───
+echo "▸ OpenCode Plugin Verification"
+
+PLUGIN_VAULT_DIR=$(mktemp -d)
+PLUGIN_OUTPUT=$(XDG_DATA_HOME="$PLUGIN_VAULT_DIR" timeout 20 bun run tests/docker/plugin-verify-test.ts 2>/dev/null || true)
+rm -rf "$PLUGIN_VAULT_DIR"
+echo "$PLUGIN_OUTPUT" | grep -E "^  [✅❌]" || true
+
+PLUGIN_RESULT=$(echo "$PLUGIN_OUTPUT" | grep "PLUGIN_RESULT" || echo "PLUGIN_RESULT:0:24")
+PLUGIN_PASS=$(echo "$PLUGIN_RESULT" | cut -d: -f2)
+PLUGIN_FAIL=$(echo "$PLUGIN_RESULT" | cut -d: -f3)
+PASS=$((PASS + PLUGIN_PASS))
+FAIL=$((FAIL + PLUGIN_FAIL))
+if [ "$PLUGIN_FAIL" -gt 0 ]; then
+  TESTS+=("FAIL: plugin verification — $PLUGIN_FAIL failures")
+fi
+echo ""
+
+# ─── 19. npm pack produces valid package ───
 echo "▸ npm pack Validation"
 
 PACK_OUTPUT=$(bun pm pack 2>&1 || npm pack 2>&1 || true)
@@ -517,7 +535,7 @@ else
 fi
 echo ""
 
-# ─── 19. CLI entry points respond ───
+# ─── 20. CLI entry points respond ───
 echo "▸ CLI Entry Points"
 
 OUTPUT=$(timeout 5 bun dist/cli.js --help 2>&1 || true)
@@ -535,7 +553,7 @@ else
 fi
 echo ""
 
-# ─── 20. Local model smoke tests (if LOCAL_MODELS=1) ───
+# ─── 21. Local model smoke tests (if LOCAL_MODELS=1) ───
 if [ "${LOCAL_MODELS:-}" = "1" ]; then
   echo "▸ Local Model Quality Tests"
 

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -78,20 +78,20 @@ describe('NoteRepository readonly mode', () => {
     readonlyRepo.close();
   });
 
-  it('getByTag works on readonly connection', () => {
-    ctx.engine.store('Decision content for myapp', {
-      title: 'myapp decision',
-      kind: 'decision',
+  it('getDomainNote works on readonly connection', () => {
+    ctx.engine.store('Domain content for myapp', {
+      title: 'myapp domain',
+      kind: 'domain',
       status: 'permanent',
       tags: ['project:myapp'],
-      summary: 'Decision for myapp',
+      summary: 'Domain note for myapp',
       guidance: 'Follow these conventions',
     });
 
     const readonlyRepo = new NoteRepository(ctx.tempDir, { readonly: true });
-    const results = readonlyRepo.getByTag('project:myapp');
-    expect(results.length).toBeGreaterThan(0);
-    expect(results[0].kind).toBe('decision');
+    const domain = readonlyRepo.getDomainNote('myapp');
+    expect(domain).not.toBeNull();
+    expect(domain!.kind).toBe('domain');
     readonlyRepo.close();
   });
 
@@ -122,7 +122,7 @@ describe('fetchKbContext', () => {
   it('returns domain note and relevant permanent notes', () => {
     ctx.engine.store('Domain: conventions for myapp', {
       title: 'myapp domain',
-      kind: 'domain' as any,
+      kind: 'domain',
       status: 'permanent',
       tags: ['project:myapp'],
       summary: 'Project conventions',
@@ -148,7 +148,7 @@ describe('fetchKbContext', () => {
   it('excludes domain note from recent results', () => {
     ctx.engine.store('Domain content', {
       title: 'myapp domain',
-      kind: 'domain' as any,
+      kind: 'domain',
       status: 'permanent',
       tags: ['project:myapp'],
       summary: 'Domain note',
@@ -200,7 +200,7 @@ describe('formatContext', () => {
       domainNote: {
         id: '2026043000000000',
         title: 'myapp domain',
-        kind: 'domain' as any,
+        kind: 'domain',
         status: 'permanent',
         lifecycle: 'living',
         type: 'atomic',
@@ -254,7 +254,7 @@ describe('createKbPlugin lifecycle', () => {
   it('injects context on first LLM turn after session.created', async () => {
     ctx.engine.store('Domain rules for testproject', {
       title: 'testproject domain',
-      kind: 'domain' as any,
+      kind: 'domain',
       status: 'permanent',
       tags: ['project:testproject'],
       summary: 'Test project domain',
@@ -293,7 +293,7 @@ describe('createKbPlugin lifecycle', () => {
   it('only injects once per session (consume marker)', async () => {
     ctx.engine.store('Domain content', {
       title: 'testproject domain',
-      kind: 'domain' as any,
+      kind: 'domain',
       status: 'permanent',
       tags: ['project:testproject'],
       summary: 'Domain note',
@@ -333,7 +333,7 @@ describe('createKbPlugin lifecycle', () => {
   it('re-injects on compaction and resets marker', async () => {
     ctx.engine.store('Domain content', {
       title: 'testproject domain',
-      kind: 'domain' as any,
+      kind: 'domain',
       status: 'permanent',
       tags: ['project:testproject'],
       summary: 'Domain note',
@@ -381,7 +381,7 @@ describe('createKbPlugin lifecycle', () => {
   it('cleans up state on session.deleted', async () => {
     ctx.engine.store('Domain content', {
       title: 'testproject domain',
-      kind: 'domain' as any,
+      kind: 'domain',
       status: 'permanent',
       tags: ['project:testproject'],
       summary: 'Domain note',

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -1,0 +1,417 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createTestHarness, cleanupTestHarness, type TestContext } from './harness';
+import { detectProject } from '../src/opencode-plugin/project-detect';
+import { fetchKbContext, formatContext } from '../src/opencode-plugin/context';
+import { createKbPlugin } from '../src/opencode-plugin/plugin';
+import { NoteRepository } from '../src/storage/NoteRepository';
+
+// ── project-detect ──
+
+describe('detectProject', () => {
+  const originalHome = process.env.HOME;
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+  });
+
+  it('extracts top-level directory under ~/dev/', () => {
+    process.env.HOME = '/Users/teal';
+    expect(detectProject('/Users/teal/dev/open-zk-kb')).toBe('open-zk-kb');
+  });
+
+  it('extracts top-level even for nested paths', () => {
+    process.env.HOME = '/Users/teal';
+    expect(detectProject('/Users/teal/dev/open-zk-kb/src/storage')).toBe('open-zk-kb');
+  });
+
+  it('falls back to basename outside ~/dev/', () => {
+    process.env.HOME = '/Users/teal';
+    expect(detectProject('/tmp/my-project')).toBe('my-project');
+  });
+
+  it('returns null for home directory', () => {
+    process.env.HOME = '/Users/teal';
+    expect(detectProject('/Users/teal')).toBeNull();
+  });
+
+  it('returns null for root', () => {
+    expect(detectProject('/')).toBeNull();
+  });
+});
+
+// ── read-only NoteRepository ──
+
+describe('NoteRepository readonly mode', () => {
+  let ctx: TestContext;
+
+  beforeEach(() => {
+    ctx = createTestHarness();
+  });
+
+  afterEach(() => {
+    cleanupTestHarness(ctx);
+  });
+
+  it('opens existing DB in readonly mode', () => {
+    const readonlyRepo = new NoteRepository(ctx.tempDir, { readonly: true });
+    expect(readonlyRepo).toBeDefined();
+    readonlyRepo.close();
+  });
+
+  it('search works on readonly connection', () => {
+    ctx.engine.store('Test note content', {
+      title: 'Test Note',
+      kind: 'reference',
+      status: 'permanent',
+      tags: ['project:myapp'],
+      summary: 'A test note',
+      guidance: 'Use for testing',
+    });
+
+    const readonlyRepo = new NoteRepository(ctx.tempDir, { readonly: true });
+    const results = readonlyRepo.search('test', { tags: ['project:myapp'] });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].title).toBe('Test Note');
+    readonlyRepo.close();
+  });
+
+  it('getByTag works on readonly connection', () => {
+    ctx.engine.store('Decision content for myapp', {
+      title: 'myapp decision',
+      kind: 'decision',
+      status: 'permanent',
+      tags: ['project:myapp'],
+      summary: 'Decision for myapp',
+      guidance: 'Follow these conventions',
+    });
+
+    const readonlyRepo = new NoteRepository(ctx.tempDir, { readonly: true });
+    const results = readonlyRepo.getByTag('project:myapp');
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].kind).toBe('decision');
+    readonlyRepo.close();
+  });
+
+  it('throws when DB does not exist', () => {
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-empty-'));
+    try {
+      expect(() => new NoteRepository(emptyDir, { readonly: true }))
+        .toThrow('Database not found');
+    } finally {
+      fs.rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── context fetching ──
+
+describe('fetchKbContext', () => {
+  let ctx: TestContext;
+
+  beforeEach(() => {
+    ctx = createTestHarness();
+  });
+
+  afterEach(() => {
+    cleanupTestHarness(ctx);
+  });
+
+  it('returns domain note and relevant permanent notes', () => {
+    ctx.engine.store('Domain: conventions for myapp', {
+      title: 'myapp domain',
+      kind: 'domain' as any,
+      status: 'permanent',
+      tags: ['project:myapp'],
+      summary: 'Project conventions',
+      guidance: 'Follow these rules',
+    });
+
+    ctx.engine.store('We chose FTS5 for search', {
+      title: 'FTS5 search decision',
+      kind: 'decision',
+      status: 'permanent',
+      tags: ['project:myapp'],
+      summary: 'Chose FTS5 over trigram',
+      guidance: 'Use FTS5 for all search',
+    });
+
+    const result = fetchKbContext(ctx.engine, 'myapp');
+    expect(result.project).toBe('myapp');
+    expect(result.domainNote).not.toBeNull();
+    expect(result.domainNote!.kind).toBe('domain');
+    expect(result.recentNotes.length).toBeGreaterThan(0);
+  });
+
+  it('excludes domain note from recent results', () => {
+    ctx.engine.store('Domain content', {
+      title: 'myapp domain',
+      kind: 'domain' as any,
+      status: 'permanent',
+      tags: ['project:myapp'],
+      summary: 'Domain note',
+      guidance: 'Guidance',
+    });
+
+    const result = fetchKbContext(ctx.engine, 'myapp');
+    const recentIds = result.recentNotes.map(n => n.id);
+    if (result.domainNote) {
+      expect(recentIds).not.toContain(result.domainNote.id);
+    }
+  });
+
+  it('excludes index and log kinds', () => {
+    ctx.engine.store('Some decision', {
+      title: 'Decision A',
+      kind: 'decision',
+      status: 'permanent',
+      tags: ['project:myapp'],
+      summary: 'Decision',
+      guidance: 'Follow',
+    });
+
+    const result = fetchKbContext(ctx.engine, 'myapp');
+    for (const note of result.recentNotes) {
+      expect(note.kind).not.toBe('index');
+      expect(note.kind).not.toBe('log');
+    }
+  });
+
+  it('returns empty for project with no notes', () => {
+    const result = fetchKbContext(ctx.engine, 'nonexistent');
+    expect(result.domainNote).toBeNull();
+    expect(result.recentNotes).toHaveLength(0);
+  });
+});
+
+// ── formatContext ──
+
+describe('formatContext', () => {
+  it('returns empty string when no notes', () => {
+    const result = formatContext({ domainNote: null, recentNotes: [], project: 'test' });
+    expect(result).toBe('');
+  });
+
+  it('includes domain note XML', () => {
+    const result = formatContext({
+      project: 'myapp',
+      domainNote: {
+        id: '2026043000000000',
+        title: 'myapp domain',
+        kind: 'domain' as any,
+        status: 'permanent',
+        lifecycle: 'living',
+        type: 'atomic',
+        tags: ['project:myapp'],
+        content: '',
+        summary: 'Project rules',
+        guidance: 'Follow these',
+        path: '/tmp/test.md',
+        updated_at: Date.now(),
+        created_at: Date.now(),
+        word_count: 10,
+      },
+      recentNotes: [],
+    });
+    expect(result).toContain('## Knowledge Base Context (project: myapp)');
+    expect(result).toContain('### Domain Note');
+    expect(result).toContain('<note');
+    expect(result).toContain('kind="domain"');
+  });
+});
+
+// ── plugin lifecycle (3-hook integration) ──
+
+describe('createKbPlugin lifecycle', () => {
+  let ctx: TestContext;
+
+  beforeEach(() => {
+    ctx = createTestHarness();
+  });
+
+  afterEach(() => {
+    cleanupTestHarness(ctx);
+  });
+
+  it('returns noop hooks when no project detected', async () => {
+    const factory = createKbPlugin();
+    const mockCtx = {
+      directory: '/',
+      client: { app: { log: () => {} } },
+    };
+    const hooks = await factory(mockCtx);
+
+    const output = { system: [] as string[] };
+    await hooks['experimental.chat.system.transform'](
+      { sessionID: 'ses_1', model: { id: 'test', providerID: 'test' } },
+      output,
+    );
+    expect(output.system).toHaveLength(0);
+  });
+
+  it('injects context on first LLM turn after session.created', async () => {
+    ctx.engine.store('Domain rules for testproject', {
+      title: 'testproject domain',
+      kind: 'domain' as any,
+      status: 'permanent',
+      tags: ['project:testproject'],
+      summary: 'Test project domain',
+      guidance: 'Follow these rules',
+    });
+    ctx.engine.close();
+
+    const factory = createKbPlugin();
+    const mockCtx = {
+      directory: `${process.env.HOME}/dev/testproject`,
+      client: { app: { log: () => {} } },
+    };
+
+    process.env.__OPEN_ZK_KB_TEST_VAULT = ctx.tempDir;
+    const hooks = await factory(mockCtx);
+    delete process.env.__OPEN_ZK_KB_TEST_VAULT;
+
+    await hooks.event({
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'ses_test' } },
+      },
+    });
+
+    const output = { system: [] as string[] };
+    await hooks['experimental.chat.system.transform'](
+      { sessionID: 'ses_test', model: { id: 'test', providerID: 'test' } },
+      output,
+    );
+
+    expect(output.system.length).toBeGreaterThan(0);
+    expect(output.system[0]).toContain('Knowledge Base Context');
+    expect(output.system[0]).toContain('Domain Note');
+  });
+
+  it('only injects once per session (consume marker)', async () => {
+    ctx.engine.store('Domain content', {
+      title: 'testproject domain',
+      kind: 'domain' as any,
+      status: 'permanent',
+      tags: ['project:testproject'],
+      summary: 'Domain note',
+      guidance: 'Rules',
+    });
+    ctx.engine.close();
+
+    const factory = createKbPlugin();
+    const mockCtx = {
+      directory: `${process.env.HOME}/dev/testproject`,
+      client: { app: { log: () => {} } },
+    };
+
+    process.env.__OPEN_ZK_KB_TEST_VAULT = ctx.tempDir;
+    const hooks = await factory(mockCtx);
+    delete process.env.__OPEN_ZK_KB_TEST_VAULT;
+
+    await hooks.event({
+      event: { type: 'session.created', properties: { info: { id: 'ses_once' } } },
+    });
+
+    const output1 = { system: [] as string[] };
+    await hooks['experimental.chat.system.transform'](
+      { sessionID: 'ses_once', model: { id: 'test', providerID: 'test' } },
+      output1,
+    );
+    expect(output1.system.length).toBeGreaterThan(0);
+
+    const output2 = { system: [] as string[] };
+    await hooks['experimental.chat.system.transform'](
+      { sessionID: 'ses_once', model: { id: 'test', providerID: 'test' } },
+      output2,
+    );
+    expect(output2.system).toHaveLength(0);
+  });
+
+  it('re-injects on compaction and resets marker', async () => {
+    ctx.engine.store('Domain content', {
+      title: 'testproject domain',
+      kind: 'domain' as any,
+      status: 'permanent',
+      tags: ['project:testproject'],
+      summary: 'Domain note',
+      guidance: 'Rules',
+    });
+    ctx.engine.close();
+
+    const factory = createKbPlugin();
+    const mockCtx = {
+      directory: `${process.env.HOME}/dev/testproject`,
+      client: { app: { log: () => {} } },
+    };
+
+    process.env.__OPEN_ZK_KB_TEST_VAULT = ctx.tempDir;
+    const hooks = await factory(mockCtx);
+    delete process.env.__OPEN_ZK_KB_TEST_VAULT;
+
+    await hooks.event({
+      event: { type: 'session.created', properties: { info: { id: 'ses_compact' } } },
+    });
+
+    const output1 = { system: [] as string[] };
+    await hooks['experimental.chat.system.transform'](
+      { sessionID: 'ses_compact', model: { id: 'test', providerID: 'test' } },
+      output1,
+    );
+    expect(output1.system.length).toBeGreaterThan(0);
+
+    const compactOutput = { context: [] as string[] };
+    await hooks['experimental.session.compacting'](
+      { sessionID: 'ses_compact' },
+      compactOutput,
+    );
+    expect(compactOutput.context.length).toBeGreaterThan(0);
+    expect(compactOutput.context[0]).toContain('Knowledge Base Context');
+
+    const output2 = { system: [] as string[] };
+    await hooks['experimental.chat.system.transform'](
+      { sessionID: 'ses_compact', model: { id: 'test', providerID: 'test' } },
+      output2,
+    );
+    expect(output2.system.length).toBeGreaterThan(0);
+  });
+
+  it('cleans up state on session.deleted', async () => {
+    ctx.engine.store('Domain content', {
+      title: 'testproject domain',
+      kind: 'domain' as any,
+      status: 'permanent',
+      tags: ['project:testproject'],
+      summary: 'Domain note',
+      guidance: 'Rules',
+    });
+    ctx.engine.close();
+
+    const factory = createKbPlugin();
+    const mockCtx = {
+      directory: `${process.env.HOME}/dev/testproject`,
+      client: { app: { log: () => {} } },
+    };
+
+    process.env.__OPEN_ZK_KB_TEST_VAULT = ctx.tempDir;
+    const hooks = await factory(mockCtx);
+    delete process.env.__OPEN_ZK_KB_TEST_VAULT;
+
+    await hooks.event({
+      event: { type: 'session.created', properties: { info: { id: 'ses_del' } } },
+    });
+
+    await hooks.event({
+      event: { type: 'session.deleted', properties: { info: { id: 'ses_del' } } },
+    });
+
+    const output = { system: [] as string[] };
+    await hooks['experimental.chat.system.transform'](
+      { sessionID: 'ses_del', model: { id: 'test', providerID: 'test' } },
+      output,
+    );
+    expect(output.system).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an OpenCode plugin that deterministically injects KB context into the system prompt at session start — the core feature of #88
- Plugin reads the vault via a new `readonly` NoteRepository mode (no writes, no telemetry, no schema migrations)
- Installer wires `"plugin": ["open-zk-kb"]` into `opencode.json` alongside the MCP server entry

## Design

**Three-hook lifecycle** (Hindsight pattern):
1. `event` (`session.created`) → pre-fetch domain note + 5 FTS5-ranked permanent notes, cache in memory
2. `experimental.chat.system.transform` → inject cached context on first LLM turn, consume marker
3. `experimental.session.compacting` → re-inject context + reset marker for post-compaction turns

**Ownership boundaries** (#93): Plugin owns injection timing and CWD→project detection. Server owns search ranking and note rendering. Agent owns capture decisions.

**No embeddings in plugin** — FTS5 + project-tag filter is sufficient for <100 project notes, avoids 23MB ONNX cold-start in OpenCode's process.

## Files

| File | Purpose |
|---|---|
| `src/storage/NoteRepository.ts` | `readonly` constructor option — opens DB read-only, skips init |
| `src/opencode-plugin/index.ts` | PluginModule V1 default export |
| `src/opencode-plugin/plugin.ts` | `createKbPlugin()` factory — 3 hooks |
| `src/opencode-plugin/context.ts` | Read-only repo → FTS5 search → formatted context |
| `src/opencode-plugin/project-detect.ts` | `detectProject(directory)` — CWD → project tag |
| `package.json` | `./server` subpath export for V1 resolution |
| `src/setup.ts` | `pluginPackage` field + install/uninstall plugin array management |
| `tests/opencode-plugin.test.ts` | 20 unit tests (bun:test) |
| `tests/docker/plugin-verify-test.ts` | 24 isolated verification checks |
| `tests/docker/smoke-test.sh` | Plugin registration install/uninstall/merge checks |

## Testing

- **Unit tests**: 20 cases — project detection, readonly DB, context fetching, full 3-hook lifecycle
- **Docker verification**: 24 checks — complete hook lifecycle in isolation, module shape V1
- **Smoke tests**: Plugin array written on install, removed on uninstall, preserved during config merge
- All pass: `bun test` (405/405), `bun run lint` (0 errors), `bun run build` (clean)

## Configuration

```json
{
  "plugin": ["open-zk-kb"],
  "mcp": {
    "open-zk-kb": {
      "type": "local",
      "command": ["bunx", "open-zk-kb@latest", "server"],
      "enabled": true
    }
  }
}
```

Or: `bunx open-zk-kb@latest install --client opencode` (registers both MCP + plugin)

## Closes #88 (Phase 1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New OpenCode plugin that injects knowledge base context into AI chat sessions with automatic project detection.
  * Added plugin installation and configuration management.
  * Added readonly mode for knowledge base repository access.

* **Tests**
  * Added comprehensive test coverage for the new plugin functionality and knowledge base integration.

* **Chores**
  * Updated build artifact exports for server distribution.
  * Added test workspace directory to ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->