### PR TITLE
Add dev release workflow for npm publishing on dev merges

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           BASE_VERSION=$(node -p "require('./package.json').version")
           SHORT_SHA=$(git rev-parse --short HEAD)
-          DEV_VERSION="${BASE_VERSION}-dev.${SHORT_SHA}"
+          DEV_VERSION="${BASE_VERSION}-dev.g${SHORT_SHA}"
           echo "dev_version=$DEV_VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing dev version: $DEV_VERSION"
 

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,0 +1,77 @@
+name: Publish dev release
+
+on:
+  push:
+    branches: [dev]
+
+jobs:
+  publish-dev:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Compute dev version
+        id: version
+        run: |
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          DEV_VERSION="${BASE_VERSION}-dev.${SHORT_SHA}"
+          echo "dev_version=$DEV_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing dev version: $DEV_VERSION"
+
+      - name: Check if version already published
+        id: check
+        run: |
+          DEV_VERSION="${{ steps.version.outputs.dev_version }}"
+          PUBLISHED=$(npm view open-zk-kb@"$DEV_VERSION" version 2>/dev/null || echo "")
+          if [ "$PUBLISHED" = "$DEV_VERSION" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Version $DEV_VERSION already published — skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.check.outputs.skip == 'false'
+        run: bun install
+
+      - name: Build
+        if: steps.check.outputs.skip == 'false'
+        run: bun run build
+
+      - name: Lint
+        if: steps.check.outputs.skip == 'false'
+        run: bun run lint
+
+      - name: Test
+        if: steps.check.outputs.skip == 'false'
+        run: bun test
+
+      - name: Prepare bin scripts
+        if: steps.check.outputs.skip == 'false'
+        run: chmod +x dist/cli.js dist/setup.js dist/mcp-server.js
+
+      - name: Set dev version in package.json
+        if: steps.check.outputs.skip == 'false'
+        run: npm version "${{ steps.version.outputs.dev_version }}" --no-git-tag-version
+
+      - name: Publish
+        if: steps.check.outputs.skip == 'false'
+        run: npm publish --provenance --access public --tag dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `publish-dev.yml` workflow that publishes dev-tagged npm releases on every push to `dev`
- Versions computed as `{package.json version}-dev.{short SHA}` (e.g. `1.1.0-dev.7a6651b`) — never committed to repo
- Idempotent: skips if the exact version is already published

## How it works

1. Triggered on push to `dev` (i.e. merged PRs)
2. Computes a unique dev version from the base version + git short SHA
3. Checks npm registry — skips if already published
4. Runs full build/lint/test gates (mirrors production)
5. Sets version in package.json at publish time only (`--no-git-tag-version`)
6. Publishes with `npm publish --provenance --access public --tag dev`

## What's intentionally excluded

- No GitHub Release or git tag (dev releases don't need them)
- No MCP registry publish (stable releases only)
- No CHANGELOG update
- No version committed to the repo

## Install a dev release

```bash
npm install open-zk-kb@dev
# or a specific version:
npm install open-zk-kb@1.1.0-dev.7a6651b
```

## Research basis

Modeled after TypeScript's nightly pattern (daily date-stamped `--tag next` publishes). For a project this size (~250-500 dev versions/year), npm's 100MB metadata ceiling is years away. No cleanup automation needed.