### PR TITLE
Skip prepublishOnly during dev release publish

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -72,6 +72,6 @@ jobs:
 
       - name: Publish
         if: steps.check.outputs.skip == 'false'
-        run: npm publish --provenance --access public --tag dev
+        run: npm publish --provenance --access public --tag dev --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `--ignore-scripts` to `npm publish` in the dev release workflow to prevent the `prepublishOnly` hook from re-running build+test

## Problem

The `prepublishOnly` hook in `package.json` runs `bun run build && bun test`. During dev releases, `npm version` modifies `package.json` before publish, and the hook's re-run of `bun run build && bun test` with the modified version causes 5 setup.ts tests to fail ([run log](https://github.com/mrosnerr/open-zk-kb/actions/runs/25506474923/job/74854882460)).

The workflow already runs build, lint, and test as dedicated steps before publish — the `prepublishOnly` hook is redundant in CI.

## Fix

`npm publish --ignore-scripts` — standard CI pattern when build/test are already gated in prior steps.