### PR TITLE
Add opinionated Obsidian vault scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Your AI assistant gets seven MCP tools:
 | `knowledge-maintain` | Review, promote, archive, and rebuild notes |
 | `knowledge-ingest` | Extract article content from URLs or HTML into structured markdown |
 | `knowledge-overview` | Get a project overview with auto-generated index and recent log |
-| `knowledge-open` | Open the vault in Obsidian for visual browsing and graph view |
+| `knowledge-open` | Open the vault in Obsidian with a scaffolded theme, plugins, homepage, and graph view |
 
 The installer injects instructions that guide the AI to **proactively search** for relevant context before starting work and **store valuable knowledge** as it discovers it. No plugin required — the AI drives everything through tool calls.
 
@@ -75,6 +75,14 @@ embeddings:
 ```
 
 Any OpenAI-compatible API works (OpenRouter, Together, Groq, local vLLM, etc.). See [docs/configuration.md](docs/configuration.md) for the full reference.
+
+To disable the managed Obsidian read-only defaults or scaffold auto-upgrades:
+
+```yaml
+obsidian:
+  autoUpgrade: false
+  readOnly: false
+```
 
 ## Note Kinds
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -47,6 +47,13 @@
 #   enableProjectLog: true               # Auto-append to project log on every event
 #   overviewLogEntryLimit: 10            # Recent log entries shown in knowledge-overview
 
+# ─── Obsidian Vault Experience ────────────────────────────────────────────────
+# Batteries-included vault scaffold used by knowledge-open.
+# obsidian:
+#   scaffold: true                        # Create/update .obsidian config, plugins, theme, snippets
+#   autoUpgrade: true                     # Refresh pinned scaffold assets when the server starts
+#   readOnly: true                        # Default to Reading View + read-only helpers
+
 # ─── Embeddings ──────────────────────────────────────────────────────────────
 # Local embeddings (23MB MiniLM model) are enabled by default — no config needed.
 # To use an API provider instead, uncomment below:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ open-zk-kb uses a single YAML configuration file:
 
 **Location**: `~/.config/open-zk-kb/config.yaml`
 
-The file contains core settings for the MCP server, including vault location, log level, note lifecycle, and vector embeddings.
+The file contains core settings for the MCP server, including vault location, log level, note lifecycle, the Obsidian vault scaffold, and vector embeddings.
 
 For a detailed explanation of note statuses, kinds, and the review system, see [Note Lifecycle](note-lifecycle.md).
 
@@ -36,6 +36,9 @@ embeddings:
 | lifecycle.promotionThreshold | number | 2 | Accesses needed to recommend promotion to permanent |
 | lifecycle.exemptKinds | string[] | ["personalization", "decision"] | Note kinds exempt from the review queue |
 | telemetry.enabled | boolean | false | Enable local-only tool invocation counters and access timestamps (opt-in) |
+| obsidian.scaffold | boolean | true | Create and maintain the opinionated `.obsidian/` scaffold used by `knowledge-open` |
+| obsidian.autoUpgrade | boolean | true | Refresh pinned theme/plugin/snippet assets when the server starts |
+| obsidian.readOnly | boolean | true | Default Obsidian to Reading View and enable read-only helpers |
 | embeddings.enabled | boolean | true | Enable vector embeddings |
 | embeddings.provider | string | local | Embedding provider: local or api |
 | embeddings.model | string | all-MiniLM-L6-v2 | Embedding model (local or API) |
@@ -77,6 +80,38 @@ Not recorded:
 - User identifiers, client identifiers, hostnames, or account names
 - API keys, tokens, credentials, or other secrets
 
+## Obsidian Vault Scaffold
+
+`knowledge-open` now scaffolds a polished Obsidian vault experience on first launch:
+
+- Minimal theme
+- Community plugin bundle (homepage, QuickAdd, Commander, Templater, Minimal Settings, OZ Calendar, Read Only View)
+- CSS snippets for dashboard layout, better tables, hidden metadata, and optional read-only controls
+- Auto-copied note templates under `templates/`
+- Versioned scaffold manifest at `.obsidian/open-zk-kb.json`
+
+```yaml
+obsidian:
+  scaffold: true
+  autoUpgrade: true
+  readOnly: true
+```
+
+### `obsidian.scaffold`
+
+- `true` (default): create or merge the managed `.obsidian/` scaffold when needed
+- `false`: skip scaffold creation entirely
+
+### `obsidian.autoUpgrade`
+
+- `true` (default): when `.obsidian/open-zk-kb.json` exists, the server refreshes pinned theme/plugin assets on startup
+- `false`: leave existing scaffold assets untouched until `knowledge-maintain` action `upgrade-vault`
+
+### `obsidian.readOnly`
+
+- `true` (default): sets Obsidian to Reading View, enables the read-only CSS snippet, and installs the `read-only-view` plugin config
+- `false`: keeps the rest of the scaffold, but omits the read-only helpers and defaults new tabs to source mode
+
 ## Example Configurations
 
 ### a) Minimal
@@ -107,6 +142,12 @@ embeddings:
 ```yaml
 telemetry:
   enabled: false
+```
+
+### f) Editable Obsidian vault
+```yaml
+obsidian:
+  readOnly: false
 ```
 
 ## Environment & Paths

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,11 @@ interface RawConfig {
   telemetry?: {
     enabled?: boolean;
   };
+  obsidian?: {
+    scaffold?: boolean;
+    autoUpgrade?: boolean;
+    readOnly?: boolean;
+  };
   embeddings?: EmbeddingsConfig;
 }
 
@@ -103,6 +108,11 @@ export const DEFAULT_CONFIG: AppConfig = {
   },
   telemetry: {
     enabled: false,
+  },
+  obsidian: {
+    scaffold: true,
+    autoUpgrade: true,
+    readOnly: true,
   },
 };
 
@@ -207,6 +217,17 @@ export function getConfig(): AppConfig {
       enabled: typeof raw?.telemetry?.enabled === 'boolean'
         ? raw.telemetry.enabled
         : DEFAULT_CONFIG.telemetry.enabled,
+    },
+    obsidian: {
+      scaffold: typeof raw?.obsidian?.scaffold === 'boolean'
+        ? raw.obsidian.scaffold
+        : DEFAULT_CONFIG.obsidian.scaffold,
+      autoUpgrade: typeof raw?.obsidian?.autoUpgrade === 'boolean'
+        ? raw.obsidian.autoUpgrade
+        : DEFAULT_CONFIG.obsidian.autoUpgrade,
+      readOnly: typeof raw?.obsidian?.readOnly === 'boolean'
+        ? raw.obsidian.readOnly
+        : DEFAULT_CONFIG.obsidian.readOnly,
     },
   };
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -15,9 +15,12 @@ if (typeof globalThis.Bun === 'undefined') {
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import * as fs from 'fs';
+import * as path from 'path';
 import { z } from 'zod';
 import { getConfig, getEmbeddingsConfig } from './config.js';
 import { logToFile } from './logger.js';
+import { ensureObsidianScaffold } from './obsidian-scaffold.js';
 import { handleStore, handleSearch, handleMaintain, handleIngest, handleOverview, handleOpen, handleMine, handleTemplate } from './tool-handlers.js';
 import { generateEmbedding, DEFAULT_EMBEDDING_CONFIG } from './embeddings.js';
 import type { EmbeddingConfig } from './embeddings.js';
@@ -29,13 +32,32 @@ const { NoteRepository } = await import('./storage/NoteRepository.js');
 
 const config = getConfig();
 let repo: NoteRepositoryType | null = null;
+let repoInitPromise: Promise<NoteRepositoryType> | null = null;
 
-function getOrCreateRepo(): NoteRepositoryType {
-  if (!repo) {
+async function getOrCreateRepo(): Promise<NoteRepositoryType> {
+  if (repo) return repo;
+  if (repoInitPromise) return repoInitPromise;
+
+  repoInitPromise = (async () => {
     repo = new NoteRepository(config.vault, { telemetryEnabled: config.telemetry.enabled });
     logToFile('INFO', 'MCP server: repository opened', { vault: config.vault }, config);
-  }
-  return repo;
+
+    const obsidianDir = path.join(config.vault, '.obsidian');
+    if (config.obsidian.autoUpgrade && fs.existsSync(obsidianDir)) {
+      try {
+        await ensureObsidianScaffold(config.vault, config.obsidian);
+      } catch (error) {
+        logToFile('WARN', 'Failed to auto-upgrade Obsidian scaffold on server init', {
+          error: error instanceof Error ? error.message : String(error),
+          vault: config.vault,
+        }, config);
+      }
+    }
+
+    return repo;
+  })();
+
+  return repoInitPromise;
 }
 
 let cachedEmbeddingConfig: EmbeddingConfig | null | undefined;
@@ -117,7 +139,7 @@ server.registerTool(
         client: args.client,
         related: args.related,
         model: args.model,
-      }, getOrCreateRepo(), getEmbeddingConfig(), config);
+      }, await getOrCreateRepo(), getEmbeddingConfig(), config);
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-store failed', {
@@ -154,7 +176,7 @@ server.registerTool(
         url: args.url,
         html: args.html,
         model: args.model,
-      }, getOrCreateRepo());
+      }, await getOrCreateRepo());
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-ingest failed', {
@@ -225,7 +247,7 @@ server.registerTool(
         tags: args.tags,
         limit: args.limit,
         model: args.model,
-      }, getOrCreateRepo(), queryEmbedding, config);
+      }, await getOrCreateRepo(), queryEmbedding, config);
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-search failed', {
@@ -259,7 +281,7 @@ server.registerTool(
         project: args.project,
         logEntries: args.logEntries,
         model: args.model,
-      }, getOrCreateRepo(), config);
+      }, await getOrCreateRepo(), config);
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-overview failed', {
@@ -287,9 +309,9 @@ server.registerTool(
   },
   async (args: z.infer<typeof openSchema>) => {
     try {
-      const result = handleOpen({
+      const result = await handleOpen({
         project: args.project,
-      }, config, args.project ? getOrCreateRepo() : repo ?? undefined);
+      }, config, args.project ? await getOrCreateRepo() : repo ?? undefined);
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-open failed', {
@@ -306,8 +328,8 @@ server.registerTool(
 // ---- knowledge-maintain ----
 
 const maintainSchema = z.object({
-  action: z.enum(['stats', 'promote', 'archive', 'delete', 'rebuild', 'upgrade', 'upgrade-read', 'upgrade-apply', 'review', 'dedupe', 'embed', 'agent-docs', 'scope-audit', 'orphans', 'broken-links', 'migrate-layout'])
-      .describe('Maintenance action: stats, review (pending notes), dedupe (duplicates), promote, archive, delete, rebuild, upgrade, embed (backfill embeddings), agent-docs (audit/repair managed agent instruction files), scope-audit (detect mis-scoped client tags), orphans (notes with no links), broken-links (wikilinks to non-existent notes), migrate-layout (move flat vault to kind-based directory structure)'),
+  action: z.enum(['stats', 'promote', 'archive', 'delete', 'rebuild', 'upgrade', 'upgrade-read', 'upgrade-apply', 'review', 'dedupe', 'embed', 'agent-docs', 'scope-audit', 'orphans', 'broken-links', 'migrate-layout', 'upgrade-vault'])
+      .describe('Maintenance action: stats, review (pending notes), dedupe (duplicates), promote, archive, delete, rebuild, upgrade, embed (backfill embeddings), agent-docs (audit/repair managed agent instruction files), scope-audit (detect mis-scoped client tags), orphans (notes with no links), broken-links (wikilinks to non-existent notes), migrate-layout (move flat vault to kind-based directory structure), or upgrade-vault (refresh Obsidian scaffold assets).'),
   noteId: z.string().optional().describe('Note ID (required for promote/archive/delete; migration ID for upgrade-read)'),
   filter: z.enum(['fleeting', 'permanent']).optional().describe('Filter for review action: fleeting or permanent notes'),
   days: z.number().optional().describe('Days threshold for review (default: from lifecycle.reviewAfterDays config)'),
@@ -334,7 +356,7 @@ server.registerTool(
         telemetry: args.telemetry,
         dryRun: args.dryRun,
         model: args.model,
-      }, getOrCreateRepo(), config, getEmbeddingConfig(), PKG_VERSION);
+      }, await getOrCreateRepo(), config, getEmbeddingConfig(), PKG_VERSION);
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-maintain failed', {
@@ -386,7 +408,7 @@ server.registerTool(
         project: args.project,
         dry_run: args.dry_run,
         model: args.model,
-      }, getOrCreateRepo(), getEmbeddingConfig(), config);
+      }, await getOrCreateRepo(), getEmbeddingConfig(), config);
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-mine failed', {
@@ -416,7 +438,7 @@ server.registerTool(
   },
   async (args: z.infer<typeof templateSchema>) => {
     try {
-      const r = args.project ? getOrCreateRepo() : (repo ?? undefined);
+      const r = args.project ? await getOrCreateRepo() : (repo ?? undefined);
       const result = handleTemplate({
         kind: args.kind,
         project: args.project,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -39,7 +39,8 @@ async function getOrCreateRepo(): Promise<NoteRepositoryType> {
   if (repoInitPromise) return repoInitPromise;
 
   repoInitPromise = (async () => {
-    repo = new NoteRepository(config.vault, { telemetryEnabled: config.telemetry.enabled });
+    const instance = new NoteRepository(config.vault, { telemetryEnabled: config.telemetry.enabled });
+    repo = instance;
     logToFile('INFO', 'MCP server: repository opened', { vault: config.vault }, config);
 
     const obsidianDir = path.join(config.vault, '.obsidian');
@@ -54,10 +55,16 @@ async function getOrCreateRepo(): Promise<NoteRepositoryType> {
       }
     }
 
-    return repo;
+    return instance;
   })();
 
-  return repoInitPromise;
+  try {
+    return await repoInitPromise;
+  } catch (error) {
+    repo = null;
+    repoInitPromise = null;
+    throw error;
+  }
 }
 
 let cachedEmbeddingConfig: EmbeddingConfig | null | undefined;

--- a/src/obsidian-scaffold.ts
+++ b/src/obsidian-scaffold.ts
@@ -10,6 +10,7 @@ export interface PluginRegistryEntry {
   repo: string;
   tag: string;
   files: string[];
+  fileDigests: Record<string, string>;
 }
 
 export interface ThemeRegistryEntry {
@@ -17,6 +18,7 @@ export interface ThemeRegistryEntry {
   repo: string;
   tag: string;
   files: string[];
+  fileDigests: Record<string, string>;
 }
 
 export interface ScaffoldManifest {
@@ -44,6 +46,9 @@ interface ObsidianScaffoldDeps {
   fetchImpl?: typeof fetch;
   now?: () => Date;
   templatesDir?: string;
+  verifyAssetIntegrity?: boolean;
+  pluginRegistry?: PluginRegistryEntry[];
+  themeRegistry?: ThemeRegistryEntry;
 }
 
 interface AssetInstallResult {
@@ -61,13 +66,13 @@ export const CURRENT_SCAFFOLD_VERSION = 1;
 const SNIPPET_VERSION = 1;
 
 export const PLUGIN_REGISTRY: PluginRegistryEntry[] = [
-  { id: 'homepage', repo: 'mirnovov/obsidian-homepage', tag: '4.4.0', files: ['main.js', 'manifest.json', 'styles.css'] },
-  { id: 'quickadd', repo: 'chhoumann/quickadd', tag: '2.12.0', files: ['main.js', 'manifest.json', 'styles.css'] },
-  { id: 'cmdr', repo: 'jsmorabito/obsidian-commander', tag: '0.5.5', files: ['main.js', 'manifest.json', 'styles.css'] },
-  { id: 'templater-obsidian', repo: 'SilentVoid13/Templater', tag: '2.20.0', files: ['main.js', 'manifest.json', 'styles.css'] },
-  { id: 'obsidian-minimal-settings', repo: 'kepano/obsidian-minimal-settings', tag: '8.2.2', files: ['main.js', 'manifest.json', 'styles.css'] },
-  { id: 'oz-calendar', repo: 'ozntel/oz-calendar', tag: '0.3.4', files: ['main.js', 'manifest.json', 'styles.css'] },
-  { id: 'read-only-view', repo: 'mrKazzila/Read-Only-View', tag: '1.0.2', files: ['main.js', 'manifest.json', 'styles.css'] },
+  { id: 'homepage', repo: 'mirnovov/obsidian-homepage', tag: '4.4.0', files: ['main.js', 'manifest.json', 'styles.css'], fileDigests: { 'main.js': '4239eaaffced27ff2e743fffceefa75e19ccf784da5fc18dbec6b0f63f144b93', 'manifest.json': 'c76ac910648258eb763b4796efb62d56c7012bd8353cc1a6d59dd34f702466b1', 'styles.css': '3e0db75be5be6495188eb429f678606c27ba39d1ba97434f85c2dc387c127508' } },
+  { id: 'quickadd', repo: 'chhoumann/quickadd', tag: '2.12.0', files: ['main.js', 'manifest.json', 'styles.css'], fileDigests: { 'main.js': 'e09403bd9e20fe97affd1d53225ba09fbeada7f5e024dde8b64c5890529bffbe', 'manifest.json': '8eab8e5f9c1632dff06875c79bb55832a0a82f6fece246e05728cabdbe824889', 'styles.css': 'e820f28cbb62f604727a07a7dee614386e765ef3d98bc541ac863ce5961bcba2' } },
+  { id: 'cmdr', repo: 'jsmorabito/obsidian-commander', tag: '0.5.5', files: ['main.js', 'manifest.json', 'styles.css'], fileDigests: { 'main.js': 'ebfce0b5dbaac7dd46c8b51cd397a811020d079ab0bf931a64e20049d7510637', 'manifest.json': 'c6df5e0aa6d389695a87850eeeaf836775e2cd01579f4e277d82bc7a99fbe5e8', 'styles.css': '91765c55d9cddfbd3a62dc06bf18dc3ea6ecb879c89f939a1e50cebd3c31c28c' } },
+  { id: 'templater-obsidian', repo: 'SilentVoid13/Templater', tag: '2.20.0', files: ['main.js', 'manifest.json', 'styles.css'], fileDigests: { 'main.js': '81eccff81962daf8ec722ed2deff7957b3fabee244afc9fb15c39e7b8d2943e3', 'manifest.json': '47f59f1683eca98be9a9fb58ebce3cf37557af2f5947b47bcba9e8f54c567eae', 'styles.css': 'f7d4ee5bd4ec1d032eda1f4e1da481e713c57af964ec1e55d31494f086068d1e' } },
+  { id: 'obsidian-minimal-settings', repo: 'kepano/obsidian-minimal-settings', tag: '8.2.2', files: ['main.js', 'manifest.json', 'styles.css'], fileDigests: { 'main.js': '8aa9350977fca098f56cea444eb672942e10fcaeb9b07aceb05a3d5368aa742b', 'manifest.json': 'cc07b2a08a2128acab9f678f2fdc1a0492b370be928d6ddfb1df1ae4b376667a', 'styles.css': '50084760da927a5bf5ac1b9d3b960dc52e1d0a3bf690e54df8f4d76f8212628c' } },
+  { id: 'oz-calendar', repo: 'ozntel/oz-calendar', tag: '0.3.4', files: ['main.js', 'manifest.json', 'styles.css'], fileDigests: { 'main.js': '366853a93f4e0b2dfcbba25e5f74129b91ec93787ef3c4a97097cb00a8eef458', 'manifest.json': '632f4bc99a28e1d2d54ece32f9c754ebd0cc032e77dab8a962b316a7dbe22080', 'styles.css': '5e66038c352bbe773c8e614247a937499478fedca53697e48188b27a6acc3e41' } },
+  { id: 'read-only-view', repo: 'mrKazzila/Read-Only-View', tag: '1.0.2', files: ['main.js', 'manifest.json', 'styles.css'], fileDigests: { 'main.js': '3df01d1010b8a47dfcd34f9099ab85fd0d94ff3f50794b0521febcb1408728e5', 'manifest.json': 'dbb136801ffe760c277be5707b2d9c7aee9d2a18da504acaf4a9c083f99c2fe4', 'styles.css': 'ed8507c596c292b2f4cf83f8f5645971ce14e0edf060611f258c1f3eddf997eb' } },
 ];
 
 export const THEME_REGISTRY: ThemeRegistryEntry = {
@@ -75,6 +80,7 @@ export const THEME_REGISTRY: ThemeRegistryEntry = {
   repo: 'kepano/obsidian-minimal',
   tag: '8.1.7',
   files: ['manifest.json', 'theme.css'],
+  fileDigests: { 'manifest.json': '7e71c6d34fa20ceafe51aff1220ee62e9a7fc9548592e01da60d366945227e07', 'theme.css': 'ee4610bc2aec92a491e3b66fc3c6e854ddcdd3be91abb9f9aa0870f6adbdfaf8' },
 };
 
 const ASSET_DOWNLOAD_TIMEOUT_MS = 30_000;
@@ -269,26 +275,45 @@ function deterministicId(input: string): string {
   return crypto.createHash('sha1').update(input).digest('hex').replace(/(.{8})(.{4})(.{4})(.{4})(.{12}).*/, '$1-$2-$3-$4-$5');
 }
 
+function sha256Hex(contents: Buffer): string {
+  return crypto.createHash('sha256').update(contents).digest('hex');
+}
+
+function expectedDigest(fileDigests: Record<string, string>, fileName: string): string {
+  const digest = fileDigests[fileName];
+  if (!digest) {
+    throw new Error(`Missing expected digest for ${fileName}`);
+  }
+  return digest;
+}
+
 function buildQuickAddChoices(): Array<Record<string, unknown>> {
   const kinds = [
-    { kind: 'decision', folder: 'decisions', template: 'decision.md', label: 'Decision' },
-    { kind: 'procedure', folder: 'procedures', template: 'procedure.md', label: 'Procedure' },
-    { kind: 'observation', folder: 'observations', template: 'observation.md', label: 'Observation' },
-    { kind: 'reference', folder: 'references', template: 'reference.md', label: 'Reference' },
-    { kind: 'resource', folder: 'resources', template: 'resource.md', label: 'Resource' },
-    { kind: 'personalization', folder: 'preferences', template: 'personalization.md', label: 'Personalization' },
-    { kind: 'domain', folder: 'projects', template: 'domain.md', label: 'Domain' },
+    { id: 'general-decision', kind: 'decision', folder: 'general/decisions', template: 'decision.md', label: 'General Decision' },
+    { id: 'general-procedure', kind: 'procedure', folder: 'general/procedures', template: 'procedure.md', label: 'General Procedure' },
+    { id: 'general-observation', kind: 'observation', folder: 'general/observations', template: 'observation.md', label: 'General Observation' },
+    { id: 'general-reference', kind: 'reference', folder: 'general/references', template: 'reference.md', label: 'General Reference' },
+    { id: 'general-resource', kind: 'resource', folder: 'general/resources', template: 'resource.md', label: 'General Resource' },
+    { id: 'preference', kind: 'personalization', folder: 'preferences', template: 'personalization.md', label: 'Preference' },
+    { id: 'project-decision', kind: 'decision', folder: 'projects/{{VALUE:project|label:Project name|case:slug}}/decisions', template: 'decision.md', label: 'Project Decision' },
+    { id: 'project-procedure', kind: 'procedure', folder: 'projects/{{VALUE:project|label:Project name|case:slug}}/procedures', template: 'procedure.md', label: 'Project Procedure' },
+    { id: 'project-observation', kind: 'observation', folder: 'projects/{{VALUE:project|label:Project name|case:slug}}/observations', template: 'observation.md', label: 'Project Observation' },
+    { id: 'project-reference', kind: 'reference', folder: 'projects/{{VALUE:project|label:Project name|case:slug}}/references', template: 'reference.md', label: 'Project Reference' },
+    { id: 'project-resource', kind: 'resource', folder: 'projects/{{VALUE:project|label:Project name|case:slug}}/resources', template: 'resource.md', label: 'Project Resource' },
+    { id: 'project-domain', kind: 'domain', folder: 'projects/{{VALUE:project|label:Project name|case:slug}}', template: 'domain.md', label: 'Project Domain' },
   ];
 
-  return kinds.map(({ kind, folder, template, label }) => ({
+  return kinds.map(({ id, kind, folder, template, label }) => ({
     name: `New ${label} Note`,
-    id: deterministicId(`quickadd-${kind}`),
+    id: deterministicId(`quickadd-${id}`),
     type: 'Template',
     command: true,
     templatePath: `templates/${template}`,
     fileNameFormat: {
       enabled: true,
-      format: '{{DATE:YYYYMMDDHHmmss}}-{{VALUE}}',
+      format: kind === 'domain'
+        ? 'domain'
+        : '{{DATE:YYYYMMDDHHmmss}}00-{{VALUE:title|label:Note title|case:slug}}',
     },
     folder: {
       enabled: true,
@@ -359,13 +384,12 @@ function buildPluginData(pluginId: string, config: ObsidianConfig): Record<strin
         user_scripts_folder: '',
         enable_folder_templates: true,
         folder_templates: [
-          { folder: 'decisions', template: 'templates/decision.md' },
-          { folder: 'procedures', template: 'templates/procedure.md' },
-          { folder: 'observations', template: 'templates/observation.md' },
-          { folder: 'references', template: 'templates/reference.md' },
-          { folder: 'resources', template: 'templates/resource.md' },
+          { folder: 'general/decisions', template: 'templates/decision.md' },
+          { folder: 'general/procedures', template: 'templates/procedure.md' },
+          { folder: 'general/observations', template: 'templates/observation.md' },
+          { folder: 'general/references', template: 'templates/reference.md' },
+          { folder: 'general/resources', template: 'templates/resource.md' },
           { folder: 'preferences', template: 'templates/personalization.md' },
-          { folder: 'projects', template: 'templates/domain.md' },
         ],
         enable_file_templates: false,
         syntax_highlighting: true,
@@ -421,7 +445,13 @@ function pluginEntriesForConfig(config: ObsidianConfig): PluginRegistryEntry[] {
     : PLUGIN_REGISTRY.filter(entry => entry.id !== 'read-only-view');
 }
 
-async function downloadAsset(repo: string, tag: string, fileName: string, fetchImpl: typeof fetch): Promise<Buffer> {
+function pluginEntriesForConfigWithRegistry(config: ObsidianConfig, registry: PluginRegistryEntry[]): PluginRegistryEntry[] {
+  return config.readOnly
+    ? registry
+    : registry.filter(entry => entry.id !== 'read-only-view');
+}
+
+async function downloadAsset(repo: string, tag: string, fileName: string, fetchImpl: typeof fetch, verifyDigest: string | null): Promise<Buffer> {
   const url = `https://github.com/${repo}/releases/download/${tag}/${fileName}`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), ASSET_DOWNLOAD_TIMEOUT_MS);
@@ -447,7 +477,17 @@ async function downloadAsset(repo: string, tag: string, fileName: string, fetchI
     throw new Error(`HTTP ${response.status} for ${url}`);
   }
   const arrayBuffer = await response.arrayBuffer();
-  return Buffer.from(arrayBuffer);
+  const contents = Buffer.from(arrayBuffer);
+  if (verifyDigest && sha256Hex(contents) !== verifyDigest) {
+    throw new Error(`Digest mismatch for ${url}`);
+  }
+  return contents;
+}
+
+function installedAssetMatchesDigest(dirPath: string, fileName: string, digest: string): boolean {
+  const assetPath = path.join(dirPath, fileName);
+  if (!fs.existsSync(assetPath)) return false;
+  return sha256Hex(fs.readFileSync(assetPath)) === digest;
 }
 
 async function installPluginAssets(
@@ -455,14 +495,14 @@ async function installPluginAssets(
   plugin: PluginRegistryEntry,
   fetchImpl: typeof fetch,
   forceRefresh: boolean,
+  verifyAssetIntegrity: boolean,
 ): Promise<AssetInstallResult> {
   const pluginDir = path.join(getObsidianDir(vaultPath), 'plugins', plugin.id);
   const tempDir = pluginDir + '.tmp';
   ensureDir(pluginDir);
 
-  const requiredFiles = plugin.files.filter(file => file === 'main.js' || file === 'manifest.json');
-  const hadRequiredFiles = requiredFiles.every(file => fs.existsSync(path.join(pluginDir, file)));
-  if (hadRequiredFiles && !forceRefresh) {
+  const allFilesCurrent = plugin.files.every(file => installedAssetMatchesDigest(pluginDir, file, expectedDigest(plugin.fileDigests, file)));
+  if (allFilesCurrent && !forceRefresh) {
     return { available: true, refreshed: false };
   }
 
@@ -470,7 +510,13 @@ async function installPluginAssets(
     fs.rmSync(tempDir, { recursive: true, force: true });
     ensureDir(tempDir);
     for (const fileName of plugin.files) {
-      const contents = await downloadAsset(plugin.repo, plugin.tag, fileName, fetchImpl);
+      const contents = await downloadAsset(
+        plugin.repo,
+        plugin.tag,
+        fileName,
+        fetchImpl,
+        verifyAssetIntegrity ? expectedDigest(plugin.fileDigests, fileName) : null,
+      );
       fs.writeFileSync(path.join(tempDir, fileName), contents);
     }
     for (const fileName of plugin.files) {
@@ -481,7 +527,7 @@ async function installPluginAssets(
   } catch {
     fs.rmSync(tempDir, { recursive: true, force: true });
     return {
-      available: requiredFiles.every(file => fs.existsSync(path.join(pluginDir, file))),
+      available: plugin.files.every(file => fs.existsSync(path.join(pluginDir, file))),
       refreshed: false,
     };
   }
@@ -492,14 +538,14 @@ async function installThemeAssets(
   theme: ThemeRegistryEntry,
   fetchImpl: typeof fetch,
   forceRefresh: boolean,
+  verifyAssetIntegrity: boolean,
 ): Promise<AssetInstallResult> {
   const themeDir = path.join(getObsidianDir(vaultPath), 'themes', theme.name);
   const tempDir = themeDir + '.tmp';
   ensureDir(themeDir);
 
-  const requiredFiles = ['manifest.json', 'theme.css'];
-  const alreadyInstalled = requiredFiles.every(file => fs.existsSync(path.join(themeDir, file)));
-  if (alreadyInstalled && !forceRefresh) {
+  const allFilesCurrent = theme.files.every(file => installedAssetMatchesDigest(themeDir, file, expectedDigest(theme.fileDigests, file)));
+  if (allFilesCurrent && !forceRefresh) {
     return { available: true, refreshed: false };
   }
 
@@ -507,7 +553,13 @@ async function installThemeAssets(
     fs.rmSync(tempDir, { recursive: true, force: true });
     ensureDir(tempDir);
     for (const fileName of theme.files) {
-      const contents = await downloadAsset(theme.repo, theme.tag, fileName, fetchImpl);
+      const contents = await downloadAsset(
+        theme.repo,
+        theme.tag,
+        fileName,
+        fetchImpl,
+        verifyAssetIntegrity ? expectedDigest(theme.fileDigests, fileName) : null,
+      );
       fs.writeFileSync(path.join(tempDir, fileName), contents);
     }
     for (const fileName of theme.files) {
@@ -518,7 +570,7 @@ async function installThemeAssets(
   } catch {
     fs.rmSync(tempDir, { recursive: true, force: true });
     return {
-      available: requiredFiles.every(file => fs.existsSync(path.join(themeDir, file))),
+      available: theme.files.every(file => fs.existsSync(path.join(themeDir, file))),
       refreshed: false,
     };
   }
@@ -626,10 +678,11 @@ function buildPluginManifestState(
   manifest: ScaffoldManifest,
   config: ObsidianConfig,
   pluginResults: Map<string, AssetInstallResult>,
+  registry: PluginRegistryEntry[],
 ): Record<string, { version: string; configVersion: number }> {
   const nextPlugins: Record<string, { version: string; configVersion: number }> = {};
 
-  for (const plugin of pluginEntriesForConfig(config)) {
+  for (const plugin of pluginEntriesForConfigWithRegistry(config, registry)) {
     const result = pluginResults.get(plugin.id);
     if (!result?.available) continue;
 
@@ -654,10 +707,13 @@ async function applyScaffoldV1(
   writeOwnedSnippets(vaultPath, config);
 
   const fetchImpl = deps.fetchImpl ?? fetch;
+  const verifyAssetIntegrity = deps.verifyAssetIntegrity ?? true;
+  const pluginRegistry = deps.pluginRegistry ?? PLUGIN_REGISTRY;
+  const themeRegistry = deps.themeRegistry ?? THEME_REGISTRY;
   const pluginResults = new Map<string, AssetInstallResult>();
   const enabledPlugins: string[] = [];
-  for (const plugin of pluginEntriesForConfig(config)) {
-    const result = await installPluginAssets(vaultPath, plugin, fetchImpl, manifest.plugins[plugin.id]?.version !== plugin.tag);
+  for (const plugin of pluginEntriesForConfigWithRegistry(config, pluginRegistry)) {
+    const result = await installPluginAssets(vaultPath, plugin, fetchImpl, manifest.plugins[plugin.id]?.version !== plugin.tag, verifyAssetIntegrity);
     pluginResults.set(plugin.id, result);
     if (result.available) {
       enabledPlugins.push(plugin.id);
@@ -666,9 +722,9 @@ async function applyScaffoldV1(
     }
   }
 
-  const themeResult = await installThemeAssets(vaultPath, THEME_REGISTRY, fetchImpl, manifest.theme?.version !== THEME_REGISTRY.tag);
+  const themeResult = await installThemeAssets(vaultPath, themeRegistry, fetchImpl, manifest.theme?.version !== themeRegistry.tag, verifyAssetIntegrity);
   if (!themeResult.available) {
-    logToFile('WARN', 'Skipped Obsidian theme scaffold asset after download failure', { theme: THEME_REGISTRY.name, repo: THEME_REGISTRY.repo, tag: THEME_REGISTRY.tag });
+    logToFile('WARN', 'Skipped Obsidian theme scaffold asset after download failure', { theme: themeRegistry.name, repo: themeRegistry.repo, tag: themeRegistry.tag });
   }
 
   syncManagedAppConfig(vaultPath, config);
@@ -681,10 +737,10 @@ async function applyScaffoldV1(
     ...manifest,
     scaffoldVersion: CURRENT_SCAFFOLD_VERSION,
     lastUpgrade: (deps.now ?? (() => new Date()))().toISOString(),
-    plugins: buildPluginManifestState(manifest, config, pluginResults),
+    plugins: buildPluginManifestState(manifest, config, pluginResults, pluginRegistry),
     theme: themeResult.available
       ? (themeResult.refreshed || !manifest.theme
-        ? { name: THEME_REGISTRY.name, version: THEME_REGISTRY.tag }
+        ? { name: themeRegistry.name, version: themeRegistry.tag }
         : manifest.theme)
       : null,
     snippets: { version: SNIPPET_VERSION },

--- a/src/obsidian-scaffold.ts
+++ b/src/obsidian-scaffold.ts
@@ -1,0 +1,629 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { fileURLToPath } from 'url';
+import type { ObsidianConfig } from './types.js';
+import { logToFile } from './logger.js';
+
+export interface PluginRegistryEntry {
+  id: string;
+  repo: string;
+  tag: string;
+  files: string[];
+}
+
+export interface ThemeRegistryEntry {
+  name: string;
+  repo: string;
+  tag: string;
+  files: string[];
+}
+
+export interface ScaffoldManifest {
+  scaffoldVersion: number;
+  installedAt: string;
+  lastUpgrade: string;
+  plugins: Record<string, { version: string; configVersion: number }>;
+  theme: { name: string; version: string } | null;
+  snippets: { version: number };
+}
+
+export interface ObsidianScaffoldStatus {
+  scaffolded: boolean;
+  scaffoldVersion: number | null;
+  latestVersion: number;
+  theme: { name: string; version: string } | null;
+  pluginsInstalled: number;
+  pluginsExpected: number;
+  pluginsNeedingUpdate: number;
+  readOnly: boolean;
+  autoUpgrade: boolean;
+}
+
+interface ObsidianScaffoldDeps {
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  templatesDir?: string;
+}
+
+const DEFAULT_OBSIDIAN_CONFIG: ObsidianConfig = {
+  scaffold: true,
+  autoUpgrade: true,
+  readOnly: true,
+};
+
+export const CURRENT_SCAFFOLD_VERSION = 1;
+const SNIPPET_VERSION = 1;
+
+export const PLUGIN_REGISTRY: PluginRegistryEntry[] = [
+  { id: 'homepage', repo: 'mirnovov/obsidian-homepage', tag: '4.4.0', files: ['main.js', 'manifest.json', 'styles.css'] },
+  { id: 'quickadd', repo: 'chhoumann/quickadd', tag: '2.12.0', files: ['main.js', 'manifest.json', 'styles.css'] },
+  { id: 'cmdr', repo: 'jsmorabito/obsidian-commander', tag: '0.5.5', files: ['main.js', 'manifest.json', 'styles.css'] },
+  { id: 'templater-obsidian', repo: 'SilentVoid13/Templater', tag: '2.20.0', files: ['main.js', 'manifest.json', 'styles.css'] },
+  { id: 'obsidian-minimal-settings', repo: 'kepano/obsidian-minimal-settings', tag: '8.2.2', files: ['main.js', 'manifest.json', 'styles.css'] },
+  { id: 'oz-calendar', repo: 'ozntel/oz-calendar', tag: '0.3.4', files: ['main.js', 'manifest.json', 'styles.css'] },
+  { id: 'read-only-view', repo: 'mrKazzila/Read-Only-View', tag: '1.0.2', files: ['main.js', 'manifest.json', 'styles.css'] },
+];
+
+export const THEME_REGISTRY: ThemeRegistryEntry = {
+  name: 'Minimal',
+  repo: 'kepano/obsidian-minimal',
+  tag: '8.1.7',
+  files: ['manifest.json', 'theme.css'],
+};
+
+const CORE_PLUGINS = [
+  'file-explorer',
+  'global-search',
+  'switcher',
+  'graph',
+  'backlink',
+  'outgoing-link',
+  'tag-pane',
+  'outline',
+  'properties',
+  'bookmarks',
+  'note-composer',
+  'command-palette',
+  'word-count',
+];
+
+const SNIPPETS: Record<string, string> = {
+  'zk-dashboard.css': `
+.dashboard.markdown-reading-view .markdown-preview-sizer,
+.dashboard.markdown-source-view.mod-cm6 .cm-sizer {
+  max-width: 1100px;
+}
+
+.dashboard .callout[data-callout="abstract"] {
+  border-color: var(--interactive-accent);
+  background-color: color-mix(in srgb, var(--interactive-accent) 8%, transparent);
+}
+
+.dashboard h2 {
+  margin-top: 2.25rem;
+}
+
+.dashboard table {
+  width: 100%;
+}
+`.trimStart(),
+  'zk-tables.css': `
+.markdown-rendered table tr:nth-child(even) td {
+  background-color: var(--table-row-alt-background, var(--background-secondary-alt, rgba(0,0,0,0.02)));
+}
+
+.markdown-rendered table thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.markdown-rendered table th {
+  background-color: var(--background-secondary);
+  font-weight: var(--bold-weight, 600);
+  border-bottom: 2px solid var(--interactive-accent);
+}
+
+.markdown-rendered table tr:hover td {
+  background-color: var(--background-modifier-hover, rgba(0,0,0,0.04));
+}
+
+.markdown-rendered table {
+  table-layout: auto;
+  border-collapse: collapse;
+}
+
+.markdown-rendered table th,
+.markdown-rendered table td {
+  padding: 6px 14px;
+}
+
+.markdown-rendered .cm-table-widget {
+  overflow-x: auto;
+}
+`.trimStart(),
+  'zk-metadata.css': 'body { --metadata-display-reading: none; }\n',
+  'readonly-kb.css': `
+.clickable-icon.view-action[aria-label^="Current view"] {
+  display: none !important;
+}
+
+.markdown-source-view.mod-cm6 .edit-block-button {
+  display: none;
+}
+`.trimStart(),
+};
+
+function getPackageTemplatesDir(): string {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'templates');
+}
+
+function getObsidianDir(vaultPath: string): string {
+  return path.join(vaultPath, '.obsidian');
+}
+
+function getManifestPath(vaultPath: string): string {
+  return path.join(getObsidianDir(vaultPath), 'open-zk-kb.json');
+}
+
+function effectiveConfig(config?: Partial<ObsidianConfig>): ObsidianConfig {
+  return {
+    scaffold: config?.scaffold ?? DEFAULT_OBSIDIAN_CONFIG.scaffold,
+    autoUpgrade: config?.autoUpgrade ?? DEFAULT_OBSIDIAN_CONFIG.autoUpgrade,
+    readOnly: config?.readOnly ?? DEFAULT_OBSIDIAN_CONFIG.readOnly,
+  };
+}
+
+function ensureDir(dirPath: string): void {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function readJsonFile<T>(filePath: string): T | null {
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+function writeJsonFile(filePath: string, data: unknown): void {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+}
+
+function mergeAddOnly(existing: unknown, defaults: unknown): unknown {
+  if (Array.isArray(existing) && Array.isArray(defaults)) {
+    const merged = [...existing];
+    for (const item of defaults) {
+      if (!merged.some(existingItem => JSON.stringify(existingItem) === JSON.stringify(item))) {
+        merged.push(item);
+      }
+    }
+    return merged;
+  }
+
+  if (isPlainObject(existing) && isPlainObject(defaults)) {
+    const result: Record<string, unknown> = { ...existing };
+    for (const [key, value] of Object.entries(defaults)) {
+      if (!(key in result)) {
+        result[key] = value;
+      } else {
+        result[key] = mergeAddOnly(result[key], value);
+      }
+    }
+    return result;
+  }
+
+  return existing ?? defaults;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mergeStringArray(existing: unknown, additions: string[]): string[] {
+  const current = Array.isArray(existing) ? existing.filter((item): item is string => typeof item === 'string') : [];
+  const merged = [...current];
+  for (const item of additions) {
+    if (!merged.includes(item)) merged.push(item);
+  }
+  return merged;
+}
+
+function defaultAppConfig(config: ObsidianConfig): Record<string, unknown> {
+  return {
+    propertiesInDocument: 'hidden',
+    defaultViewMode: config.readOnly ? 'preview' : 'source',
+    alwaysUpdateLinks: true,
+    useMarkdownLinks: false,
+    newLinkFormat: 'shortest',
+    showInlineTitle: true,
+    foldHeading: true,
+    trashOption: 'local',
+  };
+}
+
+function defaultAppearanceConfig(config: ObsidianConfig): Record<string, unknown> {
+  const enabledCssSnippets = ['zk-tables', 'zk-metadata', 'zk-dashboard'];
+  if (config.readOnly) enabledCssSnippets.push('readonly-kb');
+
+  return {
+    theme: 'system',
+    cssTheme: THEME_REGISTRY.name,
+    enabledCssSnippets,
+  };
+}
+
+function deterministicId(input: string): string {
+  return crypto.createHash('sha1').update(input).digest('hex').replace(/(.{8})(.{4})(.{4})(.{4})(.{12}).*/, '$1-$2-$3-$4-$5');
+}
+
+function buildQuickAddChoices(): Array<Record<string, unknown>> {
+  const kinds = [
+    { kind: 'decision', folder: 'decisions', template: 'decision.md', label: 'Decision' },
+    { kind: 'procedure', folder: 'procedures', template: 'procedure.md', label: 'Procedure' },
+    { kind: 'observation', folder: 'observations', template: 'observation.md', label: 'Observation' },
+    { kind: 'reference', folder: 'references', template: 'reference.md', label: 'Reference' },
+    { kind: 'resource', folder: 'resources', template: 'resource.md', label: 'Resource' },
+    { kind: 'personalization', folder: 'preferences', template: 'personalization.md', label: 'Personalization' },
+    { kind: 'domain', folder: 'projects', template: 'domain.md', label: 'Domain' },
+  ];
+
+  return kinds.map(({ kind, folder, template, label }) => ({
+    name: `New ${label} Note`,
+    id: deterministicId(`quickadd-${kind}`),
+    type: 'Template',
+    command: true,
+    templatePath: `templates/${template}`,
+    fileNameFormat: {
+      enabled: true,
+      format: '{{DATE:YYYYMMDDHHmmss}}-{{VALUE}}',
+    },
+    folder: {
+      enabled: true,
+      folders: [folder],
+      chooseWhenCreatingNote: false,
+    },
+  }));
+}
+
+function buildPluginData(pluginId: string, config: ObsidianConfig): Record<string, unknown> | null {
+  switch (pluginId) {
+    case 'homepage':
+      return {
+        version: 4,
+        separateMobile: false,
+        homepages: {
+          'Main Homepage': {
+            value: 'index',
+            kind: 'File',
+            openOnStartup: true,
+            openMode: 'Replace all open notes',
+            manualOpenMode: 'Keep open notes',
+            view: 'Reading view',
+            revertView: true,
+            openWhenEmpty: false,
+            refreshDataview: false,
+            autoCreate: false,
+            autoScroll: false,
+            pin: false,
+            commands: [],
+            alwaysApply: false,
+            hideReleaseNotes: false,
+          },
+        },
+      };
+    case 'quickadd': {
+      const multiChoiceId = deterministicId('quickadd-new-note');
+      return {
+        choices: [
+          {
+            name: 'New Note',
+            id: multiChoiceId,
+            type: 'Multi',
+            command: true,
+            choices: buildQuickAddChoices(),
+          },
+        ],
+      };
+    }
+    case 'cmdr':
+      return {
+        leftRibbon: [
+          {
+            id: `quickadd:choice:${deterministicId('quickadd-new-note')}`,
+            icon: 'lucide-plus-circle',
+            name: 'New Note',
+            mode: 'any',
+          },
+        ],
+      };
+    case 'templater-obsidian':
+      return {
+        templates_folder: 'templates',
+        trigger_on_file_creation: false,
+        auto_jump_to_cursor: false,
+        enable_system_commands: false,
+        shell_path: '',
+        user_scripts_folder: '',
+        enable_folder_templates: true,
+        folder_templates: [
+          { folder: 'decisions', template: 'templates/decision.md' },
+          { folder: 'procedures', template: 'templates/procedure.md' },
+          { folder: 'observations', template: 'templates/observation.md' },
+          { folder: 'references', template: 'templates/reference.md' },
+          { folder: 'resources', template: 'templates/resource.md' },
+          { folder: 'preferences', template: 'templates/personalization.md' },
+          { folder: 'projects', template: 'templates/domain.md' },
+        ],
+        enable_file_templates: false,
+        syntax_highlighting: true,
+      };
+    case 'oz-calendar':
+      return {
+        openViewOnStart: true,
+        calendarType: 'ISO 8601',
+        dateSource: 'yaml',
+        yamlKey: 'created',
+        dateFormat: 'YYYY-MM-DD',
+        defaultFolder: '/',
+        defaultFileNamePrefix: 'YYYY-MM-DD',
+        fixedCalendar: true,
+      };
+    case 'read-only-view':
+      if (!config.readOnly) return null;
+      return {
+        includeRules: ['**/*.md'],
+        excludeRules: [],
+        enabled: true,
+        useGlobPatterns: true,
+        caseSensitive: false,
+      };
+    default:
+      return null;
+  }
+}
+
+function readManifest(vaultPath: string): ScaffoldManifest | null {
+  return readJsonFile<ScaffoldManifest>(getManifestPath(vaultPath));
+}
+
+function newManifest(now: Date): ScaffoldManifest {
+  const iso = now.toISOString();
+  return {
+    scaffoldVersion: 0,
+    installedAt: iso,
+    lastUpgrade: iso,
+    plugins: {},
+    theme: null,
+    snippets: { version: 0 },
+  };
+}
+
+function writeManifest(vaultPath: string, manifest: ScaffoldManifest): void {
+  writeJsonFile(getManifestPath(vaultPath), manifest);
+}
+
+function pluginEntriesForConfig(config: ObsidianConfig): PluginRegistryEntry[] {
+  return config.readOnly
+    ? PLUGIN_REGISTRY
+    : PLUGIN_REGISTRY.filter(entry => entry.id !== 'read-only-view');
+}
+
+async function downloadAsset(repo: string, tag: string, fileName: string, fetchImpl: typeof fetch): Promise<Buffer> {
+  const url = `https://github.com/${repo}/releases/download/${tag}/${fileName}`;
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} for ${url}`);
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
+async function installPluginAssets(
+  vaultPath: string,
+  plugin: PluginRegistryEntry,
+  fetchImpl: typeof fetch,
+  forceRefresh: boolean,
+): Promise<boolean> {
+  const pluginDir = path.join(getObsidianDir(vaultPath), 'plugins', plugin.id);
+  ensureDir(pluginDir);
+
+  const requiredFiles = plugin.files.filter(file => file === 'main.js' || file === 'manifest.json');
+  const hadRequiredFiles = requiredFiles.every(file => fs.existsSync(path.join(pluginDir, file)));
+  if (hadRequiredFiles && !forceRefresh) return true;
+
+  if (forceRefresh) {
+    for (const fileName of plugin.files) {
+      const assetPath = path.join(pluginDir, fileName);
+      if (fs.existsSync(assetPath)) fs.unlinkSync(assetPath);
+    }
+  }
+
+  try {
+    for (const fileName of plugin.files) {
+      const contents = await downloadAsset(plugin.repo, plugin.tag, fileName, fetchImpl);
+      fs.writeFileSync(path.join(pluginDir, fileName), contents);
+    }
+    return true;
+  } catch {
+    return requiredFiles.every(file => fs.existsSync(path.join(pluginDir, file)));
+  }
+}
+
+async function installThemeAssets(
+  vaultPath: string,
+  theme: ThemeRegistryEntry,
+  fetchImpl: typeof fetch,
+  forceRefresh: boolean,
+): Promise<boolean> {
+  const themeDir = path.join(getObsidianDir(vaultPath), 'themes', theme.name);
+  ensureDir(themeDir);
+
+  const requiredFiles = ['manifest.json', 'theme.css'];
+  const alreadyInstalled = requiredFiles.every(file => fs.existsSync(path.join(themeDir, file)));
+  if (alreadyInstalled && !forceRefresh) return true;
+
+  if (forceRefresh) {
+    for (const fileName of theme.files) {
+      const assetPath = path.join(themeDir, fileName);
+      if (fs.existsSync(assetPath)) fs.unlinkSync(assetPath);
+    }
+  }
+
+  try {
+    for (const fileName of theme.files) {
+      const contents = await downloadAsset(theme.repo, theme.tag, fileName, fetchImpl);
+      fs.writeFileSync(path.join(themeDir, fileName), contents);
+    }
+    return true;
+  } catch {
+    return requiredFiles.every(file => fs.existsSync(path.join(themeDir, file)));
+  }
+}
+
+function writeOwnedSnippets(vaultPath: string, config: ObsidianConfig): void {
+  const snippetsDir = path.join(getObsidianDir(vaultPath), 'snippets');
+  ensureDir(snippetsDir);
+
+  for (const [fileName, content] of Object.entries(SNIPPETS)) {
+    if (fileName === 'readonly-kb.css' && !config.readOnly) continue;
+    fs.writeFileSync(path.join(snippetsDir, fileName), content, 'utf-8');
+  }
+}
+
+function copyPackageTemplates(vaultPath: string, templatesDir?: string): void {
+  const sourceDir = templatesDir ?? getPackageTemplatesDir();
+  const targetDir = path.join(vaultPath, 'templates');
+  ensureDir(targetDir);
+
+  for (const fileName of fs.readdirSync(sourceDir)) {
+    if (!fileName.endsWith('.md')) continue;
+    const targetPath = path.join(targetDir, fileName);
+    if (!fs.existsSync(targetPath)) {
+      fs.copyFileSync(path.join(sourceDir, fileName), targetPath);
+    }
+  }
+}
+
+function mergeJsonFile(filePath: string, defaults: unknown, arrayMode: 'replace' | 'union' = 'replace'): void {
+  const existing = readJsonFile<unknown>(filePath);
+  if (arrayMode === 'union') {
+    writeJsonFile(filePath, mergeStringArray(existing, defaults as string[]));
+    return;
+  }
+
+  if (existing == null) {
+    writeJsonFile(filePath, defaults);
+    return;
+  }
+
+  writeJsonFile(filePath, mergeAddOnly(existing, defaults));
+}
+
+function applyPluginConfigs(vaultPath: string, config: ObsidianConfig, pluginIds: string[]): Record<string, { version: string; configVersion: number }> {
+  const installed: Record<string, { version: string; configVersion: number }> = {};
+
+  for (const plugin of PLUGIN_REGISTRY) {
+    if (!pluginIds.includes(plugin.id)) continue;
+    installed[plugin.id] = { version: plugin.tag, configVersion: 1 };
+    const data = buildPluginData(plugin.id, config);
+    if (data == null) continue;
+
+    const dataPath = path.join(getObsidianDir(vaultPath), 'plugins', plugin.id, 'data.json');
+    const existing = readJsonFile<unknown>(dataPath);
+    writeJsonFile(dataPath, existing == null ? data : mergeAddOnly(existing, data));
+  }
+
+  return installed;
+}
+
+async function applyScaffoldV1(
+  vaultPath: string,
+  config: ObsidianConfig,
+  manifest: ScaffoldManifest,
+  deps: ObsidianScaffoldDeps,
+): Promise<ScaffoldManifest> {
+  ensureDir(getObsidianDir(vaultPath));
+  copyPackageTemplates(vaultPath, deps.templatesDir);
+  writeOwnedSnippets(vaultPath, config);
+
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const enabledPlugins: string[] = [];
+  for (const plugin of pluginEntriesForConfig(config)) {
+    const ok = await installPluginAssets(vaultPath, plugin, fetchImpl, manifest.plugins[plugin.id]?.version !== plugin.tag);
+    if (ok) {
+      enabledPlugins.push(plugin.id);
+    } else {
+      logToFile('WARN', 'Skipped Obsidian plugin scaffold asset after download failure', { plugin: plugin.id, repo: plugin.repo, tag: plugin.tag });
+    }
+  }
+
+  const themeInstalled = await installThemeAssets(vaultPath, THEME_REGISTRY, fetchImpl, manifest.theme?.version !== THEME_REGISTRY.tag);
+  if (!themeInstalled) {
+    logToFile('WARN', 'Skipped Obsidian theme scaffold asset after download failure', { theme: THEME_REGISTRY.name, repo: THEME_REGISTRY.repo, tag: THEME_REGISTRY.tag });
+  }
+
+  mergeJsonFile(path.join(getObsidianDir(vaultPath), 'app.json'), defaultAppConfig(config));
+  mergeJsonFile(path.join(getObsidianDir(vaultPath), 'appearance.json'), defaultAppearanceConfig(config));
+  mergeJsonFile(path.join(getObsidianDir(vaultPath), 'core-plugins.json'), CORE_PLUGINS, 'union');
+  mergeJsonFile(path.join(getObsidianDir(vaultPath), 'community-plugins.json'), enabledPlugins, 'union');
+
+  const updatedManifest: ScaffoldManifest = {
+    ...manifest,
+    scaffoldVersion: CURRENT_SCAFFOLD_VERSION,
+    lastUpgrade: (deps.now ?? (() => new Date()))().toISOString(),
+    plugins: applyPluginConfigs(vaultPath, config, enabledPlugins),
+    theme: themeInstalled ? { name: THEME_REGISTRY.name, version: THEME_REGISTRY.tag } : null,
+    snippets: { version: SNIPPET_VERSION },
+  };
+
+  writeManifest(vaultPath, updatedManifest);
+  return updatedManifest;
+}
+
+export async function ensureObsidianScaffold(
+  vaultPath: string,
+  config?: Partial<ObsidianConfig>,
+  deps: ObsidianScaffoldDeps = {},
+): Promise<ScaffoldManifest | null> {
+  const resolvedConfig = effectiveConfig(config);
+  if (!resolvedConfig.scaffold) return null;
+
+  const now = (deps.now ?? (() => new Date()))();
+  let manifest = readManifest(vaultPath) ?? newManifest(now);
+
+  if (manifest.scaffoldVersion < 1) {
+    manifest = await applyScaffoldV1(vaultPath, resolvedConfig, manifest, deps);
+  } else if (resolvedConfig.autoUpgrade) {
+    manifest = await applyScaffoldV1(vaultPath, resolvedConfig, manifest, deps);
+  }
+
+  return manifest;
+}
+
+export function getObsidianScaffoldStatus(vaultPath: string, config?: Partial<ObsidianConfig>): ObsidianScaffoldStatus {
+  const resolvedConfig = effectiveConfig(config);
+  const manifest = readManifest(vaultPath);
+  const pluginsExpected = pluginEntriesForConfig(resolvedConfig).length;
+  const pluginsInstalled = manifest ? Object.keys(manifest.plugins).length : 0;
+  const pluginsNeedingUpdate = manifest
+    ? pluginEntriesForConfig(resolvedConfig)
+      .filter(plugin => manifest.plugins[plugin.id] && manifest.plugins[plugin.id].version !== plugin.tag)
+      .length
+    : 0;
+
+  return {
+    scaffolded: manifest != null,
+    scaffoldVersion: manifest?.scaffoldVersion ?? null,
+    latestVersion: CURRENT_SCAFFOLD_VERSION,
+    theme: manifest?.theme ?? null,
+    pluginsInstalled,
+    pluginsExpected,
+    pluginsNeedingUpdate,
+    readOnly: resolvedConfig.readOnly,
+    autoUpgrade: resolvedConfig.autoUpgrade,
+  };
+}

--- a/src/obsidian-scaffold.ts
+++ b/src/obsidian-scaffold.ts
@@ -501,7 +501,9 @@ async function installPluginAssets(
   const tempDir = pluginDir + '.tmp';
   ensureDir(pluginDir);
 
-  const allFilesCurrent = plugin.files.every(file => installedAssetMatchesDigest(pluginDir, file, expectedDigest(plugin.fileDigests, file)));
+  const allFilesCurrent = verifyAssetIntegrity
+    ? plugin.files.every(file => installedAssetMatchesDigest(pluginDir, file, expectedDigest(plugin.fileDigests, file)))
+    : plugin.files.every(file => fs.existsSync(path.join(pluginDir, file)));
   if (allFilesCurrent && !forceRefresh) {
     return { available: true, refreshed: false };
   }
@@ -544,7 +546,9 @@ async function installThemeAssets(
   const tempDir = themeDir + '.tmp';
   ensureDir(themeDir);
 
-  const allFilesCurrent = theme.files.every(file => installedAssetMatchesDigest(themeDir, file, expectedDigest(theme.fileDigests, file)));
+  const allFilesCurrent = verifyAssetIntegrity
+    ? theme.files.every(file => installedAssetMatchesDigest(themeDir, file, expectedDigest(theme.fileDigests, file)))
+    : theme.files.every(file => fs.existsSync(path.join(themeDir, file)));
   if (allFilesCurrent && !forceRefresh) {
     return { available: true, refreshed: false };
   }

--- a/src/obsidian-scaffold.ts
+++ b/src/obsidian-scaffold.ts
@@ -72,6 +72,10 @@ export const THEME_REGISTRY: ThemeRegistryEntry = {
   files: ['manifest.json', 'theme.css'],
 };
 
+const ASSET_DOWNLOAD_TIMEOUT_MS = 30_000;
+const MANAGED_SNIPPETS = ['zk-tables', 'zk-metadata', 'zk-dashboard', 'readonly-kb'];
+const MANAGED_PLUGIN_IDS = PLUGIN_REGISTRY.map(plugin => plugin.id);
+
 const CORE_PLUGINS = [
   'file-explorer',
   'global-search',
@@ -414,7 +418,26 @@ function pluginEntriesForConfig(config: ObsidianConfig): PluginRegistryEntry[] {
 
 async function downloadAsset(repo: string, tag: string, fileName: string, fetchImpl: typeof fetch): Promise<Buffer> {
   const url = `https://github.com/${repo}/releases/download/${tag}/${fileName}`;
-  const response = await fetchImpl(url);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ASSET_DOWNLOAD_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, { signal: controller.signal });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      logToFile('WARN', 'Timed out Obsidian scaffold asset download', {
+        repo,
+        tag,
+        fileName,
+        timeoutMs: ASSET_DOWNLOAD_TIMEOUT_MS,
+      });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} for ${url}`);
   }
@@ -429,26 +452,27 @@ async function installPluginAssets(
   forceRefresh: boolean,
 ): Promise<boolean> {
   const pluginDir = path.join(getObsidianDir(vaultPath), 'plugins', plugin.id);
+  const tempDir = pluginDir + '.tmp';
   ensureDir(pluginDir);
 
   const requiredFiles = plugin.files.filter(file => file === 'main.js' || file === 'manifest.json');
   const hadRequiredFiles = requiredFiles.every(file => fs.existsSync(path.join(pluginDir, file)));
   if (hadRequiredFiles && !forceRefresh) return true;
 
-  if (forceRefresh) {
-    for (const fileName of plugin.files) {
-      const assetPath = path.join(pluginDir, fileName);
-      if (fs.existsSync(assetPath)) fs.unlinkSync(assetPath);
-    }
-  }
-
   try {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    ensureDir(tempDir);
     for (const fileName of plugin.files) {
       const contents = await downloadAsset(plugin.repo, plugin.tag, fileName, fetchImpl);
-      fs.writeFileSync(path.join(pluginDir, fileName), contents);
+      fs.writeFileSync(path.join(tempDir, fileName), contents);
     }
+    for (const fileName of plugin.files) {
+      fs.renameSync(path.join(tempDir, fileName), path.join(pluginDir, fileName));
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
     return true;
   } catch {
+    fs.rmSync(tempDir, { recursive: true, force: true });
     return requiredFiles.every(file => fs.existsSync(path.join(pluginDir, file)));
   }
 }
@@ -460,26 +484,27 @@ async function installThemeAssets(
   forceRefresh: boolean,
 ): Promise<boolean> {
   const themeDir = path.join(getObsidianDir(vaultPath), 'themes', theme.name);
+  const tempDir = themeDir + '.tmp';
   ensureDir(themeDir);
 
   const requiredFiles = ['manifest.json', 'theme.css'];
   const alreadyInstalled = requiredFiles.every(file => fs.existsSync(path.join(themeDir, file)));
   if (alreadyInstalled && !forceRefresh) return true;
 
-  if (forceRefresh) {
-    for (const fileName of theme.files) {
-      const assetPath = path.join(themeDir, fileName);
-      if (fs.existsSync(assetPath)) fs.unlinkSync(assetPath);
-    }
-  }
-
   try {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    ensureDir(tempDir);
     for (const fileName of theme.files) {
       const contents = await downloadAsset(theme.repo, theme.tag, fileName, fetchImpl);
-      fs.writeFileSync(path.join(themeDir, fileName), contents);
+      fs.writeFileSync(path.join(tempDir, fileName), contents);
     }
+    for (const fileName of theme.files) {
+      fs.renameSync(path.join(tempDir, fileName), path.join(themeDir, fileName));
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
     return true;
   } catch {
+    fs.rmSync(tempDir, { recursive: true, force: true });
     return requiredFiles.every(file => fs.existsSync(path.join(themeDir, file)));
   }
 }
@@ -491,6 +516,13 @@ function writeOwnedSnippets(vaultPath: string, config: ObsidianConfig): void {
   for (const [fileName, content] of Object.entries(SNIPPETS)) {
     if (fileName === 'readonly-kb.css' && !config.readOnly) continue;
     fs.writeFileSync(path.join(snippetsDir, fileName), content, 'utf-8');
+  }
+
+  if (!config.readOnly) {
+    const readonlySnippetPath = path.join(snippetsDir, 'readonly-kb.css');
+    if (fs.existsSync(readonlySnippetPath)) {
+      fs.rmSync(readonlySnippetPath, { force: true });
+    }
   }
 }
 
@@ -521,6 +553,46 @@ function mergeJsonFile(filePath: string, defaults: unknown, arrayMode: 'replace'
   }
 
   writeJsonFile(filePath, mergeAddOnly(existing, defaults));
+}
+
+function syncManagedAppConfig(vaultPath: string, config: ObsidianConfig): void {
+  const filePath = path.join(getObsidianDir(vaultPath), 'app.json');
+  const existing = readJsonFile<Record<string, unknown>>(filePath) ?? {};
+  const merged = mergeAddOnly(existing, defaultAppConfig(config)) as Record<string, unknown>;
+  merged.defaultViewMode = config.readOnly ? 'preview' : 'source';
+  writeJsonFile(filePath, merged);
+}
+
+function syncManagedAppearanceConfig(vaultPath: string, config: ObsidianConfig): void {
+  const filePath = path.join(getObsidianDir(vaultPath), 'appearance.json');
+  const existing = readJsonFile<Record<string, unknown>>(filePath) ?? {};
+  const merged = mergeAddOnly(existing, defaultAppearanceConfig(config)) as Record<string, unknown>;
+  const currentSnippets = Array.isArray(existing.enabledCssSnippets)
+    ? existing.enabledCssSnippets.filter((item): item is string => typeof item === 'string')
+    : [];
+  const desiredSnippets = (defaultAppearanceConfig(config).enabledCssSnippets as string[]);
+
+  merged.enabledCssSnippets = [...currentSnippets.filter(item => !MANAGED_SNIPPETS.includes(item))];
+  for (const snippet of desiredSnippets) {
+    if (!(merged.enabledCssSnippets as string[]).includes(snippet)) {
+      (merged.enabledCssSnippets as string[]).push(snippet);
+    }
+  }
+
+  writeJsonFile(filePath, merged);
+}
+
+function syncManagedCommunityPlugins(vaultPath: string, enabledPlugins: string[]): void {
+  const filePath = path.join(getObsidianDir(vaultPath), 'community-plugins.json');
+  const existing = readJsonFile<unknown>(filePath);
+  const currentPlugins = Array.isArray(existing)
+    ? existing.filter((item): item is string => typeof item === 'string')
+    : [];
+  const merged = currentPlugins.filter(plugin => !MANAGED_PLUGIN_IDS.includes(plugin));
+  for (const plugin of enabledPlugins) {
+    if (!merged.includes(plugin)) merged.push(plugin);
+  }
+  writeJsonFile(filePath, merged);
 }
 
 function applyPluginConfigs(vaultPath: string, config: ObsidianConfig, pluginIds: string[]): Record<string, { version: string; configVersion: number }> {
@@ -566,10 +638,10 @@ async function applyScaffoldV1(
     logToFile('WARN', 'Skipped Obsidian theme scaffold asset after download failure', { theme: THEME_REGISTRY.name, repo: THEME_REGISTRY.repo, tag: THEME_REGISTRY.tag });
   }
 
-  mergeJsonFile(path.join(getObsidianDir(vaultPath), 'app.json'), defaultAppConfig(config));
-  mergeJsonFile(path.join(getObsidianDir(vaultPath), 'appearance.json'), defaultAppearanceConfig(config));
+  syncManagedAppConfig(vaultPath, config);
+  syncManagedAppearanceConfig(vaultPath, config);
   mergeJsonFile(path.join(getObsidianDir(vaultPath), 'core-plugins.json'), CORE_PLUGINS, 'union');
-  mergeJsonFile(path.join(getObsidianDir(vaultPath), 'community-plugins.json'), enabledPlugins, 'union');
+  syncManagedCommunityPlugins(vaultPath, enabledPlugins);
 
   const updatedManifest: ScaffoldManifest = {
     ...manifest,

--- a/src/obsidian-scaffold.ts
+++ b/src/obsidian-scaffold.ts
@@ -46,6 +46,11 @@ interface ObsidianScaffoldDeps {
   templatesDir?: string;
 }
 
+interface AssetInstallResult {
+  available: boolean;
+  refreshed: boolean;
+}
+
 const DEFAULT_OBSIDIAN_CONFIG: ObsidianConfig = {
   scaffold: true,
   autoUpgrade: true,
@@ -450,14 +455,16 @@ async function installPluginAssets(
   plugin: PluginRegistryEntry,
   fetchImpl: typeof fetch,
   forceRefresh: boolean,
-): Promise<boolean> {
+): Promise<AssetInstallResult> {
   const pluginDir = path.join(getObsidianDir(vaultPath), 'plugins', plugin.id);
   const tempDir = pluginDir + '.tmp';
   ensureDir(pluginDir);
 
   const requiredFiles = plugin.files.filter(file => file === 'main.js' || file === 'manifest.json');
   const hadRequiredFiles = requiredFiles.every(file => fs.existsSync(path.join(pluginDir, file)));
-  if (hadRequiredFiles && !forceRefresh) return true;
+  if (hadRequiredFiles && !forceRefresh) {
+    return { available: true, refreshed: false };
+  }
 
   try {
     fs.rmSync(tempDir, { recursive: true, force: true });
@@ -470,10 +477,13 @@ async function installPluginAssets(
       fs.renameSync(path.join(tempDir, fileName), path.join(pluginDir, fileName));
     }
     fs.rmSync(tempDir, { recursive: true, force: true });
-    return true;
+    return { available: true, refreshed: true };
   } catch {
     fs.rmSync(tempDir, { recursive: true, force: true });
-    return requiredFiles.every(file => fs.existsSync(path.join(pluginDir, file)));
+    return {
+      available: requiredFiles.every(file => fs.existsSync(path.join(pluginDir, file))),
+      refreshed: false,
+    };
   }
 }
 
@@ -482,14 +492,16 @@ async function installThemeAssets(
   theme: ThemeRegistryEntry,
   fetchImpl: typeof fetch,
   forceRefresh: boolean,
-): Promise<boolean> {
+): Promise<AssetInstallResult> {
   const themeDir = path.join(getObsidianDir(vaultPath), 'themes', theme.name);
   const tempDir = themeDir + '.tmp';
   ensureDir(themeDir);
 
   const requiredFiles = ['manifest.json', 'theme.css'];
   const alreadyInstalled = requiredFiles.every(file => fs.existsSync(path.join(themeDir, file)));
-  if (alreadyInstalled && !forceRefresh) return true;
+  if (alreadyInstalled && !forceRefresh) {
+    return { available: true, refreshed: false };
+  }
 
   try {
     fs.rmSync(tempDir, { recursive: true, force: true });
@@ -502,10 +514,13 @@ async function installThemeAssets(
       fs.renameSync(path.join(tempDir, fileName), path.join(themeDir, fileName));
     }
     fs.rmSync(tempDir, { recursive: true, force: true });
-    return true;
+    return { available: true, refreshed: true };
   } catch {
     fs.rmSync(tempDir, { recursive: true, force: true });
-    return requiredFiles.every(file => fs.existsSync(path.join(themeDir, file)));
+    return {
+      available: requiredFiles.every(file => fs.existsSync(path.join(themeDir, file))),
+      refreshed: false,
+    };
   }
 }
 
@@ -595,12 +610,9 @@ function syncManagedCommunityPlugins(vaultPath: string, enabledPlugins: string[]
   writeJsonFile(filePath, merged);
 }
 
-function applyPluginConfigs(vaultPath: string, config: ObsidianConfig, pluginIds: string[]): Record<string, { version: string; configVersion: number }> {
-  const installed: Record<string, { version: string; configVersion: number }> = {};
-
+function writePluginConfigs(vaultPath: string, config: ObsidianConfig, pluginIds: string[]): void {
   for (const plugin of PLUGIN_REGISTRY) {
     if (!pluginIds.includes(plugin.id)) continue;
-    installed[plugin.id] = { version: plugin.tag, configVersion: 1 };
     const data = buildPluginData(plugin.id, config);
     if (data == null) continue;
 
@@ -608,8 +620,27 @@ function applyPluginConfigs(vaultPath: string, config: ObsidianConfig, pluginIds
     const existing = readJsonFile<unknown>(dataPath);
     writeJsonFile(dataPath, existing == null ? data : mergeAddOnly(existing, data));
   }
+}
 
-  return installed;
+function buildPluginManifestState(
+  manifest: ScaffoldManifest,
+  config: ObsidianConfig,
+  pluginResults: Map<string, AssetInstallResult>,
+): Record<string, { version: string; configVersion: number }> {
+  const nextPlugins: Record<string, { version: string; configVersion: number }> = {};
+
+  for (const plugin of pluginEntriesForConfig(config)) {
+    const result = pluginResults.get(plugin.id);
+    if (!result?.available) continue;
+
+    if (result.refreshed || !manifest.plugins[plugin.id]) {
+      nextPlugins[plugin.id] = { version: plugin.tag, configVersion: 1 };
+    } else {
+      nextPlugins[plugin.id] = manifest.plugins[plugin.id];
+    }
+  }
+
+  return nextPlugins;
 }
 
 async function applyScaffoldV1(
@@ -623,18 +654,20 @@ async function applyScaffoldV1(
   writeOwnedSnippets(vaultPath, config);
 
   const fetchImpl = deps.fetchImpl ?? fetch;
+  const pluginResults = new Map<string, AssetInstallResult>();
   const enabledPlugins: string[] = [];
   for (const plugin of pluginEntriesForConfig(config)) {
-    const ok = await installPluginAssets(vaultPath, plugin, fetchImpl, manifest.plugins[plugin.id]?.version !== plugin.tag);
-    if (ok) {
+    const result = await installPluginAssets(vaultPath, plugin, fetchImpl, manifest.plugins[plugin.id]?.version !== plugin.tag);
+    pluginResults.set(plugin.id, result);
+    if (result.available) {
       enabledPlugins.push(plugin.id);
     } else {
       logToFile('WARN', 'Skipped Obsidian plugin scaffold asset after download failure', { plugin: plugin.id, repo: plugin.repo, tag: plugin.tag });
     }
   }
 
-  const themeInstalled = await installThemeAssets(vaultPath, THEME_REGISTRY, fetchImpl, manifest.theme?.version !== THEME_REGISTRY.tag);
-  if (!themeInstalled) {
+  const themeResult = await installThemeAssets(vaultPath, THEME_REGISTRY, fetchImpl, manifest.theme?.version !== THEME_REGISTRY.tag);
+  if (!themeResult.available) {
     logToFile('WARN', 'Skipped Obsidian theme scaffold asset after download failure', { theme: THEME_REGISTRY.name, repo: THEME_REGISTRY.repo, tag: THEME_REGISTRY.tag });
   }
 
@@ -642,13 +675,18 @@ async function applyScaffoldV1(
   syncManagedAppearanceConfig(vaultPath, config);
   mergeJsonFile(path.join(getObsidianDir(vaultPath), 'core-plugins.json'), CORE_PLUGINS, 'union');
   syncManagedCommunityPlugins(vaultPath, enabledPlugins);
+  writePluginConfigs(vaultPath, config, enabledPlugins);
 
   const updatedManifest: ScaffoldManifest = {
     ...manifest,
     scaffoldVersion: CURRENT_SCAFFOLD_VERSION,
     lastUpgrade: (deps.now ?? (() => new Date()))().toISOString(),
-    plugins: applyPluginConfigs(vaultPath, config, enabledPlugins),
-    theme: themeInstalled ? { name: THEME_REGISTRY.name, version: THEME_REGISTRY.tag } : null,
+    plugins: buildPluginManifestState(manifest, config, pluginResults),
+    theme: themeResult.available
+      ? (themeResult.refreshed || !manifest.theme
+        ? { name: THEME_REGISTRY.name, version: THEME_REGISTRY.tag }
+        : manifest.theme)
+      : null,
     snippets: { version: SNIPPET_VERSION },
   };
 

--- a/src/storage/IndexBuilder.ts
+++ b/src/storage/IndexBuilder.ts
@@ -198,15 +198,24 @@ export function buildGlobalIndexContent(
   preferencesCount: number,
   generalCount: number,
   fleetingCount: number,
+  totalNoteCount: number,
 ): string {
   const lines: string[] = [];
 
-  lines.push('# Knowledge Base');
+  lines.push('---');
+  lines.push('cssclasses:');
+  lines.push('  - dashboard');
+  lines.push('---');
+  lines.push('');
+  lines.push('# 🧠 Knowledge Base');
+  lines.push('');
+  lines.push(`> [!abstract] Your persistent memory across AI sessions`);
+  lines.push(`> **${totalNoteCount}** notes · **${projectStats.length}** projects · Last updated: ${formatDateTime()}`);
   lines.push('');
 
   if (projectStats.length > 0) {
     const sorted = [...projectStats].sort((a, b) => b.lastActive - a.lastActive);
-    lines.push(`## Projects (${sorted.length})`);
+    lines.push('## 📂 Projects');
     lines.push('| Project | Notes | Last Active |');
     lines.push('|---------|-------|-------------|');
     for (const stat of sorted) {
@@ -216,23 +225,28 @@ export function buildGlobalIndexContent(
     lines.push('');
   }
 
-  if (preferencesCount > 0) {
-    lines.push(`## [[preferences/index|Preferences]] — ${preferencesCount} notes`);
-    lines.push('');
-  }
+  lines.push('## 📚 Browse');
+  lines.push('| Section | Notes | Description |');
+  lines.push('|---------|-------|-------------|');
+  lines.push(`| [[general/index\\|General Knowledge]] | ${generalCount} | Unscoped references, decisions, observations |`);
+  lines.push(`| [[preferences/index\\|Preferences]] | ${preferencesCount} | Personal style, habits, and tool preferences |`);
+  lines.push(`| [[review\\|📝 Needs Review]] | ${fleetingCount} | Fleeting notes awaiting promotion or archive |`);
+  lines.push('');
 
-  if (generalCount > 0) {
-    lines.push(`## [[general/index|General]] — ${generalCount} notes`);
-    lines.push('');
-  }
+  lines.push('## 📖 Activity');
+  lines.push('');
+  lines.push('- [[log|Operations Log]] — Recent knowledge capture events');
+  lines.push('');
 
-  if (fleetingCount > 0) {
-    lines.push(`## [[review|📝 Needs Review]] — ${fleetingCount} fleeting notes`);
-    lines.push('');
-  }
+  lines.push('## 🔗 Resources');
+  lines.push('');
+  lines.push('- [Documentation](https://github.com/mrosnerr/open-zk-kb#readme) — Setup, configuration, note kinds');
+  lines.push('- [Report an Issue](https://github.com/mrosnerr/open-zk-kb/issues/new) — Bug reports and feature requests');
+  lines.push('- [Changelog](https://github.com/mrosnerr/open-zk-kb/releases) — What\'s new');
+  lines.push('');
 
   lines.push('---');
-  lines.push(`Last rebuilt: ${formatDateTime()}`);
+  lines.push('*Powered by [open-zk-kb](https://github.com/mrosnerr/open-zk-kb) · MIT License*');
 
   return lines.join('\n');
 }

--- a/src/storage/IndexBuilder.ts
+++ b/src/storage/IndexBuilder.ts
@@ -199,8 +199,14 @@ export function buildGlobalIndexContent(
   generalCount: number,
   fleetingCount: number,
   totalNoteCount: number,
+  options?: {
+    includeReviewLink?: boolean;
+    includeGlobalLogLink?: boolean;
+  },
 ): string {
   const lines: string[] = [];
+  const includeReviewLink = options?.includeReviewLink !== false;
+  const includeGlobalLogLink = options?.includeGlobalLogLink !== false;
 
   lines.push('---');
   lines.push('cssclasses:');
@@ -230,13 +236,17 @@ export function buildGlobalIndexContent(
   lines.push('|---------|-------|-------------|');
   lines.push(`| [[general/index\\|General Knowledge]] | ${generalCount} | Unscoped references, decisions, observations |`);
   lines.push(`| [[preferences/index\\|Preferences]] | ${preferencesCount} | Personal style, habits, and tool preferences |`);
-  lines.push(`| [[review\\|📝 Needs Review]] | ${fleetingCount} | Fleeting notes awaiting promotion or archive |`);
+  if (includeReviewLink) {
+    lines.push(`| [[review\\|📝 Needs Review]] | ${fleetingCount} | Fleeting notes awaiting promotion or archive |`);
+  }
   lines.push('');
 
-  lines.push('## 📖 Activity');
-  lines.push('');
-  lines.push('- [[log|Operations Log]] — Recent knowledge capture events');
-  lines.push('');
+  if (includeGlobalLogLink) {
+    lines.push('## 📖 Activity');
+    lines.push('');
+    lines.push('- [[log|Operations Log]] — Recent knowledge capture events');
+    lines.push('');
+  }
 
   lines.push('## 🔗 Resources');
   lines.push('');

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -548,7 +548,10 @@ function updateGlobalNavigation(
       const prefsCount = repo.getPersonalizationNotes().length;
       const generalCount = getUnscopedNotes().length;
       const fleetingCount = getFleetingNotes().length;
-      const content = buildGlobalIndexContent(projectStats, prefsCount, generalCount, fleetingCount, totalNoteCount);
+      const content = buildGlobalIndexContent(projectStats, prefsCount, generalCount, fleetingCount, totalNoteCount, {
+        includeReviewLink: config?.navigation?.enableReviewMoc !== false,
+        includeGlobalLogLink: config?.navigation?.enableGlobalLog !== false,
+      });
       fs.writeFileSync(path.join(vaultPath, 'index.md'), content, 'utf-8');
     } catch (error) {
       logToFile('WARN', 'Failed to rebuild global index', {
@@ -1006,7 +1009,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         output += `- Auto-upgrade: ${scaffoldStatus.autoUpgrade ? 'enabled' : 'disabled'}\n`;
         output += `- Read-only: ${scaffoldStatus.readOnly ? 'enabled' : 'disabled'}\n`;
         if (!scaffoldStatus.readOnly) {
-          output += '⚠️ Vault editing enabled. Direct edits may desync the search index and frontmatter. Use knowledge-store for best results.\n';
+          output += '- External edits risk index/frontmatter drift: true\n';
         }
       }
 

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -38,6 +38,7 @@ import { extractFromUrl, extractArticle } from './url-extractor.js';
 import type { ExtractionResult } from './url-extractor.js';
 import { splitSections, extractLinks, countWords } from './content-splitter.js';
 import { detectObsidian, launchObsidian, formatNotInstalledMessage, formatSuccessMessage } from './obsidian.js';
+import { ensureObsidianScaffold, getObsidianScaffoldStatus } from './obsidian-scaffold.js';
 import { contractPath } from './utils/path.js';
 import { getTemplate, getExpectedCategories, matchCategories, extractHeaders, stripExamplesBlock, CONFORMANCE_KINDS } from './template-handler.js';
 
@@ -220,6 +221,7 @@ export interface OpenArgs {
   project?: string;
   _detectObsidian?: typeof detectObsidian;
   _launchObsidian?: typeof launchObsidian;
+  _ensureScaffold?: typeof ensureObsidianScaffold;
 }
 
 interface RelatedNote {
@@ -542,10 +544,11 @@ function updateGlobalNavigation(
   if (config?.navigation?.enableGlobalIndex !== false) {
     try {
       const projectStats = repo.getProjectStats();
+      const totalNoteCount = repo.getStats().total;
       const prefsCount = repo.getPersonalizationNotes().length;
       const generalCount = getUnscopedNotes().length;
       const fleetingCount = getFleetingNotes().length;
-      const content = buildGlobalIndexContent(projectStats, prefsCount, generalCount, fleetingCount);
+      const content = buildGlobalIndexContent(projectStats, prefsCount, generalCount, fleetingCount, totalNoteCount);
       fs.writeFileSync(path.join(vaultPath, 'index.md'), content, 'utf-8');
     } catch (error) {
       logToFile('WARN', 'Failed to rebuild global index', {
@@ -985,6 +988,28 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         }
       }
 
+      if (config.vault) {
+        const scaffoldStatus = getObsidianScaffoldStatus(config.vault, config.obsidian);
+        output += '\n## Obsidian Vault\n';
+        output += `- Scaffold: ${scaffoldStatus.scaffolded ? 'present' : 'not installed'}\n`;
+        if (scaffoldStatus.scaffoldVersion != null) {
+          output += `- Scaffold version: ${scaffoldStatus.scaffoldVersion} (latest: ${scaffoldStatus.latestVersion})\n`;
+        }
+        if (scaffoldStatus.theme) {
+          output += `- Theme: ${scaffoldStatus.theme.name} ${scaffoldStatus.theme.version}\n`;
+        }
+        output += `- Plugins: ${scaffoldStatus.pluginsInstalled}/${scaffoldStatus.pluginsExpected} installed`;
+        if (scaffoldStatus.pluginsNeedingUpdate > 0) {
+          output += `, ${scaffoldStatus.pluginsNeedingUpdate} need update`;
+        }
+        output += '\n';
+        output += `- Auto-upgrade: ${scaffoldStatus.autoUpgrade ? 'enabled' : 'disabled'}\n`;
+        output += `- Read-only: ${scaffoldStatus.readOnly ? 'enabled' : 'disabled'}\n`;
+        if (!scaffoldStatus.readOnly) {
+          output += '⚠️ Vault editing enabled. Direct edits may desync the search index and frontmatter. Use knowledge-store for best results.\n';
+        }
+      }
+
       if (embeddingStats.total > 0 || embeddingConfig) {
         output += '\n## Embeddings\n';
         if (embeddingConfig) {
@@ -1119,6 +1144,21 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
           output += `- **${m.id}** (v${m.version}): ${m.description} — ${m.pending} pending [${m.status}]\n`;
         }
       }
+      return output;
+    }
+    case 'upgrade-vault': {
+      const manifest = await ensureObsidianScaffold(config.vault, config.obsidian);
+      if (!manifest) {
+        return 'Obsidian scaffold is disabled in config.';
+      }
+
+      const status = getObsidianScaffoldStatus(config.vault, config.obsidian);
+      let output = '## Obsidian Vault Upgrade\n\n';
+      output += `Scaffold version: ${status.scaffoldVersion} (latest: ${status.latestVersion})\n`;
+      output += `Theme: ${status.theme ? `${status.theme.name} ${status.theme.version}` : 'not installed'}\n`;
+      output += `Plugins: ${status.pluginsInstalled}/${status.pluginsExpected} installed\n`;
+      output += `Auto-upgrade: ${status.autoUpgrade ? 'enabled' : 'disabled'}\n`;
+      output += `Read-only: ${status.readOnly ? 'enabled' : 'disabled'}\n`;
       return output;
     }
     case 'upgrade-read': {
@@ -1695,7 +1735,7 @@ export function handleOverview(args: OverviewArgs, repo: NoteRepository, config?
   return output;
 }
 
-export function handleOpen(args: OpenArgs, config: AppConfig, repo?: NoteRepository): string {
+export async function handleOpen(args: OpenArgs, config: AppConfig, repo?: NoteRepository): Promise<string> {
   const vaultPath = config.vault;
 
   if (!fs.existsSync(vaultPath)) {
@@ -1707,6 +1747,16 @@ export function handleOpen(args: OpenArgs, config: AppConfig, repo?: NoteReposit
 
   if (!detection.installed) {
     return formatNotInstalledMessage(vaultPath);
+  }
+
+  const ensureScaffold = args._ensureScaffold || ensureObsidianScaffold;
+  try {
+    await ensureScaffold(vaultPath, config.obsidian);
+  } catch (error) {
+    logToFile('WARN', 'Failed to scaffold Obsidian vault config before launch', {
+      error: error instanceof Error ? error.message : String(error),
+      vaultPath,
+    });
   }
 
   let filePath: string | undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,12 @@ export interface TelemetryConfig {
   enabled: boolean;
 }
 
+export interface ObsidianConfig {
+  scaffold: boolean;
+  autoUpgrade: boolean;
+  readOnly: boolean;
+}
+
 export interface RelatedNotesConfig {
   enabled: boolean;
   maxResults: number;
@@ -89,6 +95,7 @@ export interface AppConfig {
   store: StoreConfig;
   navigation: NavigationConfig;
   telemetry: TelemetryConfig;
+  obsidian: ObsidianConfig;
 }
 
 // NOTE: NoteMetadata and StoreResult are defined in storage/NoteRepository.ts

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -81,6 +81,9 @@ describe('config.ts', () => {
     expect(cfg.lifecycle.exemptKinds).toEqual(['personalization', 'decision']);
     expect(cfg.lifecycle.autoArchiveFleetingDays).toBe(90);
     expect(cfg.telemetry.enabled).toBe(false);
+    expect(cfg.obsidian.scaffold).toBe(true);
+    expect(cfg.obsidian.autoUpgrade).toBe(true);
+    expect(cfg.obsidian.readOnly).toBe(true);
   });
 
   it('reads vault path from YAML config', async () => {
@@ -130,6 +133,22 @@ describe('config.ts', () => {
     const cfg = configModule.getConfig();
 
     expect(cfg.telemetry.enabled).toBe(true);
+  });
+
+  it('reads obsidian scaffold config overrides', async () => {
+    const isolated = createIsolatedConfigHome();
+    fs.writeFileSync(
+      isolated.configPath,
+      ['obsidian:', '  scaffold: false', '  autoUpgrade: false', '  readOnly: false', ''].join('\n'),
+      'utf-8'
+    );
+
+    const configModule = await loadFreshConfigModule();
+    const cfg = configModule.getConfig();
+
+    expect(cfg.obsidian.scaffold).toBe(false);
+    expect(cfg.obsidian.autoUpgrade).toBe(false);
+    expect(cfg.obsidian.readOnly).toBe(false);
   });
 
   it('falls back to disabled telemetry for malformed telemetry config', async () => {

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -58,6 +58,11 @@ export function createTestHarness(options: TestHarnessOptions = {}): TestContext
     telemetry: {
       enabled: options.telemetryEnabled ?? false,
     },
+    obsidian: {
+      scaffold: true,
+      autoUpgrade: true,
+      readOnly: true,
+    },
   };
 
   const engine = new NoteRepository(tempDir, { telemetryEnabled: config.telemetry.enabled });

--- a/tests/obsidian-scaffold.test.ts
+++ b/tests/obsidian-scaffold.test.ts
@@ -1,9 +1,55 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { createTestHarness, cleanupTestHarness } from './harness.js';
 import type { TestContext } from './harness.js';
 import { ensureObsidianScaffold } from '../src/obsidian-scaffold.js';
+
+const MOCK_MANIFEST_CONTENT = JSON.stringify({ name: 'Mock', id: 'mock', version: '1.0.0' });
+const MOCK_STYLE_CONTENT = 'body { color: var(--text-normal); }';
+const MOCK_MAIN_CONTENT = 'module.exports = {};';
+
+function sha256(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+function mockScaffoldDeps() {
+  return {
+    fetchImpl: mockFetchFactory(),
+    verifyAssetIntegrity: false,
+  };
+}
+
+function mockIntegrityDeps() {
+  return {
+    fetchImpl: mockFetchFactory(),
+    verifyAssetIntegrity: true,
+    pluginRegistry: [
+      {
+        id: 'homepage',
+        repo: 'mock/homepage',
+        tag: '1.0.0',
+        files: ['main.js', 'manifest.json', 'styles.css'],
+        fileDigests: {
+          'main.js': sha256(MOCK_MAIN_CONTENT),
+          'manifest.json': sha256(MOCK_MANIFEST_CONTENT),
+          'styles.css': sha256(MOCK_STYLE_CONTENT),
+        },
+      },
+    ],
+    themeRegistry: {
+      name: 'Minimal',
+      repo: 'mock/minimal',
+      tag: '1.0.0',
+      files: ['manifest.json', 'theme.css'],
+      fileDigests: {
+        'manifest.json': sha256(MOCK_MANIFEST_CONTENT),
+        'theme.css': sha256(MOCK_STYLE_CONTENT),
+      },
+    },
+  };
+}
 
 function mockFetchFactory() {
   return async (url: string | URL | Request): Promise<Response> => {
@@ -11,13 +57,13 @@ function mockFetchFactory() {
     const fileName = urlString.split('/').pop() || 'asset.txt';
 
     if (fileName === 'manifest.json') {
-      return new Response(JSON.stringify({ name: 'Mock', id: 'mock', version: '1.0.0' }), { status: 200 });
+      return new Response(MOCK_MANIFEST_CONTENT, { status: 200 });
     }
     if (fileName === 'theme.css' || fileName === 'styles.css') {
-      return new Response('body { color: var(--text-normal); }', { status: 200 });
+      return new Response(MOCK_STYLE_CONTENT, { status: 200 });
     }
     if (fileName === 'main.js') {
-      return new Response('module.exports = {};', { status: 200 });
+      return new Response(MOCK_MAIN_CONTENT, { status: 200 });
     }
 
     return new Response('ok', { status: 200 });
@@ -50,7 +96,7 @@ describe('Obsidian scaffold', () => {
 
   it('writes scaffold config, snippets, templates, manifest, and downloaded assets', async () => {
     await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, {
-      fetchImpl: mockFetchFactory(),
+      ...mockScaffoldDeps(),
       now: () => new Date('2026-05-03T12:00:00Z'),
     });
 
@@ -81,6 +127,13 @@ describe('Obsidian scaffold', () => {
     const homepageData = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'plugins', 'homepage', 'data.json'), 'utf-8'));
     expect(homepageData.homepages['Main Homepage'].value).toBe('index');
 
+    const quickAddData = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'plugins', 'quickadd', 'data.json'), 'utf-8'));
+    const nestedChoices = quickAddData.choices[0].choices;
+    expect(nestedChoices.some((choice: { folder: { folders: string[] } }) => choice.folder.folders[0] === 'general/decisions')).toBe(true);
+    expect(nestedChoices.some((choice: { folder: { folders: string[] } }) => choice.folder.folders[0] === 'projects/{{VALUE:project|label:Project name|case:slug}}/decisions')).toBe(true);
+    expect(nestedChoices.some((choice: { fileNameFormat: { format: string } }) => choice.fileNameFormat.format === '{{DATE:YYYYMMDDHHmmss}}00-{{VALUE:title|label:Note title|case:slug}}')).toBe(true);
+    expect(nestedChoices.some((choice: { fileNameFormat: { format: string } }) => choice.fileNameFormat.format === 'domain')).toBe(true);
+
     const readOnlyData = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'plugins', 'read-only-view', 'data.json'), 'utf-8'));
     expect(readOnlyData.useGlobPatterns).toBe(true);
     expect(readOnlyData.includeRules).toEqual(['**/*.md']);
@@ -88,7 +141,7 @@ describe('Obsidian scaffold', () => {
 
   it('respects readOnly=false by omitting read-only plugin defaults', async () => {
     await ensureObsidianScaffold(ctx.tempDir, { ...ctx.config.obsidian, readOnly: false }, {
-      fetchImpl: mockFetchFactory(),
+      ...mockScaffoldDeps(),
     });
 
     const obsidianDir = path.join(ctx.tempDir, '.obsidian');
@@ -108,8 +161,8 @@ describe('Obsidian scaffold', () => {
     fs.writeFileSync(path.join(obsidianDir, 'app.json'), JSON.stringify({ defaultViewMode: 'source', custom: true }, null, 2));
     fs.writeFileSync(path.join(obsidianDir, 'community-plugins.json'), JSON.stringify(['custom-plugin'], null, 2));
 
-    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, { fetchImpl: mockFetchFactory() });
-    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, { fetchImpl: mockFetchFactory() });
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, mockScaffoldDeps());
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, mockScaffoldDeps());
 
     const appConfig = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'app.json'), 'utf-8'));
     expect(appConfig.defaultViewMode).toBe('preview');
@@ -122,8 +175,8 @@ describe('Obsidian scaffold', () => {
   });
 
   it('applies readOnly=false on rerun after an initial read-only scaffold', async () => {
-    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, { fetchImpl: mockFetchFactory() });
-    await ensureObsidianScaffold(ctx.tempDir, { ...ctx.config.obsidian, readOnly: false }, { fetchImpl: mockFetchFactory() });
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, mockScaffoldDeps());
+    await ensureObsidianScaffold(ctx.tempDir, { ...ctx.config.obsidian, readOnly: false }, mockScaffoldDeps());
 
     const obsidianDir = path.join(ctx.tempDir, '.obsidian');
     const appConfig = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'app.json'), 'utf-8'));
@@ -138,7 +191,7 @@ describe('Obsidian scaffold', () => {
   });
 
   it('preserves existing manifest versions when forced plugin and theme refresh fail', async () => {
-    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, { fetchImpl: mockFetchFactory() });
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, mockScaffoldDeps());
 
     const obsidianDir = path.join(ctx.tempDir, '.obsidian');
     const manifestPath = path.join(obsidianDir, 'open-zk-kb.json');
@@ -149,6 +202,7 @@ describe('Obsidian scaffold', () => {
 
     await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, {
       fetchImpl: selectiveFailureFetchFactory(['main.js', 'theme.css']),
+      verifyAssetIntegrity: false,
     });
 
     const nextManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
@@ -156,5 +210,17 @@ describe('Obsidian scaffold', () => {
     expect(nextManifest.theme.version).toBe('0.0.1');
     expect(fs.existsSync(path.join(obsidianDir, 'plugins', 'homepage', 'main.js'))).toBe(true);
     expect(fs.existsSync(path.join(obsidianDir, 'themes', 'Minimal', 'theme.css'))).toBe(true);
+  });
+
+  it('reinstalls managed assets when local files drift from expected digests', async () => {
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, mockIntegrityDeps());
+
+    const obsidianDir = path.join(ctx.tempDir, '.obsidian');
+    const pluginMainPath = path.join(obsidianDir, 'plugins', 'homepage', 'main.js');
+    fs.writeFileSync(pluginMainPath, 'tampered', 'utf-8');
+
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, mockIntegrityDeps());
+
+    expect(fs.readFileSync(pluginMainPath, 'utf-8')).toBe(MOCK_MAIN_CONTENT);
   });
 });

--- a/tests/obsidian-scaffold.test.ts
+++ b/tests/obsidian-scaffold.test.ts
@@ -99,12 +99,28 @@ describe('Obsidian scaffold', () => {
     await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, { fetchImpl: mockFetchFactory() });
 
     const appConfig = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'app.json'), 'utf-8'));
-    expect(appConfig.defaultViewMode).toBe('source');
+    expect(appConfig.defaultViewMode).toBe('preview');
     expect(appConfig.propertiesInDocument).toBe('hidden');
     expect(appConfig.custom).toBe(true);
 
     const plugins = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'community-plugins.json'), 'utf-8'));
     expect(plugins).toContain('custom-plugin');
     expect(plugins.filter((plugin: string) => plugin === 'homepage')).toHaveLength(1);
+  });
+
+  it('applies readOnly=false on rerun after an initial read-only scaffold', async () => {
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, { fetchImpl: mockFetchFactory() });
+    await ensureObsidianScaffold(ctx.tempDir, { ...ctx.config.obsidian, readOnly: false }, { fetchImpl: mockFetchFactory() });
+
+    const obsidianDir = path.join(ctx.tempDir, '.obsidian');
+    const appConfig = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'app.json'), 'utf-8'));
+    expect(appConfig.defaultViewMode).toBe('source');
+
+    const appearance = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'appearance.json'), 'utf-8'));
+    expect(appearance.enabledCssSnippets).not.toContain('readonly-kb');
+
+    const plugins = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'community-plugins.json'), 'utf-8'));
+    expect(plugins).not.toContain('read-only-view');
+    expect(fs.existsSync(path.join(obsidianDir, 'snippets', 'readonly-kb.css'))).toBe(false);
   });
 });

--- a/tests/obsidian-scaffold.test.ts
+++ b/tests/obsidian-scaffold.test.ts
@@ -14,6 +14,16 @@ function sha256(text: string): string {
   return crypto.createHash('sha256').update(text).digest('hex');
 }
 
+function getRequestedFileName(url: string | URL | Request): string {
+  const raw = typeof url === 'string'
+    ? url
+    : url instanceof URL
+      ? url.toString()
+      : url.url;
+  const { pathname } = new URL(raw, 'https://mock.local');
+  return pathname.split('/').pop() || 'asset.txt';
+}
+
 function mockScaffoldDeps() {
   return {
     fetchImpl: mockFetchFactory(),
@@ -53,8 +63,7 @@ function mockIntegrityDeps() {
 
 function mockFetchFactory() {
   return async (url: string | URL | Request): Promise<Response> => {
-    const urlString = String(url);
-    const fileName = urlString.split('/').pop() || 'asset.txt';
+    const fileName = getRequestedFileName(url);
 
     if (fileName === 'manifest.json') {
       return new Response(MOCK_MANIFEST_CONTENT, { status: 200 });
@@ -66,14 +75,13 @@ function mockFetchFactory() {
       return new Response(MOCK_MAIN_CONTENT, { status: 200 });
     }
 
-    return new Response('ok', { status: 200 });
+    throw new Error(`Unexpected scaffold asset request: ${fileName}`);
   };
 }
 
 function selectiveFailureFetchFactory(failFiles: string[]) {
   return async (url: string | URL | Request): Promise<Response> => {
-    const urlString = String(url);
-    const fileName = urlString.split('/').pop() || 'asset.txt';
+    const fileName = getRequestedFileName(url);
 
     if (failFiles.includes(fileName)) {
       throw new Error(`forced failure for ${fileName}`);

--- a/tests/obsidian-scaffold.test.ts
+++ b/tests/obsidian-scaffold.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createTestHarness, cleanupTestHarness } from './harness.js';
+import type { TestContext } from './harness.js';
+import { ensureObsidianScaffold } from '../src/obsidian-scaffold.js';
+
+function mockFetchFactory() {
+  return async (url: string | URL | Request): Promise<Response> => {
+    const urlString = String(url);
+    const fileName = urlString.split('/').pop() || 'asset.txt';
+
+    if (fileName === 'manifest.json') {
+      return new Response(JSON.stringify({ name: 'Mock', id: 'mock', version: '1.0.0' }), { status: 200 });
+    }
+    if (fileName === 'theme.css' || fileName === 'styles.css') {
+      return new Response('body { color: var(--text-normal); }', { status: 200 });
+    }
+    if (fileName === 'main.js') {
+      return new Response('module.exports = {};', { status: 200 });
+    }
+
+    return new Response('ok', { status: 200 });
+  };
+}
+
+describe('Obsidian scaffold', () => {
+  let ctx: TestContext;
+
+  beforeEach(() => {
+    ctx = createTestHarness();
+  });
+
+  afterEach(() => {
+    cleanupTestHarness(ctx);
+  });
+
+  it('writes scaffold config, snippets, templates, manifest, and downloaded assets', async () => {
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, {
+      fetchImpl: mockFetchFactory(),
+      now: () => new Date('2026-05-03T12:00:00Z'),
+    });
+
+    const obsidianDir = path.join(ctx.tempDir, '.obsidian');
+    expect(fs.existsSync(path.join(obsidianDir, 'app.json'))).toBe(true);
+    expect(fs.existsSync(path.join(obsidianDir, 'appearance.json'))).toBe(true);
+    expect(fs.existsSync(path.join(obsidianDir, 'open-zk-kb.json'))).toBe(true);
+    expect(fs.existsSync(path.join(obsidianDir, 'snippets', 'zk-dashboard.css'))).toBe(true);
+    expect(fs.existsSync(path.join(obsidianDir, 'themes', 'Minimal', 'theme.css'))).toBe(true);
+    expect(fs.existsSync(path.join(obsidianDir, 'plugins', 'homepage', 'main.js'))).toBe(true);
+    expect(fs.existsSync(path.join(ctx.tempDir, 'templates', 'decision.md'))).toBe(true);
+
+    const appConfig = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'app.json'), 'utf-8'));
+    expect(appConfig.defaultViewMode).toBe('preview');
+
+    const appearance = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'appearance.json'), 'utf-8'));
+    expect(appearance.cssTheme).toBe('Minimal');
+    expect(appearance.enabledCssSnippets).toContain('readonly-kb');
+
+    const plugins = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'community-plugins.json'), 'utf-8'));
+    expect(plugins).toContain('homepage');
+    expect(plugins).toContain('read-only-view');
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'open-zk-kb.json'), 'utf-8'));
+    expect(manifest.scaffoldVersion).toBe(1);
+    expect(manifest.plugins.homepage.version).toBe('4.4.0');
+
+    const homepageData = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'plugins', 'homepage', 'data.json'), 'utf-8'));
+    expect(homepageData.homepages['Main Homepage'].value).toBe('index');
+
+    const readOnlyData = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'plugins', 'read-only-view', 'data.json'), 'utf-8'));
+    expect(readOnlyData.useGlobPatterns).toBe(true);
+    expect(readOnlyData.includeRules).toEqual(['**/*.md']);
+  });
+
+  it('respects readOnly=false by omitting read-only plugin defaults', async () => {
+    await ensureObsidianScaffold(ctx.tempDir, { ...ctx.config.obsidian, readOnly: false }, {
+      fetchImpl: mockFetchFactory(),
+    });
+
+    const obsidianDir = path.join(ctx.tempDir, '.obsidian');
+    const appConfig = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'app.json'), 'utf-8'));
+    expect(appConfig.defaultViewMode).toBe('source');
+
+    const appearance = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'appearance.json'), 'utf-8'));
+    expect(appearance.enabledCssSnippets).not.toContain('readonly-kb');
+
+    const plugins = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'community-plugins.json'), 'utf-8'));
+    expect(plugins).not.toContain('read-only-view');
+  });
+
+  it('merges existing config and remains idempotent on rerun', async () => {
+    const obsidianDir = path.join(ctx.tempDir, '.obsidian');
+    fs.mkdirSync(obsidianDir, { recursive: true });
+    fs.writeFileSync(path.join(obsidianDir, 'app.json'), JSON.stringify({ defaultViewMode: 'source', custom: true }, null, 2));
+    fs.writeFileSync(path.join(obsidianDir, 'community-plugins.json'), JSON.stringify(['custom-plugin'], null, 2));
+
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, { fetchImpl: mockFetchFactory() });
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, { fetchImpl: mockFetchFactory() });
+
+    const appConfig = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'app.json'), 'utf-8'));
+    expect(appConfig.defaultViewMode).toBe('source');
+    expect(appConfig.propertiesInDocument).toBe('hidden');
+    expect(appConfig.custom).toBe(true);
+
+    const plugins = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'community-plugins.json'), 'utf-8'));
+    expect(plugins).toContain('custom-plugin');
+    expect(plugins.filter((plugin: string) => plugin === 'homepage')).toHaveLength(1);
+  });
+});

--- a/tests/obsidian-scaffold.test.ts
+++ b/tests/obsidian-scaffold.test.ts
@@ -24,6 +24,19 @@ function mockFetchFactory() {
   };
 }
 
+function selectiveFailureFetchFactory(failFiles: string[]) {
+  return async (url: string | URL | Request): Promise<Response> => {
+    const urlString = String(url);
+    const fileName = urlString.split('/').pop() || 'asset.txt';
+
+    if (failFiles.includes(fileName)) {
+      throw new Error(`forced failure for ${fileName}`);
+    }
+
+    return mockFetchFactory()(url);
+  };
+}
+
 describe('Obsidian scaffold', () => {
   let ctx: TestContext;
 
@@ -122,5 +135,26 @@ describe('Obsidian scaffold', () => {
     const plugins = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'community-plugins.json'), 'utf-8'));
     expect(plugins).not.toContain('read-only-view');
     expect(fs.existsSync(path.join(obsidianDir, 'snippets', 'readonly-kb.css'))).toBe(false);
+  });
+
+  it('preserves existing manifest versions when forced plugin and theme refresh fail', async () => {
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, { fetchImpl: mockFetchFactory() });
+
+    const obsidianDir = path.join(ctx.tempDir, '.obsidian');
+    const manifestPath = path.join(obsidianDir, 'open-zk-kb.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    manifest.plugins.homepage.version = '0.0.1';
+    manifest.theme.version = '0.0.1';
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, {
+      fetchImpl: selectiveFailureFetchFactory(['main.js', 'theme.css']),
+    });
+
+    const nextManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    expect(nextManifest.plugins.homepage.version).toBe('0.0.1');
+    expect(nextManifest.theme.version).toBe('0.0.1');
+    expect(fs.existsSync(path.join(obsidianDir, 'plugins', 'homepage', 'main.js'))).toBe(true);
+    expect(fs.existsSync(path.join(obsidianDir, 'themes', 'Minimal', 'theme.css'))).toBe(true);
   });
 });

--- a/tests/obsidian-scaffold.test.ts
+++ b/tests/obsidian-scaffold.test.ts
@@ -223,4 +223,20 @@ describe('Obsidian scaffold', () => {
 
     expect(fs.readFileSync(pluginMainPath, 'utf-8')).toBe(MOCK_MAIN_CONTENT);
   });
+
+  it('skips digest-currentness checks when integrity verification is disabled', async () => {
+    const deps = mockIntegrityDeps();
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, deps);
+
+    const obsidianDir = path.join(ctx.tempDir, '.obsidian');
+    const pluginMainPath = path.join(obsidianDir, 'plugins', 'homepage', 'main.js');
+    fs.writeFileSync(pluginMainPath, 'locally modified but allowed', 'utf-8');
+
+    await ensureObsidianScaffold(ctx.tempDir, ctx.config.obsidian, {
+      ...deps,
+      verifyAssetIntegrity: false,
+    });
+
+    expect(fs.readFileSync(pluginMainPath, 'utf-8')).toBe('locally modified but allowed');
+  });
 });

--- a/tests/obsidian.test.ts
+++ b/tests/obsidian.test.ts
@@ -303,23 +303,24 @@ describe('handleOpen', () => {
   beforeEach(() => { ctx = createTestHarness(); });
   afterEach(() => { cleanupTestHarness(ctx); });
 
-  it('should return error when vault does not exist', () => {
+  it('should return error when vault does not exist', async () => {
     const config = { ...ctx.config, vault: '/nonexistent/vault/path' };
-    const result = handleOpen({ _detectObsidian: noObsidian }, config);
+    const result = await handleOpen({ _detectObsidian: noObsidian }, config);
     expect(result).toContain('Vault directory does not exist');
     expect(result).toContain('Store a note first');
   });
 
-  it('should return not-installed message when Obsidian is missing', () => {
-    const result = handleOpen({ _detectObsidian: noObsidian }, ctx.config);
+  it('should return not-installed message when Obsidian is missing', async () => {
+    const result = await handleOpen({ _detectObsidian: noObsidian }, ctx.config);
     expect(result).toContain('Obsidian is not installed');
     expect(result).toContain('https://obsidian.md/download');
   });
 
-  it('should return success when Obsidian is installed', () => {
-    const result = handleOpen({
+  it('should return success when Obsidian is installed', async () => {
+    const result = await handleOpen({
       _detectObsidian: fakeObsidian,
       _launchObsidian: noopLaunch,
+      _ensureScaffold: async () => null,
     }, ctx.config);
     expect(result).toContain('Opened vault in Obsidian');
   });
@@ -334,35 +335,38 @@ describe('handleOpen', () => {
       project: 'myapp',
     }, ctx.engine, null, ctx.config);
 
-    const result = handleOpen({
+    const result = await handleOpen({
       project: 'myapp',
       _detectObsidian: fakeObsidian,
       _launchObsidian: noopLaunch,
+      _ensureScaffold: async () => null,
     }, ctx.config, ctx.engine);
     expect(result).toContain('Focused on project: myapp');
   });
 
-  it('should not claim project focus when no index note exists', () => {
-    const result = handleOpen({
+  it('should not claim project focus when no index note exists', async () => {
+    const result = await handleOpen({
       project: 'nonexistent',
       _detectObsidian: fakeObsidian,
       _launchObsidian: noopLaunch,
+      _ensureScaffold: async () => null,
     }, ctx.config, ctx.engine);
     expect(result).not.toContain('Focused on project');
   });
 
-  it('should report launch failure', () => {
+  it('should report launch failure', async () => {
     const failLaunch = () => 'spawn failed';
-    const result = handleOpen({
+    const result = await handleOpen({
       _detectObsidian: fakeObsidian,
       _launchObsidian: failLaunch,
+      _ensureScaffold: async () => null,
     }, ctx.config);
     expect(result).toContain('Failed to launch Obsidian');
     expect(result).toContain('spawn failed');
   });
 
-  it('should work without repo when no project specified', () => {
-    const result = handleOpen({ _detectObsidian: noObsidian }, ctx.config);
+  it('should work without repo when no project specified', async () => {
+    const result = await handleOpen({ _detectObsidian: noObsidian }, ctx.config);
     expect(typeof result).toBe('string');
     expect(result.length).toBeGreaterThan(0);
   });

--- a/tests/vault-layout.test.ts
+++ b/tests/vault-layout.test.ts
@@ -5,6 +5,7 @@ import {
   createTestHarness,
   cleanupTestHarness,
   createNoteFile,
+  readNoteFile,
 } from './harness.js';
 import type { TestContext } from './harness.js';
 import { resolveNotePath, walkMarkdownFiles, extractProjectFromTags } from '../src/storage/path-resolver.js';
@@ -188,6 +189,25 @@ describe('Structured Vault Storage', () => {
     });
 
     expect(fs.existsSync(decisionsDir)).toBe(true);
+  });
+
+  it('renders enhanced global homepage dashboard', async () => {
+    await handleStore({
+      title: 'Test Decision',
+      content: 'Decision content',
+      kind: 'decision',
+      summary: 'A test decision',
+      guidance: 'Keep using this pattern.',
+      project: 'open-zk-kb',
+    }, context.engine, null, context.config);
+
+    const home = readNoteFile(context, 'index.md');
+    expect(home).toContain('cssclasses:');
+    expect(home).toContain('# 🧠 Knowledge Base');
+    expect(home).toContain('## 📂 Projects');
+    expect(home).toContain('## 📚 Browse');
+    expect(home).toContain('## 🔗 Resources');
+    expect(home).toContain('Powered by [open-zk-kb]');
   });
 
   it('preserves directory on update (birthplace-only)', () => {
@@ -464,7 +484,7 @@ describe('Global Navigation', () => {
     const globalIndex = path.join(context.tempDir, 'index.md');
     expect(fs.existsSync(globalIndex)).toBe(true);
     const content = fs.readFileSync(globalIndex, 'utf-8');
-    expect(content).toContain('# Knowledge Base');
+    expect(content).toContain('Knowledge Base');
     expect(content).toContain('myproject');
   });
 
@@ -697,7 +717,7 @@ describe('Structured navigation regressions', () => {
     expect(content).not.toContain('[[index|Back to Knowledge Base]]');
 
     const globalIndex = fs.readFileSync(path.join(context.tempDir, 'index.md'), 'utf-8');
-    expect(globalIndex).toContain('[[preferences/index|Preferences]]');
+    expect(globalIndex).toContain('[[preferences/index\\|Preferences]]');
   });
 
   it('generates general kind subdir indexes for unscoped notes', async () => {

--- a/tests/vault-layout.test.ts
+++ b/tests/vault-layout.test.ts
@@ -488,6 +488,22 @@ describe('Global Navigation', () => {
     expect(content).toContain('myproject');
   });
 
+  it('omits review and log links when those navigation outputs are disabled', async () => {
+    context.config.navigation.enableReviewMoc = false;
+    context.config.navigation.enableGlobalLog = false;
+
+    await handleStore(
+      { title: 'Test Note', content: 'Content', kind: 'decision', project: 'myproject', summary: 'A decision', guidance: 'Use it' } as any,
+      context.engine,
+      null,
+      context.config,
+    );
+
+    const content = fs.readFileSync(path.join(context.tempDir, 'index.md'), 'utf-8');
+    expect(content).not.toContain('[[review\\|📝 Needs Review]]');
+    expect(content).not.toContain('[[log|Operations Log]]');
+  });
+
   it('generates global log.md on store', async () => {
     await handleStore(
       { title: 'Logged Note', content: 'Content', kind: 'observation', project: 'proj', summary: 'Obs', guidance: 'Note it' } as any,


### PR DESCRIPTION
## Summary
- add a managed Obsidian scaffold with pinned theme/plugin assets, snippets, templates, and upgrade metadata
- wire scaffold creation and upgrade status into knowledge-open, knowledge-maintain, and server initialization
- upgrade the global homepage into an Obsidian-friendly dashboard and document the new config surface

## Verification
- bun run build
- bun test
- bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Obsidian vault scaffolding: installs curated plugins, theme, snippets, templates and tracks scaffold state; vault auto-upgrade and upgrade action; open/launch now attempts scaffold before launch
  * Enhanced Knowledge Base dashboard with revamped layout, browse/resources, activity sections and updated footer

* **Documentation**
  * Added Obsidian config docs, examples, README/tool description, and config-table entries

* **Tests**
  * Expanded scaffold, open, index/dashboard, and harness test coverage and defaults
<!-- end of auto-generated comment: release notes by coderabbit.ai -->