### PR TITLE
Enhance knowledge-maintain review with structured curation UX (#104)

### DIFF
--- a/.github/workflows/pr-agent-gpt53-codex.yml
+++ b/.github/workflows/pr-agent-gpt53-codex.yml
@@ -40,16 +40,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          config.model: "openrouter/openai/gpt-5.3-codex"
-          config.fallback_models: '["openrouter/openai/gpt-5.2-codex"]'
+          # Model override: MUST NOT appear in .pr_agent.toml — apply_repo_settings()
+          # clobbers env vars for keys present in the TOML. See PR #114.
+          CONFIG__MODEL: "openrouter/openai/gpt-5.3-codex"
+          CONFIG__FALLBACK_MODELS: '["openrouter/openai/gpt-5.2-codex"]'
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "false"
-          # KEEP IN SYNC: Lines below duplicate .pr_agent.toml [pr_reviewer].extra_instructions
-          # with only the MODEL IDENTIFICATION prefix changed. pr-agent env vars shadow TOML
-          # values entirely (no merge), so the full instructions must be repeated here.
-          # If review policy changes, update .pr_agent.toml AND both GPT workflow files.
-          pr_reviewer.extra_instructions: |
+          # KEEP IN SYNC: Full review instruction block with GPT-5.3 Codex model badge.
+          # If review policy changes, update ALL three pr-agent workflow files.
+          PR_REVIEWER__EXTRA_INSTRUCTIONS: |
             MODEL IDENTIFICATION: Always begin your security_concerns text with exactly '[GPT-5.3 Codex] ' (brackets, model name, space) before your assessment. This is required for multi-model comparison across concurrent reviewers.
 
             You are reviewing open-zk-kb — a persistent AI memory MCP server using Zettelkasten.

--- a/.github/workflows/pr-agent-gpt54.yml
+++ b/.github/workflows/pr-agent-gpt54.yml
@@ -40,16 +40,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          config.model: "openrouter/openai/gpt-5.4"
-          config.fallback_models: '["openrouter/openai/gpt-4.1"]'
+          # Model override: MUST NOT appear in .pr_agent.toml — apply_repo_settings()
+          # clobbers env vars for keys present in the TOML. See PR #114.
+          CONFIG__MODEL: "openrouter/openai/gpt-5.4"
+          CONFIG__FALLBACK_MODELS: '["openrouter/openai/gpt-4.1"]'
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "false"
-          # KEEP IN SYNC: Lines below duplicate .pr_agent.toml [pr_reviewer].extra_instructions
-          # with only the MODEL IDENTIFICATION prefix changed. pr-agent env vars shadow TOML
-          # values entirely (no merge), so the full instructions must be repeated here.
-          # If review policy changes, update .pr_agent.toml AND both GPT workflow files.
-          pr_reviewer.extra_instructions: |
+          # KEEP IN SYNC: Full review instruction block with GPT-5.4 model badge.
+          # If review policy changes, update ALL three pr-agent workflow files.
+          PR_REVIEWER__EXTRA_INSTRUCTIONS: |
             MODEL IDENTIFICATION: Always begin your security_concerns text with exactly '[GPT-5.4] ' (brackets, model name, space) before your assessment. This is required for multi-model comparison across concurrent reviewers.
 
             You are reviewing open-zk-kb — a persistent AI memory MCP server using Zettelkasten.

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -40,20 +40,130 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          # Model + review config lives in .pr_agent.toml (repo root)
-          # Only secrets and action-level config set here
-          #
+          # Model override: these MUST NOT appear in .pr_agent.toml because
+          # apply_repo_settings() loads the TOML after Dynaconf env loading and
+          # overwrites any env-var-set values for keys present in the TOML.
+          # By keeping model/fallback_models out of the TOML, env vars survive.
+          # See PR #114 for root-cause analysis.
+          CONFIG__MODEL: "openrouter/anthropic/claude-sonnet-4.6"
+          CONFIG__FALLBACK_MODELS: '["openrouter/google/gemini-2.5-pro", "openrouter/z-ai/glm-5.1"]'
           # 2026-04-29 update: re-enabled /improve to get per-line inline
           # suggestion comments (Greptile/CodeRabbit-style) which `/review`
           # cannot produce. /improve posts comments with native GitHub
-          # ```suggestion``` blocks; pr-agent NEVER auto-commits. Source-verified
-          # in agent-architecture/04-References/pr-agent-extra-instructions-scope.md.
+          # ```suggestion``` blocks; pr-agent NEVER auto-commits.
           # The pr_actions filter in .pr_agent.toml restricts /improve and /review
           # to opened/reopened/ready_for_review only — synchronize events do NOT
           # auto-fire either tool. Use `/improve` or `/review -i` PR comment to
-          # re-run manually. Cost rises ~$3.65/mo → ~$7-12/mo (still below
-          # CodeRabbit's $24).
-          # Rationale: agent-architecture/04-References/cost-analysis-by-tier.md
+          # re-run manually.
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "true"
+          # KEEP IN SYNC: Full review instruction block with Claude model badge.
+          # If review policy changes, update ALL three pr-agent workflow files.
+          # pr-agent env vars shadow TOML values entirely (no merge).
+          PR_REVIEWER__EXTRA_INSTRUCTIONS: |
+            MODEL IDENTIFICATION: Always begin your security_concerns text with exactly '[Claude Sonnet 4.6] ' (brackets, model name, space) before your assessment. This is required for multi-model comparison across concurrent reviewers.
+
+            You are reviewing open-zk-kb — a persistent AI memory MCP server using Zettelkasten.
+            Stack: Bun 1.x (NOT Node.js), TypeScript (strict, ESNext, NodeNext), SQLite FTS5,
+            @modelcontextprotocol/sdk. Runtime: Bun. Tests: bun:test.
+
+            ## Review Behavior
+
+            BE THOROUGH ON FIRST REVIEW. Report ALL findings upfront — do not hold back issues
+            for later rounds. The goal is ONE comprehensive review that converges to resolution,
+            not a trickle of new findings across multiple push cycles.
+
+            ON SUBSEQUENT PUSHES (synchronize events): Only flag issues NEWLY INTRODUCED by the
+            latest commits. Do not re-raise resolved issues. Do not discover things you missed
+            before — that signals the first review was incomplete. If the author addressed your
+            previous feedback correctly, acknowledge resolution and approve.
+
+            CONVERGE TO APPROVAL: After 1-2 rounds of feedback, the review should either approve
+            or clearly state the remaining blocking items. Do not keep finding new nits indefinitely.
+
+            ## Priority Tiers (exactly ONE per finding)
+
+            🔴 **Must Fix** — Blocks merge. Will not approve until resolved.
+            Security vulnerability, data loss, crash in production path, resource leak,
+            auth bypass, hardcoded secrets, MCP stdout pollution, lifecycle enforcement gap.
+
+            🟡 **Should Fix** — Important but non-blocking. Approve with these outstanding.
+            Logic error in edge case, missing error handling, API contract concern, missing
+            regression test for a bugfix, type safety gap (`as any`, `@ts-ignore`).
+
+            ⚪ **Nit** — Take it or leave it. Do not re-raise if author declines.
+            Naming suggestion, minor readability improvement, documentation wording,
+            code organization preference. Maximum 2 nits per review — more than that is noise.
+
+            ## What to Flag
+            - Actual bugs with exact line numbers and variable names
+            - Security issues exploitable in production
+            - Missing error handling on I/O boundaries (DB, filesystem, fetch)
+            - API contract violations (param removal, type changes without defaults)
+            - Lifecycle violations: snapshot notes mutated, append-only notes rewritten
+            - MCP protocol violations: console.log/warn/error in server code (pollutes stdout)
+
+            ## What NOT to Flag
+            - Theoretical risks without concrete exploitation path
+            - Issues in unchanged code outside the diff
+            - Style preferences handled by ESLint (import order, trailing commas, formatting)
+            - "Consider using library X" suggestions
+            - Generic praise or filler ("Great job", "Looks good overall", "Nice work")
+            - Node.js alternatives — this project uses Bun exclusively
+            - Repeating a finding the author already addressed in a previous round
+
+            ## Rules (WHEN condition → THEN check → BECAUSE rationale)
+
+            R1. MCP STDOUT SAFETY
+            WHEN code is in src/ (excluding setup.ts and scripts/)
+            THEN verify: no console.log, console.warn, console.error — use logToFile() only
+            BECAUSE MCP stdio transport requires clean stdout. Any console output breaks
+                 the protocol. Real fix: PR #97 added this as a documented anti-pattern.
+
+            R2. LIFECYCLE ENFORCEMENT
+            WHEN code modifies NoteRepository or tool-handlers
+            THEN verify: snapshot notes reject updates, append-only notes reject rewrites,
+                 LifecycleViolationError is thrown (not swallowed)
+            BECAUSE lifecycle rules are server-enforced invariants (PR #96, schema v6).
+
+            R3. STRUCTURAL KIND GUARD
+            WHEN code touches handleStore or handleMaintain
+            THEN verify: STRUCTURAL_KINDS (index, log) skip navigation hooks to prevent
+                 infinite loops. Auto-generated notes cannot be manually created.
+            BECAUSE PR #99 introduced navigation hooks — missing guards cause infinite recursion.
+
+            R4. DUAL STORAGE SYNC
+            WHEN code modifies note content or metadata
+            THEN verify: both filesystem (.md) and SQLite index are updated. Filesystem is
+                 source of truth — DB is rebuilt from files via rebuildFromFiles().
+            BECAUSE split-brain between file and DB causes silent data inconsistency.
+
+            R5. CONFIG INTEGRITY
+            WHEN code modifies .toml, .yaml, or .json configuration files
+            THEN verify: no TOML section shadowing (new [section] captures subsequent keys),
+                 no type mismatches, all new config keys have sensible defaults in config.ts
+            BECAUSE TOML section scoping is silent — misplaced keys end up in wrong sections.
+                 Real bug: Cubic caught this on PR #100.
+
+            R6. GITHUB ACTIONS SECURITY
+            WHEN code modifies .github/workflows/*.yml
+            THEN verify: actions pinned to SHA (not tags), secrets not exposed to forks,
+                 minimal permissions, no pull_request_target without careful checkout handling
+            BECAUSE public repo workflows are attack surface for secret exfiltration.
+
+            R7. OWNERSHIP MODEL COMPLIANCE
+            WHEN a PR adds server-side behavior
+            THEN verify: server returns data with annotations (not directives), no auto-modify
+                 of stored content beyond what caller requested, no skill instructions asking
+                 agents to replicate server computation
+            BECAUSE ownership policy (#93) — "server computes, agent judges."
+
+            ## Filetype-Specific Checks
+
+            TOML files: Verify section scoping, check that keys land in intended section.
+            YAML files: Check for hardcoded secrets, overly permissive permissions, unpinned actions.
+            Markdown files (.md): This repo treats .md as first-class policy content (AGENTS.md,
+                 architecture.md). Review for accuracy, consistency with code, and stale references.
+            Test files: Verify regression tests for bugfixes, proper cleanup via cleanupTestHarness(),
+                 no .skip without justification, no real side effects (mock OS interactions).

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -7,10 +7,20 @@
 # defaulting to the default branch). So changes here take effect for all PRs
 # once they merge to dev.
 #
-# WORKFLOW ENV VARS in .github/workflows/pr-agent.yml only set
-# [github_action_config] flags (auto_review, auto_describe, auto_improve).
-# The GPT comparison workflows also override config.model, config.fallback_models,
-# and pr_reviewer.extra_instructions via env vars for per-model labeling.
+# ENV VAR OVERRIDE MECHANISM (2026-04-30):
+# pr-agent uses Dynaconf for config. Both dotted (config.model) and
+# double-underscore (CONFIG__MODEL) env var formats work — Dynaconf's
+# _dotted_set handles both via dynaconf/base.py L1172-1178.
+#
+# CRITICAL: apply_repo_settings() (git_providers/utils.py) loads this TOML
+# and calls get_settings().set(section, merged_dict, merge=False) which
+# OVERWRITES any env-var-set values for keys present in the TOML. Only keys
+# NOT present in this TOML survive as env var overrides. Therefore model,
+# fallback_models, and pr_reviewer.extra_instructions are set per-workflow
+# via env vars and MUST NOT appear in this file. See PR #114 root-cause.
+#
+# GITHUB_ACTION_CONFIG.* settings survive because github_action_runner.py
+# re-reads them via get_setting_or_env() AFTER apply_repo_settings().
 #
 # extra_instructions SCOPE: controls what the LLM thinks about (categories,
 # severity language, what NOT to flag, WHEN/THEN/BECAUSE rules) but CANNOT
@@ -19,18 +29,9 @@
 # See: agent-architecture/04-References/pr-agent-extra-instructions-scope.md
 
 [config]
-# Model swap: Kimi K2.6 → Claude Sonnet 4.6 (2026-04-30)
-# Rationale: Kimi K2.6 + reasoning_effort=high takes 13+ min on 500-line PRs
-# (35K tokens, super-linear latency scaling). Sonnet 4.6 completes in 2-3 min
-# at 90 tok/s, ranks #4 on CR-Bench (F1 0.62, 14% critical FNR), and is the
-# recommended model for high-volume code review per BestLLM/Git AutoReview.
-# Cost delta: ~$0.19 → ~$0.55 per review (+$10.80/mo at 30 PRs).
-# Prior rationale: agent-architecture/04-references/openzkkb-pr-review-current-state.md
-model = "openrouter/anthropic/claude-sonnet-4.6"
-fallback_models = [
-    "openrouter/google/gemini-2.5-pro",
-    "openrouter/z-ai/glm-5.1",
-]
+# model + fallback_models: set per-workflow via CONFIG__MODEL / CONFIG__FALLBACK_MODELS
+# env vars. DO NOT add them here — apply_repo_settings() would clobber the env vars.
+# See header comment and PR #114 for the root-cause analysis.
 custom_model_max_tokens = 200000
 ai_timeout = 300
 response_language = "en-US"
@@ -83,116 +84,9 @@ require_ticket_analysis_review = false
 enable_review_labels_security = true
 enable_review_labels_effort = false
 publish_output_no_suggestions = true
-
-extra_instructions = """\
-MODEL IDENTIFICATION: Always begin your security_concerns text with exactly \
-'[Claude Sonnet 4.6] ' (brackets, model name, space) before your assessment. \
-This is required for multi-model comparison across concurrent reviewers.
-
-You are reviewing open-zk-kb — a persistent AI memory MCP server using Zettelkasten.
-Stack: Bun 1.x (NOT Node.js), TypeScript (strict, ESNext, NodeNext), SQLite FTS5,
-@modelcontextprotocol/sdk. Runtime: Bun. Tests: bun:test.
-
-## Review Behavior
-
-BE THOROUGH ON FIRST REVIEW. Report ALL findings upfront — do not hold back issues
-for later rounds. The goal is ONE comprehensive review that converges to resolution,
-not a trickle of new findings across multiple push cycles.
-
-ON SUBSEQUENT PUSHES (synchronize events): Only flag issues NEWLY INTRODUCED by the
-latest commits. Do not re-raise resolved issues. Do not discover things you missed
-before — that signals the first review was incomplete. If the author addressed your
-previous feedback correctly, acknowledge resolution and approve.
-
-CONVERGE TO APPROVAL: After 1-2 rounds of feedback, the review should either approve
-or clearly state the remaining blocking items. Do not keep finding new nits indefinitely.
-
-## Priority Tiers (exactly ONE per finding)
-
-🔴 **Must Fix** — Blocks merge. Will not approve until resolved.
-Security vulnerability, data loss, crash in production path, resource leak,
-auth bypass, hardcoded secrets, MCP stdout pollution, lifecycle enforcement gap.
-
-🟡 **Should Fix** — Important but non-blocking. Approve with these outstanding.
-Logic error in edge case, missing error handling, API contract concern, missing
-regression test for a bugfix, type safety gap (`as any`, `@ts-ignore`).
-
-⚪ **Nit** — Take it or leave it. Do not re-raise if author declines.
-Naming suggestion, minor readability improvement, documentation wording,
-code organization preference. Maximum 2 nits per review — more than that is noise.
-
-## What to Flag
-- Actual bugs with exact line numbers and variable names
-- Security issues exploitable in production
-- Missing error handling on I/O boundaries (DB, filesystem, fetch)
-- API contract violations (param removal, type changes without defaults)
-- Lifecycle violations: snapshot notes mutated, append-only notes rewritten
-- MCP protocol violations: console.log/warn/error in server code (pollutes stdout)
-
-## What NOT to Flag
-- Theoretical risks without concrete exploitation path
-- Issues in unchanged code outside the diff
-- Style preferences handled by ESLint (import order, trailing commas, formatting)
-- "Consider using library X" suggestions
-- Generic praise or filler ("Great job", "Looks good overall", "Nice work")
-- Node.js alternatives — this project uses Bun exclusively
-- Repeating a finding the author already addressed in a previous round
-
-## Rules (WHEN condition → THEN check → BECAUSE rationale)
-
-R1. MCP STDOUT SAFETY
-WHEN code is in src/ (excluding setup.ts and scripts/)
-THEN verify: no console.log, console.warn, console.error — use logToFile() only
-BECAUSE MCP stdio transport requires clean stdout. Any console output breaks
-     the protocol. Real fix: PR #97 added this as a documented anti-pattern.
-
-R2. LIFECYCLE ENFORCEMENT
-WHEN code modifies NoteRepository or tool-handlers
-THEN verify: snapshot notes reject updates, append-only notes reject rewrites,
-     LifecycleViolationError is thrown (not swallowed)
-BECAUSE lifecycle rules are server-enforced invariants (PR #96, schema v6).
-
-R3. STRUCTURAL KIND GUARD
-WHEN code touches handleStore or handleMaintain
-THEN verify: STRUCTURAL_KINDS (index, log) skip navigation hooks to prevent
-     infinite loops. Auto-generated notes cannot be manually created.
-BECAUSE PR #99 introduced navigation hooks — missing guards cause infinite recursion.
-
-R4. DUAL STORAGE SYNC
-WHEN code modifies note content or metadata
-THEN verify: both filesystem (.md) and SQLite index are updated. Filesystem is
-     source of truth — DB is rebuilt from files via rebuildFromFiles().
-BECAUSE split-brain between file and DB causes silent data inconsistency.
-
-R5. CONFIG INTEGRITY
-WHEN code modifies .toml, .yaml, or .json configuration files
-THEN verify: no TOML section shadowing (new [section] captures subsequent keys),
-     no type mismatches, all new config keys have sensible defaults in config.ts
-BECAUSE TOML section scoping is silent — misplaced keys end up in wrong sections.
-     Real bug: Cubic caught this on PR #100.
-
-R6. GITHUB ACTIONS SECURITY
-WHEN code modifies .github/workflows/*.yml
-THEN verify: actions pinned to SHA (not tags), secrets not exposed to forks,
-     minimal permissions, no pull_request_target without careful checkout handling
-BECAUSE public repo workflows are attack surface for secret exfiltration.
-
-R7. OWNERSHIP MODEL COMPLIANCE
-WHEN a PR adds server-side behavior
-THEN verify: server returns data with annotations (not directives), no auto-modify
-     of stored content beyond what caller requested, no skill instructions asking
-     agents to replicate server computation
-BECAUSE ownership policy (#93) — "server computes, agent judges."
-
-## Filetype-Specific Checks
-
-TOML files: Verify section scoping, check that keys land in intended section.
-YAML files: Check for hardcoded secrets, overly permissive permissions, unpinned actions.
-Markdown files (.md): This repo treats .md as first-class policy content (AGENTS.md,
-     architecture.md). Review for accuracy, consistency with code, and stale references.
-Test files: Verify regression tests for bugfixes, proper cleanup via cleanupTestHarness(),
-     no .skip without justification, no real side effects (mock OS interactions).
-"""
+# extra_instructions: set per-workflow via PR_REVIEWER__EXTRA_INSTRUCTIONS env var.
+# Each workflow carries the full instruction block with its own model badge.
+# DO NOT add extra_instructions here — apply_repo_settings() would clobber env vars.
 
 # ---------------------------------------------------------------------------
 # Code Suggestions Tool

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -123,6 +123,26 @@ Use `knowledge-overview` at the start of a project session to orient yourself:
 - Optional: `logEntries` (number, default 10) to control how many log entries are shown
 
 ### Maintenance
-- `knowledge-maintain stats` — KB health | `knowledge-maintain review` — stale notes
+- `knowledge-maintain stats` — KB health
+- `knowledge-maintain review` — curate stale notes (see below)
+
+### Review & Curate
+`knowledge-maintain review` returns numbered candidates with signals and suggested actions:
+
+```
+### [1] "Note Title" (noteId)
+kind: observation | status: fleeting | staleness: 45 days
+Accesses: 0 | Backlinks: 0 (unlinked) | Words: 89
+⮕ Suggested: ARCHIVE — Zero accesses, 45 days old, no backlinks — likely stale
+```
+
+**Workflow**: review → decide per note → act:
+1. Run `knowledge-maintain review` (optional: `limit`, `filter`, `days`)
+2. For each candidate, decide: **promote** (valuable), **archive** (stale), **delete** (wrong), or **skip**
+3. Act: `knowledge-maintain promote/archive/delete` with `noteId=<id>`
+
+**Signals per candidate**: kind, status, staleness days, access count, backlinks (0 = "unlinked"), word count (flags "oversized" against kind target).
+
+**Suggested actions are hints, not commands** — always apply your own judgment.
 
 For detailed kind descriptions and examples, see [kinds-reference.md](kinds-reference.md).

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -129,7 +129,7 @@ Use `knowledge-overview` at the start of a project session to orient yourself:
 ### Review & Curate
 `knowledge-maintain review` returns numbered candidates with signals and suggested actions:
 
-```
+```text
 ### [1] "Note Title" (noteId)
 kind: observation | status: fleeting | staleness: 45 days
 Accesses: 0 | Backlinks: 0 (unlinked) | Words: 89

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -1735,8 +1735,8 @@ export class NoteRepository {
     filter?: 'fleeting' | 'permanent',
     daysThreshold: number = 14,
     limit: number = 3,
-    promotionThreshold: number = 2,
     exemptKinds: NoteKind[] = [],
+    staleCutoff?: number,
   ): {
     fleeting: { notes: NoteMetadata[]; total: number };
     permanent: { notes: NoteMetadata[]; total: number };
@@ -1748,14 +1748,29 @@ export class NoteRepository {
       ? ` AND kind NOT IN (${exemptKinds.map(() => '?').join(',')})`
       : '';
 
+    // Exclude stale fleeting notes from candidates (they appear in a separate section)
+    const staleClause = staleCutoff != null
+      ? ' AND COALESCE(n.last_accessed_at, n.created_at) > ?'
+      : '';
+
+    // Only count live backlinks (exclude links from archived sources)
+    const backlinkSubquery = `(
+      SELECT l.target_id, COUNT(*) as cnt
+      FROM note_links l
+      JOIN notes src ON src.id = l.source_id
+      WHERE src.status != 'archived'
+      GROUP BY l.target_id
+    )`;
+
     const queryFleeting = (lim: number) => {
-      const params: (string | number)[] = [cutoff, ...exemptKinds, lim];
+      const params: (string | number)[] = [cutoff, ...(staleCutoff != null ? [staleCutoff] : []), ...exemptKinds, lim];
       return this.db.prepare(`
         SELECT n.*, COALESCE(bl.cnt, 0) as backlinks_count
         FROM notes n
-        LEFT JOIN (SELECT target_id, COUNT(*) as cnt FROM note_links GROUP BY target_id) bl ON bl.target_id = n.id
+        LEFT JOIN ${backlinkSubquery} bl ON bl.target_id = n.id
         WHERE n.status = 'fleeting' 
           AND n.created_at < ?
+          ${staleClause}
           ${exemptPlaceholders}
         ORDER BY n.access_count ASC, n.created_at ASC
         LIMIT ?
@@ -1763,10 +1778,11 @@ export class NoteRepository {
     };
 
     const countFleeting = () => {
-      const params: (string | number)[] = [cutoff, ...exemptKinds];
+      const params: (string | number)[] = [cutoff, ...(staleCutoff != null ? [staleCutoff] : []), ...exemptKinds];
       return this.db.prepare(`
-        SELECT COUNT(*) as count FROM notes 
-        WHERE status = 'fleeting' AND created_at < ?
+        SELECT COUNT(*) as count FROM notes n
+        WHERE n.status = 'fleeting' AND n.created_at < ?
+        ${staleClause}
         ${exemptPlaceholders}
       `).get(...params) as { count: number };
     };
@@ -1776,7 +1792,7 @@ export class NoteRepository {
       return this.db.prepare(`
         SELECT n.*, COALESCE(bl.cnt, 0) as backlinks_count
         FROM notes n
-        LEFT JOIN (SELECT target_id, COUNT(*) as cnt FROM note_links GROUP BY target_id) bl ON bl.target_id = n.id
+        LEFT JOIN ${backlinkSubquery} bl ON bl.target_id = n.id
         WHERE n.status = 'permanent' 
           AND n.created_at < ?
           AND n.access_count = 0
@@ -1789,8 +1805,8 @@ export class NoteRepository {
     const countPermanent = () => {
       const params: (string | number)[] = [cutoff, ...exemptKinds];
       return this.db.prepare(`
-        SELECT COUNT(*) as count FROM notes 
-        WHERE status = 'permanent' AND created_at < ? AND access_count = 0
+        SELECT COUNT(*) as count FROM notes n
+        WHERE n.status = 'permanent' AND n.created_at < ? AND n.access_count = 0
         ${exemptPlaceholders}
       `).get(...params) as { count: number };
     };

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -1749,23 +1749,24 @@ export class NoteRepository {
       : '';
 
     const queryFleeting = (lim: number) => {
-      const params: (string | number)[] = [cutoff, promotionThreshold, ...exemptKinds, lim];
+      const params: (string | number)[] = [cutoff, ...exemptKinds, lim];
       return this.db.prepare(`
-        SELECT * FROM notes 
-        WHERE status = 'fleeting' 
-          AND created_at < ?
-          AND access_count < ?
+        SELECT n.*, COALESCE(bl.cnt, 0) as backlinks_count
+        FROM notes n
+        LEFT JOIN (SELECT target_id, COUNT(*) as cnt FROM note_links GROUP BY target_id) bl ON bl.target_id = n.id
+        WHERE n.status = 'fleeting' 
+          AND n.created_at < ?
           ${exemptPlaceholders}
-        ORDER BY access_count ASC, created_at ASC
+        ORDER BY n.access_count ASC, n.created_at ASC
         LIMIT ?
       `).all(...params) as NoteMetadata[];
     };
 
     const countFleeting = () => {
-      const params: (string | number)[] = [cutoff, promotionThreshold, ...exemptKinds];
+      const params: (string | number)[] = [cutoff, ...exemptKinds];
       return this.db.prepare(`
         SELECT COUNT(*) as count FROM notes 
-        WHERE status = 'fleeting' AND created_at < ? AND access_count < ?
+        WHERE status = 'fleeting' AND created_at < ?
         ${exemptPlaceholders}
       `).get(...params) as { count: number };
     };
@@ -1773,12 +1774,14 @@ export class NoteRepository {
     const queryPermanent = (lim: number) => {
       const params: (string | number)[] = [cutoff, ...exemptKinds, lim];
       return this.db.prepare(`
-        SELECT * FROM notes 
-        WHERE status = 'permanent' 
-          AND created_at < ?
-          AND access_count = 0
+        SELECT n.*, COALESCE(bl.cnt, 0) as backlinks_count
+        FROM notes n
+        LEFT JOIN (SELECT target_id, COUNT(*) as cnt FROM note_links GROUP BY target_id) bl ON bl.target_id = n.id
+        WHERE n.status = 'permanent' 
+          AND n.created_at < ?
+          AND n.access_count = 0
           ${exemptPlaceholders}
-        ORDER BY created_at ASC
+        ORDER BY n.created_at ASC
         LIMIT ?
       `).all(...params) as NoteMetadata[];
     };
@@ -1796,6 +1799,7 @@ export class NoteRepository {
       ...r,
       kind: (r.kind || 'observation') as NoteKind,
       tags: JSON.parse(r.tags as unknown as string),
+      backlinks_count: r.backlinks_count || 0,
     });
 
     if (filter === 'fleeting') {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -71,17 +71,23 @@ function atomicityWarning(kind: NoteKind, wordCount: number): string | null {
   return null;
 }
 
-function formatDate(timestamp: number): string {
-  const date = new Date(timestamp);
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-  return `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
-}
-
-function getRecommendation(note: NoteMetadata, daysOld: number, promotionThreshold: number = 2): string {
+function getRecommendation(
+  note: NoteMetadata,
+  daysOld: number,
+  promotionThreshold: number = 2,
+): { action: 'promote' | 'archive' | 'review'; rationale: string } {
   const accesses = note.access_count || 0;
-  if (accesses >= promotionThreshold) return '2caa Promote';
-  if (accesses === 0 && daysOld > 30) return '1f44 Archive';
-  return '1f914 Review';
+  const backlinks = note.backlinks_count || 0;
+  if (accesses >= promotionThreshold) {
+    return { action: 'promote', rationale: `Accessed ${accesses} times (threshold: ${promotionThreshold})` };
+  }
+  if (accesses === 0 && daysOld > 30 && backlinks === 0) {
+    return { action: 'archive', rationale: `Zero accesses, ${daysOld} days old, no backlinks — likely stale` };
+  }
+  if (accesses === 0 && daysOld > 30) {
+    return { action: 'review', rationale: `Zero accesses but ${backlinks} backlink(s) — referenced by other notes` };
+  }
+  return { action: 'review', rationale: `${daysOld} days old, ${accesses} accesses — needs manual review` };
 }
 
 type BrokenLink = {
@@ -1072,61 +1078,50 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       const queue = repo.getReviewQueue(args.filter, daysThreshold, limit, config.lifecycle.promotionThreshold, config.lifecycle.exemptKinds);
 
       const archiveDays = Math.max(1, config.lifecycle.autoArchiveFleetingDays);
-      
-      let output = '## Review Queue\n\n';
-      
+
       const hasFleeting = queue.fleeting.total > 0;
       const hasPermanent = queue.permanent.total > 0;
-      
+
       if (!hasFleeting && !hasPermanent) {
         return 'No notes pending review. All notes are up to date!';
       }
-      
-      if (hasFleeting) {
-        const nonStaleNotes = queue.fleeting.notes.filter(n => computeStaleness(n) < archiveDays);
-        const staleInQueue = queue.fleeting.notes.length - nonStaleNotes.length;
 
-        if (nonStaleNotes.length > 0) {
-          output += `### Fleeting Notes for Review (${nonStaleNotes.length} total`;
-          output += ')\n';
+      const nonStaleFleeting = queue.fleeting.notes.filter(n => computeStaleness(n) < archiveDays);
+      const candidates = [...nonStaleFleeting, ...queue.permanent.notes];
+      const candidateIds = new Set(candidates.map(n => n.id));
+      const totalCandidates = queue.fleeting.total + queue.permanent.total;
+      let output = `## Review Candidates (${candidates.length} of ${totalCandidates})\n\n`;
 
-          for (let i = 0; i < nonStaleNotes.length; i++) {
-            const note = nonStaleNotes[i];
-            const staleness = computeStaleness(note);
-            const accessInfo = note.access_count === 0 ? 'never accessed' : `${note.access_count} access${note.access_count === 1 ? '' : 'es'}`;
-            const rec = getRecommendation(note, staleness, config.lifecycle.promotionThreshold);
-            output += `${i + 1}. "${note.title}" | ${formatDate(note.created_at)} | ${staleness} days old | ${accessInfo} | ${rec}\n`;
-          }
+      for (let i = 0; i < candidates.length; i++) {
+        const note = candidates[i];
+        const staleness = computeStaleness(note);
+        const accesses = note.access_count || 0;
+        const backlinks = note.backlinks_count || 0;
+        const wordCount = countWords(note.content);
+        const guide = KIND_WORD_GUIDELINES[note.kind as NoteKind];
+        const wordSignal = guide && wordCount > guide.warn
+          ? `${wordCount} (oversized, target: ~${guide.target})`
+          : `${wordCount}`;
+        const backlinkSignal = backlinks === 0 ? '0 (unlinked)' : `${backlinks}`;
+        const rec = getRecommendation(note, staleness, config.lifecycle.promotionThreshold);
 
-          if (staleInQueue > 0) {
-            output += `\n${staleInQueue} older note(s) moved to "Stale Fleeting Notes" below.\n`;
-          }
-          output += '\n';
-        }
+        output += `### [${i + 1}] "${note.title}" (${note.id})\n`;
+        output += `kind: ${note.kind} | status: ${note.status} | staleness: ${staleness} days\n`;
+        output += `Accesses: ${accesses} | Backlinks: ${backlinkSignal} | Words: ${wordSignal}\n`;
+        output += `⮕ Suggested: ${rec.action.toUpperCase()} — ${rec.rationale}\n\n`;
       }
-      
-      if (hasPermanent) {
-        output += `### Permanent Notes for Review (${queue.permanent.total} total`;
-        if (queue.permanent.notes.length < queue.permanent.total) {
-          output += `, showing ${queue.permanent.notes.length}`;
-        }
-        output += ')\n';
-        
-        for (let i = 0; i < queue.permanent.notes.length; i++) {
-          const note = queue.permanent.notes[i];
-          output += `${i + 1}. "${note.title}" | ${formatDate(note.created_at)} | never accessed | 2999 Review relevance\n`;
-        }
-        
-        if (queue.permanent.total > queue.permanent.notes.length) {
-          output += `\n... ${queue.permanent.total - queue.permanent.notes.length} more. Use \`--filter permanent --limit 10\` to see all.\n`;
-        }
+
+      const staleInQueue = queue.fleeting.notes.length - nonStaleFleeting.length;
+      if (staleInQueue > 0) {
+        output += `${staleInQueue} older note(s) moved to "Stale Fleeting Notes" below.\n`;
         output += '\n';
       }
-      
+
       // Flag oversized notes that may need splitting
       const allNotes = repo.getAll(Number.MAX_SAFE_INTEGER);
       const oversized = allNotes
         .filter(n => n.status !== 'archived')
+        .filter(n => !candidateIds.has(n.id))
         .map(n => ({ ...n, wordCount: countWords(n.content) }))
         .filter(n => {
           const guide = KIND_WORD_GUIDELINES[n.kind as NoteKind];
@@ -1156,14 +1151,13 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         output += '\n';
       }
 
-      output += '## Next Steps:\n';
-      let stepIdx = 65;
-      if (hasFleeting) output += `[${String.fromCharCode(stepIdx++)}] Show all fleeting notes for review\n`;
-      if (hasPermanent) output += `[${String.fromCharCode(stepIdx++)}] Show all permanent notes for review\n`;
-      output += `[${String.fromCharCode(stepIdx++)}] Promote specific note to permanent (requires --noteId)\n`;
-      output += `[${String.fromCharCode(stepIdx++)}] Archive specific note (requires --noteId)\n`;
-      if (oversized.length > 0) output += `[${String.fromCharCode(stepIdx++)}] Split an oversized note into atomic notes\n`;
-      if (staleForArchive.length > 0) output += `[${String.fromCharCode(stepIdx)}] Archive stale fleeting notes\n`;
+      output += '---\n';
+      output += 'Actions: `knowledge-maintain promote/archive/delete` with noteId=<id>\n';
+      const staleCount = queue.fleeting.notes.length - nonStaleFleeting.length;
+      const remaining = Math.max(0, totalCandidates - candidates.length - staleCount);
+      if (remaining > 0) {
+        output += `Remaining: ${remaining} more candidates (increase limit to see more)\n`;
+      }
 
       return output;
     }

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -74,17 +74,18 @@ function atomicityWarning(kind: NoteKind, wordCount: number): string | null {
 function getRecommendation(
   note: NoteMetadata,
   daysOld: number,
-  promotionThreshold: number = 2,
+  promotionThreshold: number,
+  archiveAfterDays: number,
 ): { action: 'promote' | 'archive' | 'review'; rationale: string } {
   const accesses = note.access_count || 0;
   const backlinks = note.backlinks_count || 0;
   if (accesses >= promotionThreshold) {
     return { action: 'promote', rationale: `Accessed ${accesses} times (threshold: ${promotionThreshold})` };
   }
-  if (accesses === 0 && daysOld > 30 && backlinks === 0) {
+  if (accesses === 0 && daysOld > archiveAfterDays && backlinks === 0) {
     return { action: 'archive', rationale: `Zero accesses, ${daysOld} days old, no backlinks — likely stale` };
   }
-  if (accesses === 0 && daysOld > 30) {
+  if (accesses === 0 && daysOld > archiveAfterDays) {
     return { action: 'review', rationale: `Zero accesses but ${backlinks} backlink(s) — referenced by other notes` };
   }
   return { action: 'review', rationale: `${daysOld} days old, ${accesses} accesses — needs manual review` };
@@ -1075,72 +1076,74 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
     case 'review': {
       const daysThreshold = args.days || config.lifecycle.reviewAfterDays;
       const limit = args.limit || 3;
-      const queue = repo.getReviewQueue(args.filter, daysThreshold, limit, config.lifecycle.promotionThreshold, config.lifecycle.exemptKinds);
-
       const archiveDays = Math.max(1, config.lifecycle.autoArchiveFleetingDays);
+      const staleCutoff = Date.now() - (archiveDays * 24 * 60 * 60 * 1000);
+      const queue = repo.getReviewQueue(args.filter, daysThreshold, limit, config.lifecycle.exemptKinds, staleCutoff);
 
-      const hasFleeting = queue.fleeting.total > 0;
-      const hasPermanent = queue.permanent.total > 0;
+      // Compute stale notes early — needed for the early return check
+      const allNotes = repo.getAll(Number.MAX_SAFE_INTEGER);
+      const staleForArchive = allNotes
+        .filter(n => n.status === 'fleeting' && computeStaleness(n) >= archiveDays);
 
-      if (!hasFleeting && !hasPermanent) {
+      const hasCandidates = queue.fleeting.total > 0 || queue.permanent.total > 0;
+
+      if (!hasCandidates && staleForArchive.length === 0) {
         return 'No notes pending review. All notes are up to date!';
       }
 
-      const nonStaleFleeting = queue.fleeting.notes.filter(n => computeStaleness(n) < archiveDays);
-      const candidates = [...nonStaleFleeting, ...queue.permanent.notes];
-      const candidateIds = new Set(candidates.map(n => n.id));
-      const totalCandidates = queue.fleeting.total + queue.permanent.total;
-      let output = `## Review Candidates (${candidates.length} of ${totalCandidates})\n\n`;
+      let output = '';
 
-      for (let i = 0; i < candidates.length; i++) {
-        const note = candidates[i];
-        const staleness = computeStaleness(note);
-        const accesses = note.access_count || 0;
-        const backlinks = note.backlinks_count || 0;
-        const wordCount = countWords(note.content);
-        const guide = KIND_WORD_GUIDELINES[note.kind as NoteKind];
-        const wordSignal = guide && wordCount > guide.warn
-          ? `${wordCount} (oversized, target: ~${guide.target})`
-          : `${wordCount}`;
-        const backlinkSignal = backlinks === 0 ? '0 (unlinked)' : `${backlinks}`;
-        const rec = getRecommendation(note, staleness, config.lifecycle.promotionThreshold);
+      if (hasCandidates) {
+        const candidates = [...queue.fleeting.notes, ...queue.permanent.notes];
+        const candidateIds = new Set(candidates.map(n => n.id));
+        const totalCandidates = queue.fleeting.total + queue.permanent.total;
+        output += `## Review Candidates (${candidates.length} of ${totalCandidates})\n\n`;
 
-        output += `### [${i + 1}] "${note.title}" (${note.id})\n`;
-        output += `kind: ${note.kind} | status: ${note.status} | staleness: ${staleness} days\n`;
-        output += `Accesses: ${accesses} | Backlinks: ${backlinkSignal} | Words: ${wordSignal}\n`;
-        output += `⮕ Suggested: ${rec.action.toUpperCase()} — ${rec.rationale}\n\n`;
-      }
+        for (let i = 0; i < candidates.length; i++) {
+          const note = candidates[i];
+          const staleness = computeStaleness(note);
+          const accesses = note.access_count || 0;
+          const backlinks = note.backlinks_count || 0;
+          const wordCount = countWords(note.content);
+          const guide = KIND_WORD_GUIDELINES[note.kind as NoteKind];
+          const wordSignal = guide && wordCount > guide.warn
+            ? `${wordCount} (oversized, target: ~${guide.target})`
+            : `${wordCount}`;
+          const backlinkSignal = backlinks === 0 ? '0 (unlinked)' : `${backlinks}`;
+          const rec = getRecommendation(note, staleness, config.lifecycle.promotionThreshold, daysThreshold);
 
-      const staleInQueue = queue.fleeting.notes.length - nonStaleFleeting.length;
-      if (staleInQueue > 0) {
-        output += `${staleInQueue} older note(s) moved to "Stale Fleeting Notes" below.\n`;
-        output += '\n';
-      }
-
-      // Flag oversized notes that may need splitting
-      const allNotes = repo.getAll(Number.MAX_SAFE_INTEGER);
-      const oversized = allNotes
-        .filter(n => n.status !== 'archived')
-        .filter(n => !candidateIds.has(n.id))
-        .map(n => ({ ...n, wordCount: countWords(n.content) }))
-        .filter(n => {
-          const guide = KIND_WORD_GUIDELINES[n.kind as NoteKind];
-          return guide ? n.wordCount > guide.warn : n.wordCount > ABSOLUTE_WARN_THRESHOLD;
-        })
-        .sort((a, b) => b.wordCount - a.wordCount);
-
-      if (oversized.length > 0) {
-        output += `### Oversized Notes (${oversized.length} may need splitting)\n`;
-        for (const n of oversized) {
-          const guide = KIND_WORD_GUIDELINES[n.kind as NoteKind];
-          const target = guide ? guide.target : '?';
-          output += `- "${n.title}" (${n.kind}) — ${n.wordCount} words (target: ~${target}) [${n.id}]\n`;
+          output += `### [${i + 1}] "${note.title}" (${note.id})\n`;
+          output += `kind: ${note.kind} | status: ${note.status} | staleness: ${staleness} days\n`;
+          output += `Accesses: ${accesses} | Backlinks: ${backlinkSignal} | Words: ${wordSignal}\n`;
+          output += `⮕ Suggested: ${rec.action.toUpperCase()} — ${rec.rationale}\n\n`;
         }
-        output += '\n';
-      }
 
-      const staleForArchive = allNotes
-        .filter(n => n.status === 'fleeting' && computeStaleness(n) >= archiveDays);
+        // Flag oversized notes that may need splitting (exclude already-shown candidates)
+        const oversized = allNotes
+          .filter(n => n.status !== 'archived')
+          .filter(n => !candidateIds.has(n.id))
+          .map(n => ({ ...n, wordCount: countWords(n.content) }))
+          .filter(n => {
+            const guide = KIND_WORD_GUIDELINES[n.kind as NoteKind];
+            return guide ? n.wordCount > guide.warn : n.wordCount > ABSOLUTE_WARN_THRESHOLD;
+          })
+          .sort((a, b) => b.wordCount - a.wordCount);
+
+        if (oversized.length > 0) {
+          output += `### Oversized Notes (${oversized.length} may need splitting)\n`;
+          for (const n of oversized) {
+            const guide = KIND_WORD_GUIDELINES[n.kind as NoteKind];
+            const target = guide ? guide.target : '?';
+            output += `- "${n.title}" (${n.kind}) — ${n.wordCount} words (target: ~${target}) [${n.id}]\n`;
+          }
+          output += '\n';
+        }
+
+        const remaining = Math.max(0, totalCandidates - candidates.length);
+        if (remaining > 0) {
+          output += `Remaining: ${remaining} more candidates (increase limit to see more)\n\n`;
+        }
+      }
 
       if (staleForArchive.length > 0) {
         output += `### Stale Fleeting Notes (${staleForArchive.length} older than ${archiveDays} days)\n`;
@@ -1153,11 +1156,6 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
 
       output += '---\n';
       output += 'Actions: `knowledge-maintain promote/archive/delete` with noteId=<id>\n';
-      const staleCount = queue.fleeting.notes.length - nonStaleFleeting.length;
-      const remaining = Math.max(0, totalCandidates - candidates.length - staleCount);
-      if (remaining > 0) {
-        output += `Remaining: ${remaining} more candidates (increase limit to see more)\n`;
-      }
 
       return output;
     }

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -1110,7 +1110,8 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
             ? `${wordCount} (oversized, target: ~${guide.target})`
             : `${wordCount}`;
           const backlinkSignal = backlinks === 0 ? '0 (unlinked)' : `${backlinks}`;
-          const rec = getRecommendation(note, staleness, config.lifecycle.promotionThreshold, daysThreshold);
+          const archiveSuggestionDays = Math.floor(archiveDays / 2);
+        const rec = getRecommendation(note, staleness, config.lifecycle.promotionThreshold, archiveSuggestionDays);
 
           output += `### [${i + 1}] "${note.title}" (${note.id})\n`;
           output += `kind: ${note.kind} | status: ${note.status} | staleness: ${staleness} days\n`;

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -1110,7 +1110,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
             ? `${wordCount} (oversized, target: ~${guide.target})`
             : `${wordCount}`;
           const backlinkSignal = backlinks === 0 ? '0 (unlinked)' : `${backlinks}`;
-          const archiveSuggestionDays = Math.floor(archiveDays / 2);
+          const archiveSuggestionDays = Math.max(1, Math.floor(archiveDays / 2));
         const rec = getRecommendation(note, staleness, config.lifecycle.promotionThreshold, archiveSuggestionDays);
 
           output += `### [${i + 1}] "${note.title}" (${note.id})\n`;

--- a/tests/benchmarks.test.ts
+++ b/tests/benchmarks.test.ts
@@ -365,7 +365,7 @@ describe.skipIf(!BENCH)('Performance Benchmarks', () => {
       }
 
       const elapsed = timeSync(() => {
-        const queue = ctx.engine.getReviewQueue(undefined, 14, 10, 2, []);
+        const queue = ctx.engine.getReviewQueue(undefined, 14, 10, []);
         expect(queue.fleeting.total).toBeGreaterThan(0);
       });
       console.log(`  getReviewQueue (200 notes): ${elapsed.toFixed(2)}ms`);

--- a/tests/coverage-boost.test.ts
+++ b/tests/coverage-boost.test.ts
@@ -882,7 +882,8 @@ describe('Tool Handlers — Coverage Boost', () => {
       ).run(oldTime, r.id);
 
       const output = await handleMaintain({ action: 'review' }, ctx.engine, ctx.config);
-      expect(output).toContain('Permanent Notes for Review');
+      expect(output).toContain('## Review Candidates');
+      expect(output).toContain('status: permanent');
       expect(output).toContain('OldPerm');
     });
   });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -190,7 +190,6 @@ describe('Knowledge Capture Integration Tests', () => {
         undefined,
         14,
         10,
-        context.config.lifecycle.promotionThreshold,
         context.config.lifecycle.exemptKinds,
       );
 
@@ -209,7 +208,6 @@ describe('Knowledge Capture Integration Tests', () => {
         undefined,
         14,
         10,
-        context.config.lifecycle.promotionThreshold,
         context.config.lifecycle.exemptKinds,
       );
 
@@ -235,7 +233,6 @@ describe('Knowledge Capture Integration Tests', () => {
         undefined,
         14,
         10,
-        context.config.lifecycle.promotionThreshold,
         context.config.lifecycle.exemptKinds,
       );
 
@@ -262,7 +259,6 @@ describe('Knowledge Capture Integration Tests', () => {
         undefined,
         14,
         10,
-        context.config.lifecycle.promotionThreshold,
         context.config.lifecycle.exemptKinds,
       );
 
@@ -284,7 +280,6 @@ describe('Knowledge Capture Integration Tests', () => {
         undefined,
         14,
         10,
-        context.config.lifecycle.promotionThreshold,
         context.config.lifecycle.exemptKinds,
       );
 
@@ -311,7 +306,6 @@ describe('Knowledge Capture Integration Tests', () => {
         'fleeting',
         14,
         10,
-        context.config.lifecycle.promotionThreshold,
         context.config.lifecycle.exemptKinds,
       );
       expect(fleetingOnly.fleeting.total).toBe(1);
@@ -321,7 +315,6 @@ describe('Knowledge Capture Integration Tests', () => {
         'permanent',
         14,
         10,
-        context.config.lifecycle.promotionThreshold,
         context.config.lifecycle.exemptKinds,
       );
       expect(permanentOnly.fleeting.total).toBe(0);

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -217,7 +217,7 @@ describe('Knowledge Capture Integration Tests', () => {
       expect(queue.fleeting.notes).toHaveLength(0);
     });
 
-    it('excludes fleeting notes with access_count >= promotionThreshold', () => {
+    it('includes well-used fleeting notes for promotion review', () => {
       const result = context.engine.store('Well-used fleeting note', {
         title: 'Well-used Fleeting',
         kind: 'observation',
@@ -239,8 +239,8 @@ describe('Knowledge Capture Integration Tests', () => {
         context.config.lifecycle.exemptKinds,
       );
 
-      expect(queue.fleeting.total).toBe(0);
-      expect(queue.fleeting.notes.some(n => n.id === note.id)).toBe(false);
+      expect(queue.fleeting.total).toBe(1);
+      expect(queue.fleeting.notes.some(n => n.id === note.id)).toBe(true);
     });
 
     it('excludes exemptKinds from both fleeting and permanent review', () => {

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -2107,10 +2107,11 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
     expect(output).toContain('Stale Fleeting Notes (2');
     expect(output).toContain('All Stale A');
     expect(output).toContain('All Stale B');
-    expect(output).toContain('## Review Candidates (0 of 2)');
+    // No candidates section when all notes are stale
+    expect(output).not.toContain('## Review Candidates');
   });
 
-  it('should show correct moved-to-stale count when mixed ages', async () => {
+  it('should separate stale notes from review candidates when mixed ages', async () => {
     const old = ctx.engine.store('Old note', { title: 'Stale One', kind: 'observation' });
     const recent = ctx.engine.store('Recent note', { title: 'Review One', kind: 'observation' });
     setCreatedAt(old.id, daysAgo(100));
@@ -2121,7 +2122,8 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
     expect(output).toContain('Review One');
     expect(output).toContain('Stale Fleeting Notes');
     expect(output).toContain('Stale One');
-    expect(output).toContain('1 older note(s) moved to');
+    // Stale notes are excluded from candidates via SQL, not post-filtered
+    expect(output).not.toMatch(/### \[\d+\].*Stale One/);  // Not in numbered candidates
   });
 });
 
@@ -2138,8 +2140,11 @@ describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
   };
 
   const sectionFor = (output: string, title: string): string => {
-    const start = output.indexOf(`"${title}"`);
-    if (start === -1) return '';
+    const escaped = title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const headerPattern = new RegExp(`### \\[\\d+\\][^\\n]*"${escaped}"`);
+    const match = headerPattern.exec(output);
+    if (!match) return '';
+    const start = match.index;
     const next = output.indexOf('\n### [', start + 1);
     return output.slice(start, next === -1 ? undefined : next);
   };

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -698,18 +698,19 @@ describe('MCP Tool: knowledge-maintain', () => {
     setCreatedAt(fleeting.id, daysAgo(20));
     setCreatedAt(permanent.id, daysAgo(20));
 
-    const output = await handleMaintain({ action: 'review', limit: 10 }, ctx.engine, ctx.config);
+    const customConfig = { ...ctx.config, lifecycle: { ...ctx.config.lifecycle, exemptKinds: [] } };
+    const output = await handleMaintain({ action: 'review', limit: 10 }, ctx.engine, customConfig);
 
-    expect(output).toContain('## Review Queue');
-    expect(output).toContain('### Fleeting Notes for Review (1 total)');
-    expect(output).toContain('### Permanent Notes for Review (1 total)');
+    expect(output).toContain('## Review Candidates (2 of 2)');
+    expect(output).toContain('### [1]');
+    expect(output).toContain('### [2]');
     expect(output).toContain('"Review Fleeting"');
     expect(output).toContain('"Review Permanent"');
-    expect(output).toContain('## Next Steps:');
+    expect(output).toContain('Actions: `knowledge-maintain promote/archive/delete` with noteId=<id>');
     expect(output).not.toContain('Oversized Notes');
   });
 
-  it('should include archive/review recommendations and exclude promote-threshold notes', async () => {
+  it('should include archive/review/promote recommendations', async () => {
     ctx.engine.clearAll();
 
     const promoteCandidate = ctx.engine.store('Promote candidate', {
@@ -743,13 +744,13 @@ describe('MCP Tool: knowledge-maintain', () => {
       ctx.config,
     );
 
-    expect(output).not.toContain('"Promote Candidate"');
+    expect(output).toContain('"Promote Candidate"');
     expect(output).toContain('"Archive Candidate"');
     expect(output).toContain('"Review Candidate"');
-    expect(output).not.toContain('| Promote');
-    expect(output).toContain('Archive');
-    expect(output).toContain('Review');
-    expect(output).toContain('### Fleeting Notes for Review (2 total)');
+    expect(output).toContain('⮕ Suggested: PROMOTE');
+    expect(output).toContain('⮕ Suggested: ARCHIVE');
+    expect(output).toContain('⮕ Suggested: REVIEW');
+    expect(output).toContain('## Review Candidates (3 of 3)');
   });
 
   it('should respect review filter in handleMaintain review action', async () => {
@@ -774,16 +775,18 @@ describe('MCP Tool: knowledge-maintain', () => {
       ctx.engine,
       ctx.config,
     );
-    expect(fleetingOnly).toContain('### Fleeting Notes for Review (1 total)');
-    expect(fleetingOnly).not.toContain('### Permanent Notes for Review');
+    expect(fleetingOnly).toContain('## Review Candidates (1 of 1)');
+    expect(fleetingOnly).toContain('"Filter Fleeting"');
+    expect(fleetingOnly).not.toContain('"Filter Permanent"');
 
     const permanentOnly = await handleMaintain(
       { action: 'review', filter: 'permanent', limit: 10 },
       ctx.engine,
       ctx.config,
     );
-    expect(permanentOnly).toContain('### Permanent Notes for Review (1 total)');
-    expect(permanentOnly).not.toContain('### Fleeting Notes for Review');
+    expect(permanentOnly).toContain('## Review Candidates (1 of 1)');
+    expect(permanentOnly).toContain('"Filter Permanent"');
+    expect(permanentOnly).not.toContain('"Filter Fleeting"');
   });
 
   it('should flag oversized notes in review output', async () => {
@@ -2017,19 +2020,20 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
     expect(output).toContain('Stale Duplicate Check');
 
     const staleSection = output.indexOf('Stale Fleeting Notes');
-    const fleetingSection = output.indexOf('Fleeting Notes for Review');
-    if (fleetingSection !== -1) {
-      const fleetingContent = output.substring(fleetingSection, staleSection > fleetingSection ? staleSection : undefined);
-      expect(fleetingContent).not.toContain('Stale Duplicate Check');
+    const candidatesSection = output.indexOf('Review Candidates');
+    if (candidatesSection !== -1) {
+      const candidatesContent = output.substring(candidatesSection, staleSection > candidatesSection ? staleSection : undefined);
+      expect(candidatesContent).not.toContain('Stale Duplicate Check');
     }
   });
 
-  it('should not surface permanent notes regardless of age', async () => {
-    const result = ctx.engine.store('Old permanent', { title: 'Old Perm', kind: 'decision', status: 'permanent' });
+  it('should surface old unaccessed permanent notes as review candidates', async () => {
+    const result = ctx.engine.store('Old permanent', { title: 'Old Perm', kind: 'reference', status: 'permanent' });
     setCreatedAt(result.id, daysAgo(200));
 
     const output = await handleMaintain({ action: 'review' }, ctx.engine, ctx.config);
-    expect(output).not.toContain('Old Perm');
+    expect(output).toContain('Old Perm');
+    expect(output).toContain('status: permanent');
   });
 
   it('should not surface archived notes', async () => {
@@ -2103,7 +2107,7 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
     expect(output).toContain('Stale Fleeting Notes (2');
     expect(output).toContain('All Stale A');
     expect(output).toContain('All Stale B');
-    expect(output).not.toContain('Fleeting Notes for Review');
+    expect(output).toContain('## Review Candidates (0 of 2)');
   });
 
   it('should show correct moved-to-stale count when mixed ages', async () => {
@@ -2113,11 +2117,135 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
     setCreatedAt(recent.id, daysAgo(20));
 
     const output = await handleMaintain({ action: 'review' }, ctx.engine, ctx.config);
-    expect(output).toContain('Fleeting Notes for Review');
+    expect(output).toContain('## Review Candidates');
     expect(output).toContain('Review One');
     expect(output).toContain('Stale Fleeting Notes');
     expect(output).toContain('Stale One');
     expect(output).toContain('1 older note(s) moved to');
+  });
+});
+
+describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
+  let ctx: TestContext;
+  const daysAgo = (days: number): number => Date.now() - (days * 24 * 60 * 60 * 1000);
+
+  type TestDb = { prepare: (sql: string) => { run: (...params: unknown[]) => unknown } };
+
+  const db = (): TestDb => (ctx.engine as unknown as { db: TestDb }).db;
+
+  const setCreatedAt = (noteId: string, timestamp: number): void => {
+    db().prepare('UPDATE notes SET created_at = ? WHERE id = ?').run(timestamp, noteId);
+  };
+
+  const sectionFor = (output: string, title: string): string => {
+    const start = output.indexOf(`"${title}"`);
+    if (start === -1) return '';
+    const next = output.indexOf('\n### [', start + 1);
+    return output.slice(start, next === -1 ? undefined : next);
+  };
+
+  beforeEach(() => { ctx = createTestHarness({ telemetryEnabled: true }); });
+  afterEach(() => { cleanupTestHarness(ctx); });
+
+  it('should show backlink signals in review output', async () => {
+    const noteA = ctx.engine.store('Links to another note', { title: 'Source Note', kind: 'observation' });
+    const noteB = ctx.engine.store('Linked note', { title: 'Target Note', kind: 'observation' });
+    ctx.engine.syncLinks(noteA.id, `[[${noteB.id}|test]]`);
+    setCreatedAt(noteA.id, daysAgo(20));
+    setCreatedAt(noteB.id, daysAgo(20));
+
+    const output = await handleMaintain({ action: 'review', limit: 10 }, ctx.engine, ctx.config);
+
+    expect(sectionFor(output, 'Target Note')).toContain('Backlinks: 1');
+    expect(sectionFor(output, 'Source Note')).toContain('Backlinks: 0 (unlinked)');
+  });
+
+  it('should recommend promote when accesses meet the threshold', async () => {
+    const note = ctx.engine.store('Accessed note', { title: 'Promotion Candidate', kind: 'observation' });
+    setCreatedAt(note.id, daysAgo(40));
+    for (let i = 0; i < ctx.config.lifecycle.promotionThreshold; i++) {
+      ctx.engine.recordAccess(note.id);
+    }
+
+    const output = await handleMaintain({ action: 'review', limit: 10 }, ctx.engine, ctx.config);
+
+    expect(output).toContain('PROMOTE');
+    expect(output).toContain(`Accessed ${ctx.config.lifecycle.promotionThreshold} times`);
+  });
+
+  it('should recommend archive for zero-access old unlinked notes', async () => {
+    const note = ctx.engine.store('Stale note', { title: 'Unlinked Archive Candidate', kind: 'observation' });
+    setCreatedAt(note.id, daysAgo(40));
+
+    const output = await handleMaintain({ action: 'review', limit: 10 }, ctx.engine, ctx.config);
+
+    expect(output).toContain('ARCHIVE');
+    expect(output).toContain('no backlinks');
+  });
+
+  it('should recommend review (not archive) when backlinks exist', async () => {
+    const noteA = ctx.engine.store('Source content', { title: 'Backlink Source', kind: 'observation' });
+    const noteB = ctx.engine.store('Target content', { title: 'Backlinked Review Candidate', kind: 'observation' });
+    ctx.engine.syncLinks(noteA.id, `[[${noteB.id}|test]]`);
+    setCreatedAt(noteA.id, daysAgo(10));
+    setCreatedAt(noteB.id, daysAgo(40));
+
+    const customConfig = { ...ctx.config, lifecycle: { ...ctx.config.lifecycle, exemptKinds: [] } };
+    const output = await handleMaintain({ action: 'review', limit: 10 }, ctx.engine, customConfig);
+    const targetSection = sectionFor(output, 'Backlinked Review Candidate');
+
+    expect(targetSection).toContain('REVIEW');
+    expect(targetSection).toContain('backlink(s)');
+    expect(targetSection).not.toContain('ARCHIVE');
+  });
+
+  it('should recommend review for young notes', async () => {
+    const note = ctx.engine.store('Needs judgment', { title: 'Manual Review Candidate', kind: 'observation' });
+    setCreatedAt(note.id, daysAgo(16));
+    ctx.engine.recordAccess(note.id);
+
+    const output = await handleMaintain({ action: 'review', days: 14, limit: 10 }, ctx.engine, ctx.config);
+
+    expect(output).toContain('REVIEW');
+    expect(output).toContain('needs manual review');
+  });
+
+  it('should use numbered candidate format', async () => {
+    const first = ctx.engine.store('First note', { title: 'Numbered One', kind: 'observation' });
+    const second = ctx.engine.store('Second note', { title: 'Numbered Two', kind: 'reference' });
+    setCreatedAt(first.id, daysAgo(20));
+    setCreatedAt(second.id, daysAgo(20));
+
+    const output = await handleMaintain({ action: 'review', limit: 10 }, ctx.engine, ctx.config);
+
+    expect(output).toContain('## Review Candidates');
+    expect(output).toContain('### [1]');
+    expect(output).toContain('### [2]');
+  });
+
+  it('should show oversized signal inline', async () => {
+    const content = Array(120).fill('word').join(' ');
+    const note = ctx.engine.store(content, { title: 'Inline Oversized', kind: 'personalization' });
+    setCreatedAt(note.id, daysAgo(20));
+
+    const customConfig = { ...ctx.config, lifecycle: { ...ctx.config.lifecycle, exemptKinds: [] } };
+    const output = await handleMaintain({ action: 'review', limit: 10 }, ctx.engine, customConfig);
+
+    expect(sectionFor(output, 'Inline Oversized')).toContain('oversized');
+    expect(sectionFor(output, 'Inline Oversized')).toContain('target: ~50');
+  });
+
+  it('should combine fleeting and permanent candidates in one numbered list', async () => {
+    const fleeting = ctx.engine.store('Fleeting content', { title: 'Combined Fleeting', kind: 'observation' });
+    const permanent = ctx.engine.store('Permanent content', { title: 'Combined Permanent', kind: 'reference', status: 'permanent' });
+    setCreatedAt(fleeting.id, daysAgo(20));
+    setCreatedAt(permanent.id, daysAgo(20));
+
+    const output = await handleMaintain({ action: 'review', limit: 10 }, ctx.engine, ctx.config);
+
+    expect(output).toContain('## Review Candidates (2 of 2)');
+    expect(output).toContain('### [1] "Combined Fleeting"');
+    expect(output).toContain('### [2] "Combined Permanent"');
   });
 });
 

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -729,8 +729,8 @@ describe('MCP Tool: knowledge-maintain', () => {
       status: 'fleeting',
     });
 
-    setCreatedAt(promoteCandidate.id, daysAgo(40));
-    setCreatedAt(archiveCandidate.id, daysAgo(40));
+    setCreatedAt(promoteCandidate.id, daysAgo(50));
+    setCreatedAt(archiveCandidate.id, daysAgo(50));
     setCreatedAt(reviewCandidate.id, daysAgo(20));
 
     for (let i = 0; i < ctx.config.lifecycle.promotionThreshold; i++) {
@@ -2167,7 +2167,7 @@ describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
 
   it('should recommend promote when accesses meet the threshold', async () => {
     const note = ctx.engine.store('Accessed note', { title: 'Promotion Candidate', kind: 'observation' });
-    setCreatedAt(note.id, daysAgo(40));
+    setCreatedAt(note.id, daysAgo(50));
     for (let i = 0; i < ctx.config.lifecycle.promotionThreshold; i++) {
       ctx.engine.recordAccess(note.id);
     }
@@ -2180,7 +2180,7 @@ describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
 
   it('should recommend archive for zero-access old unlinked notes', async () => {
     const note = ctx.engine.store('Stale note', { title: 'Unlinked Archive Candidate', kind: 'observation' });
-    setCreatedAt(note.id, daysAgo(40));
+    setCreatedAt(note.id, daysAgo(50));
 
     const output = await handleMaintain({ action: 'review', limit: 10 }, ctx.engine, ctx.config);
 
@@ -2193,7 +2193,7 @@ describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
     const noteB = ctx.engine.store('Target content', { title: 'Backlinked Review Candidate', kind: 'observation' });
     ctx.engine.syncLinks(noteA.id, `[[${noteB.id}|test]]`);
     setCreatedAt(noteA.id, daysAgo(10));
-    setCreatedAt(noteB.id, daysAgo(40));
+    setCreatedAt(noteB.id, daysAgo(50));
 
     const customConfig = { ...ctx.config, lifecycle: { ...ctx.config.lifecycle, exemptKinds: [] } };
     const output = await handleMaintain({ action: 'review', limit: 10 }, ctx.engine, customConfig);


### PR DESCRIPTION
## Summary

Implements V1 of #104 — enhances `knowledge-maintain review` with a structured curation UX so agents can walk through review candidates and act on them without additional lookups.

## Changes

- **`getReviewQueue()` backlinks** — LEFT JOIN `note_links` to populate `backlinks_count` per candidate. Notes with 0 backlinks are flagged as "unlinked"
- **`getRecommendation()` restructured** — returns `{ action: 'promote' | 'archive' | 'review', rationale: string }` with contextual reasoning. Notes with active backlinks get REVIEW (not ARCHIVE) to prevent dangling wikilinks
- **Unified numbered output** — fleeting + permanent candidates merged into a single numbered list with per-candidate signals: kind, status, staleness, accesses, backlinks, word count (flags oversized against kind target)
- **SKILL.md** — documents the review → decide → act workflow for agents
- **8 new tests** — backlinks signal, promote/archive/review heuristics, numbered format, oversized inline, combined list

## Output Format

```
## Review Candidates (3 of 12)

### [1] "Use FTS5 over trigram" (2026010512300000)
kind: decision | status: fleeting | staleness: 145 days
Accesses: 0 | Backlinks: 0 (unlinked) | Words: 89
⮕ Suggested: ARCHIVE — Zero accesses, 145 days old, no backlinks — likely stale

### [2] "API endpoint for user creation" (2026020112000000)
kind: reference | status: fleeting | staleness: 88 days
Accesses: 3 | Backlinks: 2 | Words: 210 (oversized, target: ~120)
⮕ Suggested: PROMOTE — Accessed 3 times (threshold: 2)
```

## Deferred (not in scope)

- Dedup integration (separate `dedupe` action)
- Merge action (complex, needs own issue)
- Telemetry-based "unused" signal
- New config namespace

## Verification

- 818 pass / 0 fail / 39 skip
- LSP diagnostics clean
- Build clean (`tsc`)

Closes #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded knowledge-maintain review guide with candidate format, signals (staleness, accesses, backlinks, word-count), suggested actions, and explicit non-binding guidance.

* **Improvements**
  * Consolidated review UI into a single "Review Candidates" list with structured recommendations and rationales.
  * Backlink counts and enhanced signals shown per candidate; command-style next-step hints.

* **Tests**
  * Updated tests and benchmarks to match the new review format and call signatures.

* **Chores**
  * CI/workflow config now injects model and reviewer instruction settings via environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->