### PR TITLE
Fix dev release auth by dropping explicit NPM_TOKEN override

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -73,5 +73,3 @@ jobs:
       - name: Publish
         if: steps.check.outputs.skip == 'false'
         run: npm publish --provenance --access public --tag dev --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Removes the explicit `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env override from the dev release publish step

## Problem

The production `publish.yml` authenticates to npm without an explicit env block — `NODE_AUTH_TOKEN` is available in the runner environment via a repo secret. The dev workflow was overriding it with `${{ secrets.NPM_TOKEN }}` which resolves to empty (wrong secret name), causing `ENEEDAUTH` ([run log](https://github.com/mrosnerr/open-zk-kb/actions/runs/25507405747/job/74856739774)).

## Fix

Drop the `env:` block to match the production workflow's auth mechanism exactly.