### PR TITLE
Add batched git versioning for vault history

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,10 @@ interface RawConfig {
     autoUpgrade?: boolean;
     readOnly?: boolean;
   };
+  versioning?: {
+    enabled?: boolean;
+    debounceMs?: number;
+  };
   embeddings?: EmbeddingsConfig;
 }
 
@@ -113,6 +117,10 @@ export const DEFAULT_CONFIG: AppConfig = {
     scaffold: true,
     autoUpgrade: true,
     readOnly: true,
+  },
+  versioning: {
+    enabled: true,
+    debounceMs: 30000,
   },
 };
 
@@ -228,6 +236,12 @@ export function getConfig(): AppConfig {
       readOnly: typeof raw?.obsidian?.readOnly === 'boolean'
         ? raw.obsidian.readOnly
         : DEFAULT_CONFIG.obsidian.readOnly,
+    },
+    versioning: {
+      enabled: typeof raw?.versioning?.enabled === 'boolean'
+        ? raw.versioning.enabled
+        : DEFAULT_CONFIG.versioning.enabled,
+      debounceMs: positiveInt(raw?.versioning?.debounceMs, DEFAULT_CONFIG.versioning.debounceMs),
     },
   };
 }

--- a/src/git-versioning.ts
+++ b/src/git-versioning.ts
@@ -229,7 +229,10 @@ export class GitVersioning {
     }
 
     const existing = fs.readFileSync(gitignorePath, 'utf-8');
-    const requiredEntries = ['.index/', '.obsidian/'];
+    const requiredEntries = GITIGNORE_CONTENT
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line !== '' && !line.startsWith('#'));
     const missing = requiredEntries.filter(entry => !existing.includes(entry));
 
     if (missing.length > 0) {
@@ -239,6 +242,18 @@ export class GitVersioning {
   }
 
   private cleanStaleLock(): void {
+    const indexLockPath = path.join(this.vaultPath, '.git', 'index.lock');
+    if (fs.existsSync(indexLockPath)) {
+      try {
+        const stat = fs.statSync(indexLockPath);
+        const age = Date.now() - stat.mtimeMs;
+        if (age > STALE_LOCK_MS) {
+          fs.unlinkSync(indexLockPath);
+          logToFile('WARN', 'Removed stale git index.lock', { age: Math.round(age / 1000) });
+        }
+      } catch { void 0; }
+    }
+
     const lockPath = path.join(this.vaultPath, '.git', LOCK_DIR_NAME);
     if (!fs.existsSync(lockPath)) return;
 
@@ -249,19 +264,7 @@ export class GitVersioning {
         fs.rmdirSync(lockPath);
         logToFile('WARN', 'Removed stale commit lock', { age: Math.round(age / 1000), lockPath });
       }
-    } catch { }
-
-    const indexLockPath = path.join(this.vaultPath, '.git', 'index.lock');
-    if (fs.existsSync(indexLockPath)) {
-      try {
-        const stat = fs.statSync(indexLockPath);
-        const age = Date.now() - stat.mtimeMs;
-        if (age > STALE_LOCK_MS) {
-          fs.unlinkSync(indexLockPath);
-          logToFile('WARN', 'Removed stale git index.lock', { age: Math.round(age / 1000) });
-        }
-      } catch { }
-    }
+    } catch { void 0; }
   }
 
   private async recoverUncommitted(): Promise<void> {
@@ -305,7 +308,7 @@ export class GitVersioning {
           fs.mkdirSync(lockPath);
           return true;
         }
-      } catch { }
+      } catch { void 0; }
       return false;
     }
   }
@@ -314,7 +317,7 @@ export class GitVersioning {
     const lockPath = path.join(this.vaultPath, '.git', LOCK_DIR_NAME);
     try {
       fs.rmdirSync(lockPath);
-    } catch { }
+    } catch { void 0; }
   }
 
   private async commitPending(): Promise<void> {
@@ -526,7 +529,7 @@ export class GitVersioning {
 
       gitExecSync(['commit', '-m', message], this.vaultPath);
     } finally {
-      try { fs.rmdirSync(lockPath); } catch { }
+      try { fs.rmdirSync(lockPath); } catch { void 0; }
     }
   }
 

--- a/src/git-versioning.ts
+++ b/src/git-versioning.ts
@@ -229,11 +229,14 @@ export class GitVersioning {
     }
 
     const existing = fs.readFileSync(gitignorePath, 'utf-8');
+    const existingLines = new Set(
+      existing.split('\n').map(line => line.trim()).filter(line => line !== '' && !line.startsWith('#')),
+    );
     const requiredEntries = GITIGNORE_CONTENT
       .split('\n')
       .map(line => line.trim())
       .filter(line => line !== '' && !line.startsWith('#'));
-    const missing = requiredEntries.filter(entry => !existing.includes(entry));
+    const missing = requiredEntries.filter(entry => !existingLines.has(entry));
 
     if (missing.length > 0) {
       const suffix = '\n# open-zk-kb: derived files\n' + missing.join('\n') + '\n';

--- a/src/git-versioning.ts
+++ b/src/git-versioning.ts
@@ -1,0 +1,562 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { logToFile } from './logger.js';
+import type { NoteKind, VersioningConfig } from './types.js';
+
+export type OpType = 'store' | 'update' | 'archive' | 'delete' | 'promote' | 'format';
+
+export interface PendingOp {
+  op: OpType;
+  noteId: string;
+  title: string;
+  kind: NoteKind;
+  project?: string;
+}
+
+interface GitResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+const LOCK_DIR_NAME = 'kb-commit.lock';
+const STALE_LOCK_MS = 30_000;
+const RETRY_ATTEMPTS = 3;
+const RETRY_BASE_MS = 100;
+const RETRY_MAX_JITTER_MS = 400;
+
+const CLOUD_SYNC_PATTERNS = [
+  '/Library/Mobile Documents/',
+  '/Library/CloudStorage/',
+  '/Dropbox/',
+];
+
+const GITIGNORE_CONTENT = `# open-zk-kb: derived files (regenerated from source notes)
+.index/
+.obsidian/
+.templates/
+templates/
+Home.md
+log.md
+review.md
+`;
+
+function jitteredDelay(attempt: number): number {
+  const base = RETRY_BASE_MS * Math.pow(2, attempt);
+  const jitter = Math.random() * RETRY_MAX_JITTER_MS;
+  return base + jitter;
+}
+
+const GIT_ENV = {
+  GIT_TERMINAL_PROMPT: '0',
+  GIT_AUTHOR_NAME: 'open-zk-kb',
+  GIT_AUTHOR_EMAIL: 'open-zk-kb@local',
+  GIT_COMMITTER_NAME: 'open-zk-kb',
+  GIT_COMMITTER_EMAIL: 'open-zk-kb@local',
+};
+
+async function gitExec(args: string[], cwd: string): Promise<GitResult> {
+  const proc = Bun.spawn(['git', ...args], {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { ...process.env, ...GIT_ENV },
+  });
+
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+
+  return { exitCode, stdout: stdout.trim(), stderr: stderr.trim() };
+}
+
+function gitExecSync(args: string[], cwd: string): GitResult {
+  const result = Bun.spawnSync(['git', ...args], {
+    cwd,
+    env: { ...process.env, ...GIT_ENV },
+  });
+
+  return {
+    exitCode: result.exitCode,
+    stdout: result.stdout.toString().trim(),
+    stderr: result.stderr.toString().trim(),
+  };
+}
+
+function buildSummaryLine(ops: PendingOp[], externalCount: number): string {
+  if (ops.length === 0 && externalCount > 0) {
+    return `${externalCount} external change${externalCount !== 1 ? 's' : ''}`;
+  }
+
+  if (ops.length === 1 && externalCount === 0) {
+    const op = ops[0];
+    const projectSuffix = op.project ? ` [${op.project}]` : '';
+    return `${capitalize(op.op)} ${op.kind}: "${op.title}"${projectSuffix}`;
+  }
+
+  const counts = new Map<string, number>();
+  for (const op of ops) {
+    counts.set(op.op, (counts.get(op.op) || 0) + 1);
+  }
+
+  const parts: string[] = [];
+  for (const [op, count] of counts) {
+    parts.push(`${count} ${op}${count !== 1 ? 's' : ''}`);
+  }
+  if (externalCount > 0) {
+    parts.push(`${externalCount} external`);
+  }
+
+  return parts.join(', ');
+}
+
+function buildCommitBody(ops: PendingOp[], externalCount: number): string {
+  if (ops.length <= 1 && externalCount === 0) return '';
+
+  const lines: string[] = [];
+  for (const op of ops) {
+    const projectSuffix = op.project ? ` [${op.project}]` : '';
+    lines.push(`- ${capitalize(op.op)} ${op.kind}: "${op.title}"${projectSuffix}`);
+  }
+  if (externalCount > 0) {
+    lines.push(`- ${externalCount} file${externalCount !== 1 ? 's' : ''} changed outside server`);
+  }
+
+  return lines.join('\n');
+}
+
+export function buildCommitMessage(ops: PendingOp[], stagedFiles: string[], _vaultPath: string): string {
+  const knownPaths = new Set<string>();
+  for (const op of ops) {
+    for (const file of stagedFiles) {
+      if (file.includes(op.noteId)) {
+        knownPaths.add(file);
+      }
+    }
+  }
+
+  const activeOps = ops.filter(op =>
+    stagedFiles.some(f => f.includes(op.noteId))
+  );
+
+  const externalCount = stagedFiles.filter(f => !knownPaths.has(f)).length;
+
+  const summary = buildSummaryLine(activeOps, externalCount);
+  const body = buildCommitBody(activeOps, externalCount);
+
+  return body ? `${summary}\n\n${body}` : summary;
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export class GitVersioning {
+  private readonly vaultPath: string;
+  private readonly config: VersioningConfig;
+  private readonly opBuffer: PendingOp[] = [];
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private committing = false;
+  private commitPaused = false;
+  private initialized = false;
+  private _shuttingDown = false;
+
+  constructor(vaultPath: string, config: VersioningConfig) {
+    this.vaultPath = vaultPath;
+    this.config = config;
+  }
+
+  async init(): Promise<void> {
+    if (!this.config.enabled || this.initialized) return;
+
+    const gitDir = path.join(this.vaultPath, '.git');
+
+    for (const pattern of CLOUD_SYNC_PATTERNS) {
+      if (this.vaultPath.includes(pattern)) {
+        logToFile('WARN', 'Vault is in a cloud-synced directory — git versioning may cause conflicts', {
+          vaultPath: this.vaultPath,
+          pattern,
+        });
+        break;
+      }
+    }
+
+    const obsidianGitDir = path.join(this.vaultPath, '.obsidian', 'plugins', 'obsidian-git');
+    if (fs.existsSync(obsidianGitDir)) {
+      logToFile('WARN', 'Obsidian Git plugin detected — may conflict with server-managed versioning', {
+        pluginPath: obsidianGitDir,
+      });
+    }
+
+    if (!fs.existsSync(gitDir)) {
+      const result = await gitExec(['init'], this.vaultPath);
+      if (result.exitCode !== 0) {
+        logToFile('ERROR', 'Failed to initialize git repository', { stderr: result.stderr });
+        return;
+      }
+      logToFile('INFO', 'Git repository initialized for vault versioning', { vaultPath: this.vaultPath });
+
+      this.ensureGitignore();
+
+      const addResult = await gitExec(['add', '-A'], this.vaultPath);
+      if (addResult.exitCode === 0) {
+        const statusResult = await gitExec(['diff', '--cached', '--name-only'], this.vaultPath);
+        const fileCount = statusResult.stdout ? statusResult.stdout.split('\n').filter(Boolean).length : 0;
+        if (fileCount > 0) {
+          await gitExec(['commit', '-m', `[init] Knowledge base (${fileCount} files)`], this.vaultPath);
+        }
+      }
+    } else {
+      this.ensureGitignore();
+    }
+
+    this.cleanStaleLock();
+    await this.recoverUncommitted();
+
+    this.initialized = true;
+    logToFile('INFO', 'Git versioning initialized', {
+      vaultPath: this.vaultPath,
+      debounceMs: this.config.debounceMs,
+    });
+  }
+
+  private ensureGitignore(): void {
+    const gitignorePath = path.join(this.vaultPath, '.gitignore');
+
+    if (!fs.existsSync(gitignorePath)) {
+      fs.writeFileSync(gitignorePath, GITIGNORE_CONTENT, 'utf-8');
+      return;
+    }
+
+    const existing = fs.readFileSync(gitignorePath, 'utf-8');
+    const requiredEntries = ['.index/', '.obsidian/'];
+    const missing = requiredEntries.filter(entry => !existing.includes(entry));
+
+    if (missing.length > 0) {
+      const suffix = '\n# open-zk-kb: derived files\n' + missing.join('\n') + '\n';
+      fs.writeFileSync(gitignorePath, existing.trimEnd() + '\n' + suffix, 'utf-8');
+    }
+  }
+
+  private cleanStaleLock(): void {
+    const lockPath = path.join(this.vaultPath, '.git', LOCK_DIR_NAME);
+    if (!fs.existsSync(lockPath)) return;
+
+    try {
+      const stat = fs.statSync(lockPath);
+      const age = Date.now() - stat.mtimeMs;
+      if (age > STALE_LOCK_MS) {
+        fs.rmdirSync(lockPath);
+        logToFile('WARN', 'Removed stale commit lock', { age: Math.round(age / 1000), lockPath });
+      }
+    } catch { }
+
+    const indexLockPath = path.join(this.vaultPath, '.git', 'index.lock');
+    if (fs.existsSync(indexLockPath)) {
+      try {
+        const stat = fs.statSync(indexLockPath);
+        const age = Date.now() - stat.mtimeMs;
+        if (age > STALE_LOCK_MS) {
+          fs.unlinkSync(indexLockPath);
+          logToFile('WARN', 'Removed stale git index.lock', { age: Math.round(age / 1000) });
+        }
+      } catch { }
+    }
+  }
+
+  private async recoverUncommitted(): Promise<void> {
+    const status = await gitExec(['status', '--porcelain'], this.vaultPath);
+    if (status.exitCode !== 0 || !status.stdout) return;
+
+    const lines = status.stdout.split('\n').filter(Boolean);
+    if (lines.length === 0) return;
+
+    logToFile('INFO', 'Recovering uncommitted changes from prior session', { fileCount: lines.length });
+
+    const addResult = await gitExec(['add', '-A'], this.vaultPath);
+    if (addResult.exitCode !== 0) return;
+
+    const modifiedCount = lines.filter(l => l.startsWith(' M') || l.startsWith('M ')).length;
+    const newCount = lines.filter(l => l.startsWith('??') || l.startsWith('A ')).length;
+    const deletedCount = lines.filter(l => l.startsWith(' D') || l.startsWith('D ')).length;
+
+    const parts: string[] = [];
+    if (newCount > 0) parts.push(`${newCount} new`);
+    if (modifiedCount > 0) parts.push(`${modifiedCount} modified`);
+    if (deletedCount > 0) parts.push(`${deletedCount} deleted`);
+    const detail = parts.length > 0 ? `\n\n- ${parts.join('\n- ')}` : '';
+
+    await gitExec(
+      ['commit', '-m', `[recovery] Uncommitted changes from prior session${detail}`],
+      this.vaultPath,
+    );
+  }
+
+  private acquireLock(): boolean {
+    const lockPath = path.join(this.vaultPath, '.git', LOCK_DIR_NAME);
+    try {
+      fs.mkdirSync(lockPath);
+      return true;
+    } catch {
+      try {
+        const stat = fs.statSync(lockPath);
+        if (Date.now() - stat.mtimeMs > STALE_LOCK_MS) {
+          fs.rmdirSync(lockPath);
+          fs.mkdirSync(lockPath);
+          return true;
+        }
+      } catch { }
+      return false;
+    }
+  }
+
+  private releaseLock(): void {
+    const lockPath = path.join(this.vaultPath, '.git', LOCK_DIR_NAME);
+    try {
+      fs.rmdirSync(lockPath);
+    } catch { }
+  }
+
+  private async commitPending(): Promise<void> {
+    if (!this.config.enabled || !this.initialized) return;
+    if (this.committing || this.commitPaused) return;
+
+    this.committing = true;
+    try {
+      for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
+        if (!this.acquireLock()) {
+          const delay = jitteredDelay(attempt);
+          logToFile('DEBUG', 'Commit lock contention, retrying', { attempt, delay: Math.round(delay) });
+          await Bun.sleep(delay);
+          continue;
+        }
+
+        try {
+          await this.doCommit();
+        } finally {
+          this.releaseLock();
+        }
+        return;
+      }
+
+      logToFile('WARN', 'Failed to acquire commit lock after retries — rescheduling', {
+        retries: RETRY_ATTEMPTS,
+      });
+      this.scheduleDebounce(5000);
+    } finally {
+      this.committing = false;
+    }
+  }
+
+  private async doCommit(): Promise<void> {
+    const addResult = await gitExec(['add', '-A'], this.vaultPath);
+    if (addResult.exitCode !== 0) {
+      logToFile('WARN', 'git add failed', { stderr: addResult.stderr });
+      return;
+    }
+
+    const diffResult = await gitExec(['diff', '--cached', '--name-only'], this.vaultPath);
+    const stagedFiles = diffResult.stdout ? diffResult.stdout.split('\n').filter(Boolean) : [];
+
+    if (stagedFiles.length === 0) {
+      this.opBuffer.length = 0;
+      return;
+    }
+
+    const message = buildCommitMessage([...this.opBuffer], stagedFiles, this.vaultPath);
+    this.opBuffer.length = 0;
+
+    const commitResult = await gitExec(['commit', '-m', message], this.vaultPath);
+    if (commitResult.exitCode !== 0) {
+      if (commitResult.stdout.includes('nothing to commit') || commitResult.stderr.includes('nothing to commit')) {
+        return;
+      }
+      logToFile('WARN', 'git commit failed', { stderr: commitResult.stderr, exitCode: commitResult.exitCode });
+    }
+  }
+
+  private scheduleDebounce(overrideMs?: number): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    const delay = overrideMs ?? this.config.debounceMs;
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      this.commitPending().catch(err => {
+        logToFile('ERROR', 'Debounced commit failed', { error: String(err) });
+      });
+    }, delay);
+  }
+
+  recordOp(op: PendingOp): void {
+    if (!this.config.enabled || !this.initialized) return;
+    this.opBuffer.push(op);
+    this.scheduleDebounce();
+  }
+
+  async recordImmediate(op: PendingOp): Promise<void> {
+    if (!this.config.enabled || !this.initialized) return;
+    this.opBuffer.push(op);
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    await this.commitPending();
+  }
+
+  async preCommit(message: string): Promise<void> {
+    if (!this.config.enabled || !this.initialized) return;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+
+    this.committing = true;
+    try {
+      for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
+        if (!this.acquireLock()) {
+          await Bun.sleep(jitteredDelay(attempt));
+          continue;
+        }
+        try {
+          const addResult = await gitExec(['add', '-A'], this.vaultPath);
+          if (addResult.exitCode !== 0) return;
+
+          const diffResult = await gitExec(['diff', '--cached', '--name-only'], this.vaultPath);
+          if (!diffResult.stdout) return;
+
+          await gitExec(['commit', '-m', message], this.vaultPath);
+        } finally {
+          this.releaseLock();
+        }
+        return;
+      }
+    } finally {
+      this.committing = false;
+    }
+  }
+
+  async checkpoint(message: string): Promise<void> {
+    if (!this.config.enabled || !this.initialized) return;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+
+    this.opBuffer.length = 0;
+
+    this.committing = true;
+    try {
+      for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
+        if (!this.acquireLock()) {
+          await Bun.sleep(jitteredDelay(attempt));
+          continue;
+        }
+        try {
+          const addResult = await gitExec(['add', '-A'], this.vaultPath);
+          if (addResult.exitCode !== 0) return;
+
+          const diffResult = await gitExec(['diff', '--cached', '--name-only'], this.vaultPath);
+          if (!diffResult.stdout) return;
+
+          const fileCount = diffResult.stdout.split('\n').filter(Boolean).length;
+          const fullMessage = `[checkpoint] ${message} (${fileCount} files)`;
+
+          await gitExec(['commit', '-m', fullMessage], this.vaultPath);
+        } finally {
+          this.releaseLock();
+        }
+        return;
+      }
+    } finally {
+      this.committing = false;
+    }
+  }
+
+  pauseCommits(): void {
+    this.commitPaused = true;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+
+  resumeCommits(): void {
+    this.commitPaused = false;
+  }
+
+  shutdownSync(): void {
+    if (!this.config.enabled || !this.initialized || this._shuttingDown) return;
+    this._shuttingDown = true;
+
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+
+    const status = gitExecSync(['status', '--porcelain'], this.vaultPath);
+    if (status.exitCode !== 0 || !status.stdout) return;
+
+    const lines = status.stdout.split('\n').filter(Boolean);
+    if (lines.length === 0) return;
+
+    const lockPath = path.join(this.vaultPath, '.git', LOCK_DIR_NAME);
+    try {
+      fs.mkdirSync(lockPath);
+    } catch {
+      logToFile('WARN', 'Could not acquire lock during shutdown — startup recovery will handle', {
+        pendingOps: this.opBuffer.length,
+      });
+      return;
+    }
+
+    try {
+      gitExecSync(['add', '-A'], this.vaultPath);
+
+      const ops = [...this.opBuffer];
+      this.opBuffer.length = 0;
+
+      const diffResult = gitExecSync(['diff', '--cached', '--name-only'], this.vaultPath);
+      const stagedFiles = diffResult.stdout ? diffResult.stdout.split('\n').filter(Boolean) : [];
+      if (stagedFiles.length === 0) return;
+
+      const message = ops.length > 0
+        ? buildCommitMessage(ops, stagedFiles, this.vaultPath)
+        : `[shutdown] ${stagedFiles.length} uncommitted change${stagedFiles.length !== 1 ? 's' : ''}`;
+
+      gitExecSync(['commit', '-m', message], this.vaultPath);
+    } finally {
+      try { fs.rmdirSync(lockPath); } catch { }
+    }
+  }
+
+  get isActive(): boolean {
+    return this.config.enabled && this.initialized;
+  }
+
+  getStats(): { commitCount: number; lastCommitAge: string | null } | null {
+    if (!this.config.enabled || !this.initialized) return null;
+
+    const logResult = gitExecSync(['rev-list', '--count', 'HEAD'], this.vaultPath);
+    const commitCount = logResult.exitCode === 0 ? parseInt(logResult.stdout, 10) || 0 : 0;
+
+    let lastCommitAge: string | null = null;
+    if (commitCount > 0) {
+      const tsResult = gitExecSync(['log', '-1', '--format=%ct'], this.vaultPath);
+      if (tsResult.exitCode === 0 && tsResult.stdout) {
+        const commitEpoch = parseInt(tsResult.stdout, 10) * 1000;
+        const ageSec = Math.floor((Date.now() - commitEpoch) / 1000);
+        if (ageSec < 60) lastCommitAge = `${ageSec}s ago`;
+        else if (ageSec < 3600) lastCommitAge = `${Math.floor(ageSec / 60)}m ago`;
+        else if (ageSec < 86400) lastCommitAge = `${Math.floor(ageSec / 3600)}h ago`;
+        else lastCommitAge = `${Math.floor(ageSec / 86400)}d ago`;
+      }
+    }
+
+    return { commitCount, lastCommitAge };
+  }
+}
+
+export function createGitVersioning(vaultPath: string, config: VersioningConfig): GitVersioning {
+  return new GitVersioning(vaultPath, config);
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -23,6 +23,8 @@ import { logToFile } from './logger.js';
 import { ensureObsidianScaffold } from './obsidian-scaffold.js';
 import { handleStore, handleSearch, handleMaintain, handleIngest, handleOverview, handleOpen, handleMine, handleTemplate } from './tool-handlers.js';
 import { generateEmbedding, DEFAULT_EMBEDDING_CONFIG } from './embeddings.js';
+import { createGitVersioning } from './git-versioning.js';
+import type { GitVersioning } from './git-versioning.js';
 import type { EmbeddingConfig } from './embeddings.js';
 import type { NoteKind } from './types.js';
 import type { NoteRepository as NoteRepositoryType } from './storage/NoteRepository.js';
@@ -33,6 +35,7 @@ const { NoteRepository } = await import('./storage/NoteRepository.js');
 const config = getConfig();
 let repo: NoteRepositoryType | null = null;
 let repoInitPromise: Promise<NoteRepositoryType> | null = null;
+let gitVersioning: GitVersioning | null = null;
 
 async function getOrCreateRepo(): Promise<NoteRepositoryType> {
   if (repo) return repo;
@@ -42,6 +45,11 @@ async function getOrCreateRepo(): Promise<NoteRepositoryType> {
     const instance = new NoteRepository(config.vault, { telemetryEnabled: config.telemetry.enabled });
     repo = instance;
     logToFile('INFO', 'MCP server: repository opened', { vault: config.vault }, config);
+
+    if (config.versioning.enabled) {
+      gitVersioning = createGitVersioning(config.vault, config.versioning);
+      await gitVersioning.init();
+    }
 
     const obsidianDir = path.join(config.vault, '.obsidian');
     if (config.obsidian.autoUpgrade && fs.existsSync(obsidianDir)) {
@@ -146,7 +154,7 @@ server.registerTool(
         client: args.client,
         related: args.related,
         model: args.model,
-      }, await getOrCreateRepo(), getEmbeddingConfig(), config);
+      }, await getOrCreateRepo(), getEmbeddingConfig(), config, gitVersioning);
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-store failed', {
@@ -363,7 +371,7 @@ server.registerTool(
         telemetry: args.telemetry,
         dryRun: args.dryRun,
         model: args.model,
-      }, await getOrCreateRepo(), config, getEmbeddingConfig(), PKG_VERSION);
+      }, await getOrCreateRepo(), config, getEmbeddingConfig(), PKG_VERSION, gitVersioning);
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-maintain failed', {
@@ -483,6 +491,15 @@ export async function startServer() {
 
 function shutdown() {
   logToFile('INFO', 'MCP server: shutting down', {}, config);
+  if (gitVersioning) {
+    try {
+      gitVersioning.shutdownSync();
+    } catch (error) {
+      logToFile('WARN', 'MCP server: failed to flush git versioning', {
+        error: error instanceof Error ? error.message : String(error),
+      }, config);
+    }
+  }
   if (repo) {
     try {
       repo.close();

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -51,6 +51,7 @@ import { detectObsidian, launchObsidian, formatNotInstalledMessage, formatSucces
 import { ensureObsidianScaffold, getObsidianScaffoldStatus } from './obsidian-scaffold.js';
 import { contractPath } from './utils/path.js';
 import { getTemplate, getExpectedCategories, matchCategories, extractHeaders, stripExamplesBlock, CONFORMANCE_KINDS } from './template-handler.js';
+import type { GitVersioning, PendingOp } from './git-versioning.js';
 
 // ---- Constants ----
 
@@ -724,7 +725,7 @@ function updateGlobalNavigation(
 
 // ---- Handlers ----
 
-export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConfig?: EmbeddingConfig | null, config?: AppConfig): Promise<string> {
+export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConfig?: EmbeddingConfig | null, config?: AppConfig, gitVersioning?: GitVersioning | null): Promise<string> {
   const effectiveStatus = toNoteStatus(args.status, KIND_DEFAULT_STATUS[args.kind]);
   const lifecycleDefaults = config?.lifecycleDefaults;
   const kindDefault = (lifecycleDefaults?.defaultForKind?.[args.kind] as Lifecycle | undefined) || KIND_DEFAULT_LIFECYCLE[args.kind];
@@ -791,6 +792,17 @@ export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddi
     summary: args.summary,
     guidance: args.guidance,
   });
+
+  if (gitVersioning) {
+    const project = args.project || extractProjectTag(tags);
+    gitVersioning.recordOp({
+      op: result.action === 'updated' ? 'update' : 'store',
+      noteId: result.id,
+      title: args.title,
+      kind: args.kind,
+      project: project || undefined,
+    });
+  }
 
   scheduleTelemetryWrite('store', () => repo.recordToolInvocation('store', args.kind, 1));
 
@@ -1020,7 +1032,7 @@ export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedd
   return output + clientWarning;
 }
 
-export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, config: AppConfig, embeddingConfig?: EmbeddingConfig | null, currentVersion?: string): Promise<string> {
+export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, config: AppConfig, embeddingConfig?: EmbeddingConfig | null, currentVersion?: string, gitVersioning?: GitVersioning | null): Promise<string> {
   scheduleTelemetryWrite('maintain', () => repo.recordToolInvocation('maintain', args.action));
   switch (args.action) {
     case 'stats': {
@@ -1105,6 +1117,17 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
           output += `\nShowing 5 of ${stats.total}. Use \`knowledge-search\` to find specific notes.\n`;
         }
       }
+      if (gitVersioning) {
+        const vStats = gitVersioning.getStats();
+        output += '\n## Versioning\n';
+        if (vStats) {
+          output += `- Git: enabled (${vStats.commitCount} commits)\n`;
+          if (vStats.lastCommitAge) output += `- Last commit: ${vStats.lastCommitAge}\n`;
+        } else {
+          output += '- Git: disabled\n';
+        }
+      }
+
       if (currentVersion) {
         const latest = await getLatestVersion('open-zk-kb');
         output += '\n## Version\n';
@@ -1151,6 +1174,10 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       const note = repo.getById(args.noteId);
       if (!note) return `Note not found: ${args.noteId}`;
       repo.promoteToPermanent(args.noteId);
+      if (gitVersioning) {
+        const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
+        await gitVersioning.recordImmediate({ op: 'promote', noteId: note.id, title: note.title, kind: note.kind, project: project || undefined });
+      }
       if (!STRUCTURAL_KINDS.has(note.kind)) {
         const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
         if (project) {
@@ -1165,6 +1192,10 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       const note = repo.getById(args.noteId);
       if (!note) return `Note not found: ${args.noteId}`;
       repo.archive(args.noteId);
+      if (gitVersioning) {
+        const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
+        await gitVersioning.recordImmediate({ op: 'archive', noteId: note.id, title: note.title, kind: note.kind, project: project || undefined });
+      }
       if (!STRUCTURAL_KINDS.has(note.kind)) {
         const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
         if (project) {
@@ -1178,7 +1209,14 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       if (!args.noteId) return 'Error: noteId is required for delete action.';
       const note = repo.getById(args.noteId);
       if (!note) return `Note not found: ${args.noteId}`;
+      if (gitVersioning) {
+        await gitVersioning.preCommit(`Pre-delete snapshot: "${note.title}"`);
+      }
       repo.remove(args.noteId);
+      if (gitVersioning) {
+        const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
+        await gitVersioning.recordImmediate({ op: 'delete', noteId: note.id, title: note.title, kind: note.kind, project: project || undefined });
+      }
       if (!STRUCTURAL_KINDS.has(note.kind)) {
         const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
         if (project) {
@@ -1189,6 +1227,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       return `Deleted "${note.title}" (${args.noteId}).`;
     }
     case 'rebuild': {
+      if (gitVersioning) await gitVersioning.checkpoint('Pre-rebuild snapshot');
       const result = repo.rebuildFromFiles();
       const projects = repo.getAllProjects();
       for (const project of projects) {
@@ -1196,6 +1235,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         appendProjectLog(project, 'Full DB rebuild', repo, config);
       }
       updateGlobalNavigation(null, 'Full DB rebuild', repo, config);
+      if (gitVersioning) await gitVersioning.checkpoint(`Full DB rebuild (${result.indexed} indexed)`);
       return `Indexed ${result.indexed} notes, ${result.errors} errors\nRebuilt index for ${projects.length} project(s).\nRebuild complete.`;
     }
     case 'format': {
@@ -1205,6 +1245,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         rebuildProjectIndex(proj, repo, config);
       }
       updateGlobalNavigation(null, 'Format all files', repo, config);
+      if (gitVersioning) await gitVersioning.checkpoint(`Format ${result.formatted} notes`);
       return `Formatted ${result.formatted} note files (${result.skipped} skipped, ${result.errors} errors).\nRegenerated navigation for ${projects.length} project(s).`;
     }
     case 'upgrade': {
@@ -1660,6 +1701,10 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
     }
     case 'migrate-layout': {
       const dryRun = args.dryRun !== false;
+      if (!dryRun && gitVersioning) {
+        await gitVersioning.checkpoint('Pre-migration snapshot');
+        gitVersioning.pauseCommits();
+      }
       repo.rebuildFromFiles();
       const allNotes = repo.getAll(Number.MAX_SAFE_INTEGER);
       let moved = 0;
@@ -1752,6 +1797,10 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         }
         output += `\nPost-migration rebuild: indexed ${rebuildResult.indexed} notes, rebuilt ${projects.length} project index(es).`;
         updateGlobalNavigation(null, 'Layout migration completed', repo, config);
+        if (gitVersioning) {
+          gitVersioning.resumeCommits();
+          await gitVersioning.checkpoint(`Layout migration (${moved} moved)`);
+        }
 
         const embeddingStats = repo.getEmbeddingStats();
         const brokenLinks = filterFalsePositiveBrokenLinks(repo.getBrokenLinks(), config?.vault);

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -51,7 +51,7 @@ import { detectObsidian, launchObsidian, formatNotInstalledMessage, formatSucces
 import { ensureObsidianScaffold, getObsidianScaffoldStatus } from './obsidian-scaffold.js';
 import { contractPath } from './utils/path.js';
 import { getTemplate, getExpectedCategories, matchCategories, extractHeaders, stripExamplesBlock, CONFORMANCE_KINDS } from './template-handler.js';
-import type { GitVersioning, PendingOp } from './git-versioning.js';
+import type { GitVersioning } from './git-versioning.js';
 
 // ---- Constants ----
 
@@ -1174,16 +1174,16 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       const note = repo.getById(args.noteId);
       if (!note) return `Note not found: ${args.noteId}`;
       repo.promoteToPermanent(args.noteId);
-      if (gitVersioning) {
-        const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
-        await gitVersioning.recordImmediate({ op: 'promote', noteId: note.id, title: note.title, kind: note.kind, project: project || undefined });
-      }
       if (!STRUCTURAL_KINDS.has(note.kind)) {
         const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
         if (project) {
           updateProjectNavigation(project, `Promoted "${note.title}" from fleeting to permanent`, repo, config);
         }
         updateGlobalNavigation(project, `Promoted "${note.title}"`, repo, config);
+      }
+      if (gitVersioning) {
+        const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
+        await gitVersioning.recordImmediate({ op: 'promote', noteId: note.id, title: note.title, kind: note.kind, project: project || undefined });
       }
       return `Promoted "${note.title}" (${args.noteId}) to permanent status.`;
     }
@@ -1192,16 +1192,16 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       const note = repo.getById(args.noteId);
       if (!note) return `Note not found: ${args.noteId}`;
       repo.archive(args.noteId);
-      if (gitVersioning) {
-        const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
-        await gitVersioning.recordImmediate({ op: 'archive', noteId: note.id, title: note.title, kind: note.kind, project: project || undefined });
-      }
       if (!STRUCTURAL_KINDS.has(note.kind)) {
         const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
         if (project) {
           updateProjectNavigation(project, `Archived "${note.title}"`, repo, config);
         }
         updateGlobalNavigation(project, `Archived "${note.title}"`, repo, config);
+      }
+      if (gitVersioning) {
+        const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
+        await gitVersioning.recordImmediate({ op: 'archive', noteId: note.id, title: note.title, kind: note.kind, project: project || undefined });
       }
       return `Archived "${note.title}" (${args.noteId}).`;
     }
@@ -1213,16 +1213,16 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         await gitVersioning.preCommit(`Pre-delete snapshot: "${note.title}"`);
       }
       repo.remove(args.noteId);
-      if (gitVersioning) {
-        const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
-        await gitVersioning.recordImmediate({ op: 'delete', noteId: note.id, title: note.title, kind: note.kind, project: project || undefined });
-      }
       if (!STRUCTURAL_KINDS.has(note.kind)) {
         const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
         if (project) {
           updateProjectNavigation(project, `Deleted "${note.title}"`, repo, config);
         }
         updateGlobalNavigation(project, `Deleted "${note.title}"`, repo, config);
+      }
+      if (gitVersioning) {
+        const project = extractProjectFromTags(Array.isArray(note.tags) ? note.tags : []);
+        await gitVersioning.recordImmediate({ op: 'delete', noteId: note.id, title: note.title, kind: note.kind, project: project || undefined });
       }
       return `Deleted "${note.title}" (${args.noteId}).`;
     }
@@ -1701,10 +1701,12 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
     }
     case 'migrate-layout': {
       const dryRun = args.dryRun !== false;
-      if (!dryRun && gitVersioning) {
+      const commitsPaused = !dryRun && !!gitVersioning;
+      if (commitsPaused && gitVersioning) {
         await gitVersioning.checkpoint('Pre-migration snapshot');
         gitVersioning.pauseCommits();
       }
+      try {
       repo.rebuildFromFiles();
       const allNotes = repo.getAll(Number.MAX_SAFE_INTEGER);
       let moved = 0;
@@ -1797,7 +1799,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         }
         output += `\nPost-migration rebuild: indexed ${rebuildResult.indexed} notes, rebuilt ${projects.length} project index(es).`;
         updateGlobalNavigation(null, 'Layout migration completed', repo, config);
-        if (gitVersioning) {
+        if (commitsPaused && gitVersioning) {
           gitVersioning.resumeCommits();
           await gitVersioning.checkpoint(`Layout migration (${moved} moved)`);
         }
@@ -1824,6 +1826,11 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       }
 
       return output;
+      } finally {
+        if (commitsPaused && gitVersioning) {
+          gitVersioning.resumeCommits();
+        }
+      }
     }
     case 'full': {
       const steps: Array<{ action: string; label: string; stepArgs: MaintainArgs }> = [

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -1849,7 +1849,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       for (const step of steps) {
         sections.push(`## ${stepNum}. ${step.label}\n`);
         try {
-          const result = await handleMaintain(step.stepArgs, repo, config, embeddingConfig, currentVersion);
+          const result = await handleMaintain(step.stepArgs, repo, config, embeddingConfig, currentVersion, gitVersioning);
           sections.push(result);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,11 @@ export interface ObsidianConfig {
   readOnly: boolean;
 }
 
+export interface VersioningConfig {
+  enabled: boolean;
+  debounceMs: number;
+}
+
 export interface RelatedNotesConfig {
   enabled: boolean;
   maxResults: number;
@@ -96,6 +101,7 @@ export interface AppConfig {
   navigation: NavigationConfig;
   telemetry: TelemetryConfig;
   obsidian: ObsidianConfig;
+  versioning: VersioningConfig;
 }
 
 // NOTE: NoteMetadata and StoreResult are defined in storage/NoteRepository.ts

--- a/tests/git-versioning.test.ts
+++ b/tests/git-versioning.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { GitVersioning, createGitVersioning, buildCommitMessage } from '../src/git-versioning.js';
+import type { PendingOp } from '../src/git-versioning.js';
+import type { VersioningConfig } from '../src/types.js';
+
+const DEBOUNCE_MS = 75;
+const ENABLED_CONFIG: VersioningConfig = { enabled: true, debounceMs: DEBOUNCE_MS };
+const DISABLED_CONFIG: VersioningConfig = { enabled: false, debounceMs: DEBOUNCE_MS };
+const GIT_ENV = {
+  GIT_TERMINAL_PROMPT: '0',
+  GIT_AUTHOR_NAME: 'open-zk-kb-test',
+  GIT_AUTHOR_EMAIL: 'open-zk-kb-test@local',
+  GIT_COMMITTER_NAME: 'open-zk-kb-test',
+  GIT_COMMITTER_EMAIL: 'open-zk-kb-test@local',
+};
+
+describe('git-versioning.ts', () => {
+  let tempDirs: string[];
+  let versioning: GitVersioning | null;
+
+  beforeEach(() => {
+    tempDirs = [];
+    versioning = null;
+  });
+
+  afterEach(() => {
+    versioning?.shutdownSync();
+    versioning = null;
+
+    for (const tempDir of tempDirs.splice(0, tempDirs.length)) {
+      if (fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  function createVault(): string {
+    const vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-git-versioning-test-'));
+    tempDirs.push(vaultPath);
+    return vaultPath;
+  }
+
+  function writeVaultFile(vaultPath: string, relativePath: string, content: string): void {
+    const filePath = path.join(vaultPath, relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content, 'utf-8');
+  }
+
+  function appendVaultFile(vaultPath: string, relativePath: string, content: string): void {
+    fs.appendFileSync(path.join(vaultPath, relativePath), content, 'utf-8');
+  }
+
+  function git(vaultPath: string, args: string[]): Bun.SpawnSyncReturns<Uint8Array, Uint8Array> {
+    return Bun.spawnSync(['git', ...args], {
+      cwd: vaultPath,
+      env: { ...process.env, ...GIT_ENV },
+    });
+  }
+
+  function gitLog(vaultPath: string): string {
+    const result = Bun.spawnSync(['git', 'log', '--oneline'], { cwd: vaultPath });
+    expect(result.exitCode).toBe(0);
+    return result.stdout.toString();
+  }
+
+  function gitFullLog(vaultPath: string): string {
+    const result = git(vaultPath, ['log', '--format=%B']);
+    expect(result.exitCode).toBe(0);
+    return result.stdout.toString();
+  }
+
+  function gitStatus(vaultPath: string): string {
+    const result = git(vaultPath, ['status', '--porcelain']);
+    expect(result.exitCode).toBe(0);
+    return result.stdout.toString().trim();
+  }
+
+  function commitCount(vaultPath: string): number {
+    const result = git(vaultPath, ['rev-list', '--count', 'HEAD']);
+    expect(result.exitCode).toBe(0);
+    return Number(result.stdout.toString().trim());
+  }
+
+  async function waitForLog(vaultPath: string, expected: string): Promise<string> {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const log = gitLog(vaultPath);
+      if (log.includes(expected)) return log;
+      await Bun.sleep(25);
+    }
+
+    return gitLog(vaultPath);
+  }
+
+  async function waitForCommitCount(vaultPath: string, expected: number): Promise<number> {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const count = commitCount(vaultPath);
+      if (count === expected) return count;
+      await Bun.sleep(25);
+    }
+
+    return commitCount(vaultPath);
+  }
+
+  function initManualRepo(vaultPath: string): void {
+    expect(git(vaultPath, ['init']).exitCode).toBe(0);
+  }
+
+  function manualCommit(vaultPath: string, message: string): void {
+    expect(git(vaultPath, ['add', '-A']).exitCode).toBe(0);
+    expect(git(vaultPath, ['commit', '-m', message]).exitCode).toBe(0);
+  }
+
+  function pendingOp(overrides: Partial<PendingOp> = {}): PendingOp {
+    return {
+      op: 'store',
+      noteId: '2026010101010100',
+      title: 'Test Note',
+      kind: 'observation',
+      ...overrides,
+    };
+  }
+
+  it('init() creates a .git directory and .gitignore', async () => {
+    const vaultPath = createVault();
+    versioning = new GitVersioning(vaultPath, ENABLED_CONFIG);
+
+    await versioning.init();
+
+    expect(fs.existsSync(path.join(vaultPath, '.git'))).toBe(true);
+    expect(fs.existsSync(path.join(vaultPath, '.gitignore'))).toBe(true);
+    expect(versioning.isActive).toBe(true);
+  });
+
+  it('init() makes an initial commit with existing files', async () => {
+    const vaultPath = createVault();
+    writeVaultFile(vaultPath, '2026010101010100-existing.md', '# Existing\n');
+    versioning = new GitVersioning(vaultPath, ENABLED_CONFIG);
+
+    await versioning.init();
+
+    const log = gitLog(vaultPath);
+    expect(log).toContain('[init] Knowledge base');
+    expect(commitCount(vaultPath)).toBe(1);
+  });
+
+  it('recordOp() commits after the debounce window', async () => {
+    const vaultPath = createVault();
+    versioning = createGitVersioning(vaultPath, ENABLED_CONFIG);
+    await versioning.init();
+    writeVaultFile(vaultPath, '2026010101010100-debounced.md', '# Debounced\n');
+
+    versioning.recordOp(pendingOp({ title: 'Debounced' }));
+    await Bun.sleep(DEBOUNCE_MS + 50);
+
+    const log = await waitForLog(vaultPath, 'Store observation: "Debounced"');
+    expect(log).toContain('Store observation: "Debounced"');
+  });
+
+  it('recordImmediate() commits without waiting for debounce', async () => {
+    const vaultPath = createVault();
+    versioning = new GitVersioning(vaultPath, ENABLED_CONFIG);
+    await versioning.init();
+    writeVaultFile(vaultPath, '2026010101010100-immediate.md', '# Immediate\n');
+
+    await versioning.recordImmediate(pendingOp({ title: 'Immediate' }));
+
+    const log = gitLog(vaultPath);
+    expect(log).toContain('Store observation: "Immediate"');
+  });
+
+  it('preCommit() creates a snapshot commit', async () => {
+    const vaultPath = createVault();
+    versioning = new GitVersioning(vaultPath, ENABLED_CONFIG);
+    await versioning.init();
+    writeVaultFile(vaultPath, 'snapshot.md', '# Snapshot\n');
+
+    await versioning.preCommit('[snapshot] Before risky edit');
+
+    const log = gitLog(vaultPath);
+    expect(log).toContain('[snapshot] Before risky edit');
+  });
+
+  it('checkpoint() creates a [checkpoint] commit', async () => {
+    const vaultPath = createVault();
+    versioning = new GitVersioning(vaultPath, ENABLED_CONFIG);
+    await versioning.init();
+    writeVaultFile(vaultPath, 'checkpoint.md', '# Checkpoint\n');
+
+    await versioning.checkpoint('Manual milestone');
+
+    const log = gitLog(vaultPath);
+    expect(log).toContain('[checkpoint] Manual milestone');
+  });
+
+  it('shutdownSync() commits pending changes synchronously', async () => {
+    const vaultPath = createVault();
+    versioning = new GitVersioning(vaultPath, { enabled: true, debounceMs: 10_000 });
+    await versioning.init();
+    writeVaultFile(vaultPath, '2026010101010100-shutdown.md', '# Shutdown\n');
+
+    versioning.recordOp(pendingOp({ title: 'Shutdown' }));
+    versioning.shutdownSync();
+
+    const log = gitLog(vaultPath);
+    expect(log).toContain('Store observation: "Shutdown"');
+  });
+
+  it('buildCommitMessage() formats a single operation', () => {
+    const message = buildCommitMessage(
+      [pendingOp({ title: 'Single', project: 'alpha' })],
+      ['2026010101010100-single.md'],
+      '/tmp/vault',
+    );
+
+    expect(message).toBe('Store observation: "Single" [alpha]');
+  });
+
+  it('buildCommitMessage() formats batched operations', () => {
+    const message = buildCommitMessage(
+      [
+        pendingOp({ noteId: '2026010101010100', title: 'First' }),
+        pendingOp({ op: 'update', noteId: '2026010101010101', title: 'Second', kind: 'decision' }),
+      ],
+      ['2026010101010100-first.md', '2026010101010101-second.md'],
+      '/tmp/vault',
+    );
+
+    expect(message).toContain('1 store, 1 update');
+    expect(message).toContain('- Store observation: "First"');
+    expect(message).toContain('- Update decision: "Second"');
+  });
+
+  it('buildCommitMessage() includes external changes', () => {
+    const message = buildCommitMessage(
+      [pendingOp({ title: 'Known' })],
+      ['2026010101010100-known.md', 'manual.md'],
+      '/tmp/vault',
+    );
+
+    expect(message).toContain('1 store, 1 external');
+    expect(message).toContain('- Store observation: "Known"');
+    expect(message).toContain('- 1 file changed outside server');
+  });
+
+  it('init() recovers a dirty working tree with a [recovery] commit', async () => {
+    const vaultPath = createVault();
+    initManualRepo(vaultPath);
+    writeVaultFile(vaultPath, 'baseline.md', '# Baseline\n');
+    manualCommit(vaultPath, 'Baseline');
+    appendVaultFile(vaultPath, 'baseline.md', '\nChanged before restart\n');
+    writeVaultFile(vaultPath, 'untracked.md', '# Untracked\n');
+
+    versioning = new GitVersioning(vaultPath, ENABLED_CONFIG);
+    await versioning.init();
+
+    const log = gitLog(vaultPath);
+    expect(log).toContain('[recovery] Uncommitted changes from prior session');
+    expect(gitStatus(vaultPath)).toBe('');
+  });
+
+  it('batches multiple operations within one debounce window into a single commit', async () => {
+    const vaultPath = createVault();
+    versioning = new GitVersioning(vaultPath, ENABLED_CONFIG);
+    await versioning.init();
+    const initialCount = commitCount(vaultPath);
+    writeVaultFile(vaultPath, '2026010101010100-first.md', '# First\n');
+    writeVaultFile(vaultPath, '2026010101010101-second.md', '# Second\n');
+
+    versioning.recordOp(pendingOp({ noteId: '2026010101010100', title: 'First' }));
+    versioning.recordOp(pendingOp({ op: 'update', noteId: '2026010101010101', title: 'Second', kind: 'decision' }));
+    await Bun.sleep(DEBOUNCE_MS + 50);
+
+    expect(await waitForCommitCount(vaultPath, initialCount + 1)).toBe(initialCount + 1);
+    const log = gitLog(vaultPath);
+    expect(log).toContain('1 store, 1 update');
+    const fullLog = gitFullLog(vaultPath);
+    expect(fullLog).toContain('Store observation: "First"');
+    expect(fullLog).toContain('Update decision: "Second"');
+  });
+
+  it('.gitignore contains .index/ and .obsidian/', async () => {
+    const vaultPath = createVault();
+    versioning = new GitVersioning(vaultPath, ENABLED_CONFIG);
+
+    await versioning.init();
+
+    const gitignore = fs.readFileSync(path.join(vaultPath, '.gitignore'), 'utf-8');
+    expect(gitignore).toContain('.index/');
+    expect(gitignore).toContain('.obsidian/');
+  });
+
+  it('disabled versioning performs no git operations', async () => {
+    const vaultPath = createVault();
+    writeVaultFile(vaultPath, '2026010101010100-disabled.md', '# Disabled\n');
+    versioning = new GitVersioning(vaultPath, DISABLED_CONFIG);
+
+    await versioning.init();
+    versioning.recordOp(pendingOp({ title: 'Disabled' }));
+    await versioning.recordImmediate(pendingOp({ title: 'Disabled Immediate' }));
+    await versioning.preCommit('[snapshot] Disabled');
+    await versioning.checkpoint('Disabled');
+    versioning.shutdownSync();
+
+    expect(fs.existsSync(path.join(vaultPath, '.git'))).toBe(false);
+    expect(fs.existsSync(path.join(vaultPath, '.gitignore'))).toBe(false);
+    expect(versioning.isActive).toBe(false);
+  });
+});

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -63,6 +63,10 @@ export function createTestHarness(options: TestHarnessOptions = {}): TestContext
       autoUpgrade: true,
       readOnly: true,
     },
+    versioning: {
+      enabled: false,
+      debounceMs: 30000,
+    },
   };
 
   const engine = new NoteRepository(tempDir, { telemetryEnabled: config.telemetry.enabled });


### PR DESCRIPTION
## Summary

- Adds automatic git versioning for the vault to prevent silent data loss (motivated by notes disappearing during rebuild/migration without any recovery path)
- Uses batched/debounced commits (30s default) for normal writes, immediate commits for destructive operations (delete, archive, promote)
- Application-level `mkdir` lock ensures atomic git operations across concurrent MCP server instances

## Design

- **Debounced stores**: `recordOp()` resets a 30s timer; commit fires after quiet period
- **Immediate ops**: Archive/promote commit instantly; delete does pre-commit → remove → post-commit
- **Checkpoints**: Rebuild, migrate-layout, and format trigger explicit checkpoint commits
- **Atomic lock**: `mkdir .git/kb-commit.lock` serializes git operations across instances (stale lock auto-removed after 30s)
- **Recovery**: On startup, detects dirty working tree and commits with `[recovery]` message
- **Shutdown flush**: `spawnSync` ensures pending changes persist before process exit
- **Commit messages**: Summary line + bullet list of operations, cross-referenced against staged files

## Config

```yaml
versioning:
  enabled: true       # on by default
  debounceMs: 30000   # quiet period before auto-commit
```

## Adoption

Fully automatic — existing vaults get `git init` + initial commit on first server start after update. No schema migration needed (filesystem-only feature).

## Stats Output

`knowledge-maintain stats` now shows:
```
## Versioning
- Git: enabled (42 commits)
- Last commit: 2h ago
```

## Files

| File | Change |
|---|---|
| `src/git-versioning.ts` | New — core module (~560 LOC) |
| `src/types.ts` | `VersioningConfig` interface |
| `src/config.ts` | Config defaults + merger |
| `src/tool-handlers.ts` | Hook recordOp/checkpoint into store + maintain handlers |
| `src/mcp-server.ts` | Create instance, pass to handlers, shutdown flush |
| `tests/harness.ts` | Add versioning config (disabled in tests) |
| `tests/git-versioning.test.ts` | New — 14 tests with real git repos |

## Test Results

906 pass, 0 fail (892 existing + 14 new)