### PR TITLE
Auto-detect dev channel and rewrite dev setup docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -29,42 +29,60 @@ For rapid iteration:
 - bun test --watch — re-runs tests on file change
 - Note: there's no watch mode for the build itself — you need to run bun run build each time
 
-## Dev release channel
+## Development Setup
 
-Pushes to the `dev` branch auto-publish to npm under the `dev` dist-tag (e.g., `1.1.0-dev.g751771b`). To test unreleased changes without a local checkout, point your MCP config at `open-zk-kb@dev` instead of `@latest`. See [Release Channels](setup-guide.md#release-channels) for details.
+Two paths depending on whether you're editing source code or just testing unreleased changes.
 
-## OpenCode local development
+### Path 1: Source checkout (contributor workflow)
 
-Use the normal installer for local OpenCode testing.
+For making and testing code changes locally.
 
-### Recommended workflow
 ```bash
+git clone https://github.com/mrosnerr/open-zk-kb
+cd open-zk-kb
+bun install
 bun run build
-bun run setup install --client opencode --force
+bun run setup install --client <name> --force
 ```
 
-This configures OpenCode to run the local `dist/mcp-server.js` build through its MCP entry, registers the local checkout as a `file://` plugin, and refreshes the managed `AGENTS.md` block. That is the supported contributor workflow for testing changes on your development branch.
+Replace `<name>` with your client: `opencode`, `claude-code`, `cursor`, `windsurf`, or `zed`.
 
-### What gets installed for OpenCode
+The installer auto-detects the source checkout (via `.git` presence) and wires everything to local paths:
+- **MCP server** → your local `dist/mcp-server.js`
+- **Plugin** (OpenCode) → `file://` URL pointing at your checkout
+- **Agent instructions** → managed block in your client's instruction file
 
-- `mcp.open-zk-kb` points at your local `dist/mcp-server.js` build.
-- `plugin` includes the local checkout as a `file://` plugin during source installs.
-- `~/.config/opencode/AGENTS.md` gets the managed knowledge-base instructions.
+After every source change:
+```bash
+bun run build
+bun run setup install --client <name> --force   # re-registers updated paths
+# Restart your client so it reloads the MCP server and plugin
+```
+
+### Path 2: Dev channel (testing unreleased changes)
+
+For testing the latest `dev` branch without cloning the repo.
+
+```bash
+bunx open-zk-kb@dev install --client <name>
+```
+
+That's it. The installer detects it's running from a dev release and writes `@dev` to your MCP config automatically. Each push to the `dev` branch publishes a new version (format: `X.Y.Z-dev.g<sha>`).
+
+To switch back to stable:
+```bash
+bunx open-zk-kb@latest install --client <name> --force
+```
+
+See [Release Channels](setup-guide.md#release-channels) for more details.
 
 ### Navigation UX boundary
 
-- Treat Obsidian as the human UX layer.
-- Treat MCP + SQLite as the agent query layer.
+- Treat Obsidian as the human UX layer; MCP + SQLite as the agent query layer.
 - Keep core knowledge notes markdown-native.
-- It is acceptable for generated `index` and `log` notes to adopt richer Obsidian-native functionality from the managed scaffold when that improves human navigation.
-- Prefer Dataview for rendering index-page lists/tables where possible; keep the server focused on shell creation, storage, and guarantees.
-- Prefer Obsidian plugins like Breadcrumbs for per-note navigation UI instead of injecting breadcrumb markdown into canonical note bodies.
-
-> **How does the installer know to use local paths?** It checks whether the running script's parent directory contains a `.git` folder. If it does, you're running from a source checkout — the installer uses `file://` URLs and absolute paths. When installed via `bunx`/`npx` (no `.git`), it uses the `open-zk-kb` npm package name instead.
-
-### Verify plugin changes locally
-
-After rebuilding, rerun the installer and restart OpenCode so it reloads both the MCP server and plugin entry.
+- Generated `index` and `log` notes may adopt richer Obsidian-native functionality when it improves human navigation.
+- Prefer Dataview for rendering index-page lists/tables; keep the server focused on storage and guarantees.
+- Prefer the Breadcrumbs plugin for per-note navigation instead of injecting breadcrumb markdown into note bodies.
 
 ## Project Structure
 (See [architecture.md](architecture.md) for details)

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,7 +64,7 @@ bun run setup install --client <name> --force   # re-registers updated paths
 For testing the latest `dev` branch without cloning the repo.
 
 ```bash
-bunx open-zk-kb@dev install --client <name>
+bunx open-zk-kb@dev install --client <name> --force
 ```
 
 That's it. The installer detects it's running from a dev release and writes `@dev` to your MCP config automatically. Each push to the `dev` branch publishes a new version (format: `X.Y.Z-dev.g<sha>`).

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -130,7 +130,7 @@ Instructions are injected as a managed block wrapped in markers:
 To install from the dev channel:
 
 ```bash
-bunx open-zk-kb@dev install --client <name>
+bunx open-zk-kb@dev install --client <name> --force
 ```
 
 The installer auto-detects the dev release and writes `@dev` to your MCP config. Dev versions follow the format `X.Y.Z-dev.g<short-sha>` (e.g., `1.1.0-dev.g751771b`). Each push to the `dev` branch publishes a new release automatically.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -51,17 +51,12 @@ git clone https://github.com/mrosnerr/open-zk-kb
 cd open-zk-kb
 bun install
 bun run build
-bun run setup            # interactive installer
+bun run setup install --client <name> --force
 ```
 
-Verification: `ls dist/mcp-server.js` should exist.
+The installer auto-detects the source checkout (via `.git` presence) and wires your client to local paths — MCP server points at `dist/mcp-server.js`, plugin uses `file://` URLs, and agent instructions are injected.
 
-For scripted/CI use:
-```bash
-bun run setup install --client opencode
-```
-
-For OpenCode development from a local checkout, this source install path wires OpenCode to your local `dist/mcp-server.js` build, registers the local checkout as a `file://` plugin, and injects the managed instructions.
+See the [Development Guide](development.md#development-setup) for the full contributor workflow.
 
 ### Config file locations
 
@@ -132,15 +127,19 @@ Instructions are injected as a managed block wrapped in markers:
 | **Stable** | `@latest` | Production-ready | Default for all users |
 | **Dev** | `@dev` | Bleeding-edge, may break | Testing unreleased changes from the `dev` branch |
 
-To use the dev channel, change `@latest` to `@dev` in your MCP config:
+To install from the dev channel:
 
-```json
-"command": ["bunx", "open-zk-kb@dev", "server"]
+```bash
+bunx open-zk-kb@dev install --client <name>
 ```
 
-Dev versions follow the format `X.Y.Z-dev.g<short-sha>` (e.g., `1.1.0-dev.g751771b`). Each push to the `dev` branch publishes a new dev release automatically.
+The installer auto-detects the dev release and writes `@dev` to your MCP config. Dev versions follow the format `X.Y.Z-dev.g<short-sha>` (e.g., `1.1.0-dev.g751771b`). Each push to the `dev` branch publishes a new release automatically.
 
-To switch back to stable: change `@dev` to `@latest` and restart your client.
+To switch back to stable:
+
+```bash
+bunx open-zk-kb@latest install --client <name> --force
+```
 
 ## Updating
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -12,6 +12,10 @@ import { injectAgentDocs, inspectAgentDocs, removeAgentDocs } from './agent-docs
 import type { InstructionSize } from './agent-docs.js';
 import { PKG_VERSION } from './version.js';
 
+function detectNpmTag(): 'dev' | 'latest' {
+  return PKG_VERSION.includes('-dev.') ? 'dev' : 'latest';
+}
+
 const xdgConfigHome = process.env.XDG_CONFIG_HOME || expandPath('~/.config');
 const xdgDataHome = process.env.XDG_DATA_HOME || expandPath('~/.local/share');
 
@@ -117,17 +121,18 @@ type McpEntry =
 
 function buildMcpEntry(clientConfig: ClientConfig, serverPath?: string): McpEntry {
   if (!serverPath) {
+    const tag = detectNpmTag();
     if (clientConfig.mcpFormat === 'opencode') {
       return {
         type: 'local',
-        command: ['bunx', 'open-zk-kb@latest', 'server'],
+        command: ['bunx', `open-zk-kb@${tag}`, 'server'],
         enabled: true,
       };
     }
 
     return {
       command: 'bunx',
-      args: ['open-zk-kb@latest', 'server'],
+      args: [`open-zk-kb@${tag}`, 'server'],
     };
   }
 
@@ -244,7 +249,7 @@ function validateOpenCodePlugin(config: JsonObject, expectedEntry: string): stri
 }
 
 function formatServerCommand(serverPath?: string): string {
-  return serverPath ? `bun run ${serverPath}` : 'bunx open-zk-kb@latest server';
+  return serverPath ? `bun run ${serverPath}` : `bunx open-zk-kb@${detectNpmTag()} server`;
 }
 
 /**
@@ -958,7 +963,7 @@ export function uninstall(args: UninstallArgs): string {
     output += `Deleted vault: ${vaultPath}\n`;
   } else {
     output += `Vault preserved at: ${vaultPath}\n`;
-    output += `Reinstall anytime with: bunx open-zk-kb@latest install --client ${args.client}\n`;
+    output += `Reinstall anytime with: bunx open-zk-kb@${detectNpmTag()} install --client ${args.client}\n`;
   }
   
   return output;


### PR DESCRIPTION
## Summary

- Installer now auto-detects whether it's running from a dev release (`X.Y.Z-dev.g<sha>`) and writes `@dev` instead of `@latest` to the generated MCP config. Running `bunx open-zk-kb@dev install --client <name>` now produces the correct config end-to-end — no manual JSON editing needed.
- Rewrote dev setup documentation in `development.md` and `setup-guide.md` with two clear paths: source checkout (contributor workflow) and dev channel (one-liner for testing unreleased changes).

## Changes

### `src/setup.ts`
- Added `detectNpmTag()` that returns `'dev'` or `'latest'` based on `PKG_VERSION`
- Replaced all 4 hardcoded `@latest` references with the dynamic tag

### `docs/development.md`
- Consolidated scattered dev sections into a single "Development Setup" section
- Path 1: Source checkout with copy-paste commands and explanation of what gets wired
- Path 2: Dev channel one-liner with switch-back instructions

### `docs/setup-guide.md`
- Replaced "manually edit JSON config" with the CLI one-liner
- Simplified "Install from source" section, cross-references development.md