### PR TITLE
Fix OpenCode plugin export path

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -33,7 +33,7 @@ For OpenCode, include both the `plugin` array and the `mcp` key:
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["open-zk-kb"],
+  "plugin": ["open-zk-kb/plugin"],
   "mcp": {
     "open-zk-kb": {
       "type": "local",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
       "types": "./dist/mcp-server.d.ts",
       "import": "./dist/mcp-server.js"
     },
-    "./server": {
+    "./plugin": {
       "types": "./dist/opencode-plugin/index.d.ts",
       "import": "./dist/opencode-plugin/index.js"
     }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -170,11 +170,11 @@ function detectServerPath(): string | undefined {
 
 function buildOpenCodePluginEntry(): string {
   const projectRoot = detectProjectRoot();
-  return projectRoot ? pathToFileURL(projectRoot).toString() : OPENCODE_PLUGIN_PACKAGE;
+  return projectRoot ? pathToFileURL(projectRoot).toString() : `${OPENCODE_PLUGIN_PACKAGE}/plugin`;
 }
 
 function isOpenCodePluginEntry(value: string): boolean {
-  if (value === OPENCODE_PLUGIN_PACKAGE || value === `${OPENCODE_PLUGIN_PACKAGE}/server`) {
+  if (value === OPENCODE_PLUGIN_PACKAGE || value === `${OPENCODE_PLUGIN_PACKAGE}/plugin`) {
     return true;
   }
 

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -321,7 +321,7 @@ describe('setup.ts', () => {
     const configPath = path.join(env.xdgConfigHome, 'opencode', 'opencode.json');
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(configPath, JSON.stringify({
-      plugin: ['open-zk-kb/server'],
+      plugin: ['open-zk-kb/plugin'],
       mcp: {
         'open-zk-kb': {
           type: 'local',


### PR DESCRIPTION
## Summary

- Fixes OpenCode startup crash: `TypeError: undefined is not an object (evaluating 'C.provider')` caused by the plugin entry resolving to the MCP server export instead of the OpenCode plugin interface
- Changes installer to write `open-zk-kb/plugin` to the plugin array (was writing bare `open-zk-kb`)
- Renames the subpath export from `./server` to `./plugin` for clarity (since the MCP server is *also* a server)
- Updates setup-guide.md to reflect the correct plugin entry

## Changes

| File | Change |
|------|--------|
| `package.json` | Rename export `./server` → `./plugin` |
| `src/setup.ts` | `buildOpenCodePluginEntry()` returns `open-zk-kb/plugin`; `isOpenCodePluginEntry()` matches `/plugin` |
| `tests/setup.test.ts` | Test fixture uses `open-zk-kb/plugin` |
| `docs/setup-guide.md` | Doc example uses `open-zk-kb/plugin` |