### PR TITLE
Document dev release channel

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -29,6 +29,10 @@ For rapid iteration:
 - bun test --watch — re-runs tests on file change
 - Note: there's no watch mode for the build itself — you need to run bun run build each time
 
+## Dev release channel
+
+Pushes to the `dev` branch auto-publish to npm under the `dev` dist-tag (e.g., `1.1.0-dev.g751771b`). To test unreleased changes without a local checkout, point your MCP config at `open-zk-kb@dev` instead of `@latest`. See [Release Channels](setup-guide.md#release-channels) for details.
+
 ## OpenCode local development
 
 Use the normal installer for local OpenCode testing.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -125,13 +125,30 @@ Instructions are injected as a managed block wrapped in markers:
 ## Optional Configuration
 - **All settings** are in `~/.config/open-zk-kb/config.yaml`. Customize vault path, log level, lifecycle review thresholds, and vector embeddings in a single file. See [configuration.md](configuration.md).
 
+## Release Channels
+
+| Channel | npm tag | Stability | Use when |
+|---------|---------|-----------|----------|
+| **Stable** | `@latest` | Production-ready | Default for all users |
+| **Dev** | `@dev` | Bleeding-edge, may break | Testing unreleased changes from the `dev` branch |
+
+To use the dev channel, change `@latest` to `@dev` in your MCP config:
+
+```json
+"command": ["bunx", "open-zk-kb@dev", "server"]
+```
+
+Dev versions follow the format `X.Y.Z-dev.g<short-sha>` (e.g., `1.1.0-dev.g751771b`). Each push to the `dev` branch publishes a new dev release automatically.
+
+To switch back to stable: change `@dev` to `@latest` and restart your client.
+
 ## Updating
 
 ### How Updates Work
 
 | Component | Auto-updates? | Mechanism |
 |-----------|---------------|-----------|
-| **MCP server** | ✅ Yes | `bunx open-zk-kb@latest` checks npm registry on each client restart |
+| **MCP server** | ✅ Yes | `bunx open-zk-kb@latest` (or `@dev`) checks npm registry on each client restart |
 | **Agent instructions** | ❌ No | Requires manual `install --force` to update |
 | **User config** | ❌ No | Your `config.yaml` is never modified after initial copy |
 


### PR DESCRIPTION
## Summary
- Add "Release Channels" section to `docs/setup-guide.md` documenting `@latest` vs `@dev` npm tags, how to switch, and version format
- Add "Dev release channel" section to `docs/development.md` pointing contributors to the setup guide
- Update "How Updates Work" table to mention `@dev` alongside `@latest`