### PR TITLE
Refresh brand voice and terminology across all public-facing docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to open-zk-kb
 
-Thank you for your interest in contributing to open-zk-kb — shared, persistent memory for AI assistants, built on the Zettelkasten method.
+Thank you for your interest in contributing to open-zk-kb — persistent memory for agents.
 
 ## Prerequisites
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools — so context persists across sessions and clients. TypeScript/Bun, SQLite FTS5, Markdown files with YAML frontmatter. Entry point: `mcp-server.ts` (MCP stdio).
+Persistent memory for agents. One knowledge base for all your tools — so context persists across sessions and clients. TypeScript/Bun, SQLite FTS5, Markdown files with YAML frontmatter. Entry point: `mcp-server.ts` (MCP stdio). See [BRAND.md](./BRAND.md) for public voice and positioning.
 
 ## Commands
 

--- a/BRAND.md
+++ b/BRAND.md
@@ -1,0 +1,158 @@
+# Brand & Voice Guide
+
+> **This document governs all outward-facing copy**: README, docs, GitHub descriptions, release notes, social posts, and any agent-generated text about the project.
+
+## Core Positioning
+
+One truth, two framings.
+
+- **The pain**: "Your agent doesn't learn from you."
+- **The payoff**: "Correct it once. It sticks."
+
+Everything else is supporting detail. Lead with the pain. Follow with the payoff.
+
+**Supporting hooks** (use to illustrate, not to lead):
+- "Stop re-explaining yourself every session."
+- "Every session makes the next one better."
+- "One memory, shared across every tool you use."
+
+## Tagline
+
+> Your agent doesn't learn from you. This fixes that.
+
+Use this as the primary one-liner anywhere a short description is needed (GitHub repo description, npm package summary, social bios). Shorten to "Persistent memory for AI agents" when character-limited.
+
+## The Aha Moment
+
+This is what makes someone care. Use it in onboarding copy, demos, and introductions.
+
+> You notice your agent keeps structuring responses wrong — or forgetting your conventions for the third time. You correct it. Next session, different tool, different day — the correction is already there. It learned. That's the moment it clicks: your agent is actually getting better at working with *you*.
+
+## Terminology
+
+Use **"agent"** as the primary term in all outward-facing copy. Use "AI" only when referring to the broader category (e.g., "AI tools" as a market). Do **not** qualify with "coding" — open-zk-kb works for any agent, not just coding agents.
+
+| Context | Use |
+|---------|-----|
+| Talking about the user's tool | "your agent" |
+| Referring to the market / category | "AI tools," "agents" |
+| Generic plural | "agents" |
+| Never | "AI assistant," "coding agent," "LLM," "the model" (in user-facing copy) |
+
+## Audience
+
+People who work with agents daily — and anyone curious about what that looks like.
+
+This includes:
+- Developers who use agents daily and feel the memory gap
+- Tech leads evaluating agent tooling for their team
+- Non-technical users who rely on agents for research, writing, or workflows
+- Anyone who's corrected their agent for the same thing twice and felt the frustration
+
+**Assume they're smart but don't assume they know MCP, Zettelkasten, or how embedding search works.** Explain outcomes, not plumbing.
+
+## Voice Principles
+
+### 1. Confident — from experience, not authority
+State what the tool does plainly. No hedging ("might help," "could potentially," "aims to"). This solves a real problem — say so. But speak from lived use, not a pedestal.
+
+- ✅ "Your agent remembers your preferences, decisions, and project context."
+- ❌ "This tool might help your AI assistant potentially remember some context."
+
+### 2. Direct, not terse
+Get to the point. Use short sentences. But don't sacrifice clarity for brevity — if something needs a sentence to explain, give it a sentence.
+
+- ✅ "One knowledge base shared across Claude Code, Cursor, Windsurf, and Zed."
+- ❌ "Cross-client KB via MCP stdio transport layer."
+
+### 3. Second person — talk to the reader
+Use "you" and "your." This is about their workflow, their frustration, their improvement.
+
+- ✅ "Your agent forgets everything between sessions. This fixes that."
+- ❌ "AI assistants lack persistent memory across sessions."
+
+### 4. Show the frustration, not just the problem
+Don't just name the problem — make it feel familiar. The reader should think "yeah, exactly" before you offer the fix.
+
+- ✅ "You open a new session and your agent has no idea who you are. Again. You re-explain your stack, your conventions, that one edge case you've corrected five times."
+- ❌ "AI assistants forget context between sessions."
+
+### 5. Plain language over jargon
+If a simpler word works, use it. Technical terms are fine when they're the right tool — but never to sound impressive. However, keep the technical terms discoverable — people search for them even if they shouldn't be the first thing they read.
+
+| In copy, avoid | In copy, prefer | Keep in metadata (SEO, keywords, topics) |
+|----------------|-----------------|------------------------------------------|
+| Zettelkasten method | structured notes / atomic notes | zettelkasten, zettelkasten-ai |
+| knowledge management system | memory, knowledge base | knowledge-management |
+| MCP server | works with your agent tools | mcp, mcp-server, model-context-protocol |
+| FTS5 + embeddings | hybrid search / finds what's relevant | fts5, embeddings, semantic-search |
+| dual storage model | human-readable files backed by a fast index | sqlite |
+| stdio transport | runs locally, no server needed | — |
+| Obsidian plugin | browse your notes visually | obsidian, knowledge-graph |
+
+**Principle**: Jargon in the metadata, plain language in the copy. Someone finds you through "zettelkasten AI tool" but reads "your agent doesn't learn from you" when they land.
+
+**Exception**: In developer docs and architecture docs, use precise technical terms freely. The simplification applies to outward-facing copy (README, landing pages, descriptions). A "deeper dive" section near the bottom of the README or landing page can use these terms for readers who already know them.
+
+### 6. Speak from the inside
+Write like someone who uses this daily, not someone describing it from the outside. Use specific, lived-in details over generic ones.
+
+- ✅ "Tired of re-explaining that weird build flag? Store it once."
+- ❌ "Store your preferences and project context for future reference."
+
+## Key Messages
+
+Use these as building blocks. Mix and match per context.
+
+### The Problem
+- Your agent starts from zero every session — no memory, no learning curve.
+- You correct the same mistakes, re-explain the same conventions, re-teach the same context.
+- Switching tools means starting over — your Cursor agent doesn't know what your Claude agent learned.
+
+### The Solution
+- Persistent memory your agent checks automatically, every session.
+- Corrections, preferences, decisions, gotchas — stored once, applied everywhere.
+- One knowledge base shared across every agent tool you use.
+
+### The Payoff
+- Correct it once. It sticks.
+- Your agent gets sharper the longer you use it — for *your* specific workflow.
+- Context compounds — what you teach it once, it knows forever.
+
+### The Differentiators
+- Works across Claude Code, Cursor, Windsurf, OpenCode, and Zed.
+- Local-first — no API keys, no cloud, works offline.
+- Human-readable — plain Markdown files you can browse in Obsidian.
+- Open source, MIT licensed.
+
+## Formatting Rules
+
+1. **Headlines are outcomes, not features.** "Your agent remembers" > "Persistent storage layer"
+2. **Bullet points are punchy.** One idea per bullet. No run-on bullets.
+3. **Code examples are real.** Never show hypothetical output. Show actual MCP calls.
+4. **No exclamation marks.** Confidence doesn't shout.
+5. **No emoji in body copy.** OK in changelogs, commit messages, and status badges.
+
+## Contexts
+
+### GitHub Repo Description (one line)
+> Your agent doesn't learn from you. This fixes that. Persistent memory across Claude Code, Cursor, Windsurf, and more.
+
+### README Opener
+> You open a new session and your agent has no idea who you are. Again. open-zk-kb gives your agent a memory — so corrections stick, context compounds, and every session starts smarter than the last.
+
+### Casual Explanation (to a friend)
+> "You know how every new chat, you have to re-explain your whole project? And your agent keeps making the same mistakes you've already corrected? I built the thing that fixes that. You correct it once, it remembers. And it gets better the more you use it."
+
+### Technical Pitch (to developers)
+> "It's an MCP server that gives agents persistent, structured memory. Local SQLite + Markdown, hybrid search, works across five clients. Your agent checks it every message — preferences, decisions, gotchas, corrections, all there."
+
+## What We Don't Say
+
+- ❌ "Knowledge management system" — sounds like enterprise middleware
+- ❌ "Zettelkasten-based" as a lead — it's an implementation detail, not a feature
+- ❌ "Might," "could," "aims to," "helps to" — hedging language
+- ❌ "Powerful," "robust," "cutting-edge" — empty adjectives
+- ❌ "AI-powered" — everything is AI-powered, this means nothing
+- ❌ "Second brain" — overused, and this is your *agent's* brain, not yours
+- ❌ "AI assistant" — use "agent" (see Terminology section)

--- a/README.md
+++ b/README.md
@@ -5,35 +5,50 @@
 [![npm downloads](https://img.shields.io/npm/dm/open-zk-kb)](https://www.npmjs.com/package/open-zk-kb)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools — so context persists across sessions and clients.
+You open a new session and your agent has no idea who you are. Again. You re-explain your stack, your conventions, that one edge case you've corrected five times.
 
-## Demo
+open-zk-kb gives your agent a memory — so corrections stick, context compounds, and every session starts smarter than the last.
 
 <p align="center">
   <img src="assets/demo.gif" alt="open-zk-kb demo" width="640">
   <br>
-  <sub>Real MCP calls — store, search, and stats run against a live knowledge base.</sub>
-</p>
-
-<p align="center">
-  <img src="assets/obsidian-home.png" alt="Knowledge Base in Obsidian" width="640">
-  <br>
-  <sub>Browse your knowledge base in Obsidian — homepage dashboard with project stats and navigation.</sub>
+  <sub>Your agent stores what it learns and searches it next session — automatically.</sub>
 </p>
 
 ## Why open-zk-kb?
 
-AI assistants forget everything between sessions. open-zk-kb gives your assistant a persistent, structured memory it queries automatically.
+Your agent starts from zero every session. No memory, no learning curve. You correct the same mistakes, re-explain the same conventions, re-teach the same context. Switch tools and it's even worse — your Cursor agent doesn't know what your Claude agent learned.
 
-- **Hybrid search** — full-text + [local embeddings](docs/configuration.md#embeddings-local-first), so only relevant notes surface
-- **Atomic notes** — one concept per note ([9 kinds](docs/note-lifecycle.md#note-kinds--defaults), [lifecycle management](docs/note-lifecycle.md)) keeps results precise
-- **Local-first** — no API keys, works offline, scales to thousands of notes
-- **Human-readable** — Markdown + YAML frontmatter, [rebuildable from files](docs/architecture.md#dual-storage-model)
-- **Obsidian-native** — [browse your knowledge graph](docs/obsidian.md), navigate by kind, and explore connections visually
-- **Shared memory across tools** — one knowledge base for [OpenCode, Claude Code, Cursor, Windsurf, and Zed](docs/setup-guide.md)
-- **MIT-licensed**
+open-zk-kb fixes that.
 
-## Quick Start
+- **Correct it once, it sticks** — your agent stores corrections, preferences, and decisions. Next session, it already knows.
+- **Works across every tool** — one knowledge base shared by [Claude Code, Cursor, Windsurf, OpenCode, and Zed](docs/setup-guide.md)
+- **Finds what's relevant** — hybrid search matches meaning, not just keywords, so only useful context surfaces
+- **Runs locally** — no API keys, no cloud, works offline. Your data stays on your machine.
+- **Human-readable** — plain Markdown files [you can browse, edit, and version control](docs/architecture.md#dual-storage-model)
+- **Open source** — MIT licensed
+
+## How it works
+
+1. **You install it** — one command, picks up your client automatically
+2. **Your agent stores what it learns** — corrections, preferences, decisions, gotchas, workflows
+3. **Next session, it searches first** — relevant context surfaces before your agent writes a single line
+
+Your agent gets sharper the longer you use it — for *your* specific workflow.
+
+## Browse your notes in Obsidian
+
+Your knowledge base is a fully themed [Obsidian](https://obsidian.md) vault — homepage dashboard, kind-based folders with icons, breadcrumb navigation, and quick-add buttons. No manual setup.
+
+<p align="center">
+  <img src="assets/obsidian-home.png" alt="Knowledge base in Obsidian" width="640">
+  <br>
+  <sub>Homepage with project stats, navigation, and your full knowledge graph.</sub>
+</p>
+
+See the [Obsidian Guide](docs/obsidian.md) for the full walkthrough.
+
+## Quick start
 
 > **Requires [Bun](https://bun.sh)** — install with `curl -fsSL https://bun.sh/install | bash`
 
@@ -43,37 +58,34 @@ bunx open-zk-kb@latest
 
 That's it. The interactive installer:
 1. Adds the MCP server to your client config
-2. Installs knowledge base instructions (skill for Claude Code, managed block for OpenCode/Windsurf)
+2. Installs knowledge base instructions so your agent knows when and how to use it
 3. Creates a local vault at `~/.local/share/open-zk-kb`
 
 Supported clients: **OpenCode**, **Claude Code**, **Cursor**, **Windsurf**, **Zed**
 
-See the [Setup Guide](docs/setup-guide.md) for manual installation, client-specific configs, and troubleshooting.
+See the [Setup Guide](docs/setup-guide.md) for manual installation and troubleshooting.
 
 ## Configuration
 
-Zero configuration required. The installer creates `~/.config/open-zk-kb/config.yaml` with sensible defaults — local embeddings work out of the box with no API key.
+Zero configuration required. Local embeddings work out of the box with no API key.
 
-See the [Configuration Reference](docs/configuration.md) for embeddings, vault path, lifecycle tuning, and Obsidian scaffold options.
+See the [Configuration Guide](docs/configuration.md) for embeddings, vault path, lifecycle tuning, and Obsidian scaffold options.
 
-## Development
+## Under the hood
 
-```bash
-git clone https://github.com/mrosnerr/open-zk-kb
-cd open-zk-kb
-bun install && bun run build
-bun run setup            # interactive installer
-```
+Built on the Zettelkasten method — atomic, linked notes with structured kinds. Each note captures one concept (a decision, a preference, a gotcha) and links to related notes, building an interconnected knowledge graph.
+
+Search combines SQLite FTS5 full-text indexing with local vector embeddings (MiniLM-L6-v2) for semantic matching. Markdown files are the source of truth; the database is a rebuildable index.
 
 ## Documentation
 
-- [Setup Guide](docs/setup-guide.md) — installation, manual config, client-specific setup, troubleshooting
+- [Setup Guide](docs/setup-guide.md) — installation, client-specific setup, troubleshooting
 - [Tools Reference](docs/tools-reference.md) — all 8 MCP tools with parameters and examples
-- [Note Lifecycle](docs/note-lifecycle.md) — 9 note kinds, statuses, review system, promotion
-- [Configuration](docs/configuration.md) — embeddings, vault, logging, Obsidian scaffold
-- [Obsidian Guide](docs/obsidian.md) — managed scaffold, 14 plugins, navigation, screenshots
+- [Note Lifecycle](docs/note-lifecycle.md) — note kinds, statuses, review system
+- [Configuration](docs/configuration.md) — embeddings, vault, Obsidian scaffold
+- [Obsidian Guide](docs/obsidian.md) — managed scaffold, plugins, navigation
 - [Architecture](docs/architecture.md) — dual storage, ownership model, design decisions
-- [Development](docs/development.md) — local dev, testing, debugging, adding tools
+- [Development](docs/development.md) — local dev, testing, debugging
 - [Contributing](.github/CONTRIBUTING.md) — guidelines for contributors
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## System Overview
 
-Shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools — so context persists across sessions and clients. Implemented as a Model Context Protocol (MCP) server, any MCP-compatible client (OpenCode, Claude Code, Cursor, Windsurf, Zed) can interact with the same atomic, linked notes.
+Persistent memory for agents, built on atomic linked notes. One knowledge base for all your tools — so context persists across sessions and clients. Implemented as a Model Context Protocol (MCP) server, any MCP-compatible client (OpenCode, Claude Code, Cursor, Windsurf, Zed) can interact with the same atomic, linked notes.
 
 Knowledge capture is driven by the calling agent's instructions (e.g., a Claude Code skill, `AGENTS.md`, or global rules), which guide the model to use the `knowledge-store` tool when relevant information is encountered.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,7 +82,7 @@ Not recorded:
 
 ## Obsidian Vault Scaffold
 
-[`knowledge-open`](tools-reference.md#knowledge-open) scaffolds a polished Obsidian vault experience on first launch. See the [Obsidian Guide](obsidian.md) for the full walkthrough.
+[`knowledge-open`](tools-reference.md) scaffolds a polished Obsidian vault experience on first launch. See the [Obsidian Guide](obsidian.md) for the full walkthrough.
 
 - Minimal theme
 - Community plugin bundle (Breadcrumbs, Homepage, QuickAdd, Commander, Templater, Minimal Settings, OZ Calendar, Read Only View)

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,7 @@
 # Development Guide
 
+Everything you need to contribute to open-zk-kb or run it from source.
+
 ## Prerequisites
 - Bun >= 1.0.0 (required — Node.js is NOT compatible). See [Setup Guide](setup-guide.md) for user-facing installation.
 - Git

--- a/docs/note-lifecycle.md
+++ b/docs/note-lifecycle.md
@@ -1,13 +1,13 @@
 # Note Lifecycle
 
-In `open-zk-kb`, notes are not static documents. They follow a dynamic lifecycle — evolving from temporary captures to validated knowledge, and eventually to a searchable archive.
+Your agent's memory isn't static. It evolves. In `open-zk-kb`, notes move from quick captures to validated knowledge, keeping your context lean and relevant. Older notes stay searchable when you need the history.
 
 ## Why one concept per note?
 
-Each note in open-zk-kb captures a single idea. This "atomic note" approach (inspired by the [Zettelkasten method](https://en.wikipedia.org/wiki/Zettelkasten)) is particularly effective for AI agents:
+Each note in open-zk-kb captures a single idea. This "atomic note" approach (inspired by the [Zettelkasten method](https://en.wikipedia.org/wiki/Zettelkasten)) is particularly effective for agents:
 
 - **Precise retrieval** — search returns exactly what's relevant, not a wall of loosely related text
-- **Context window efficiency** — 10 focused notes cost far fewer tokens than a 500-line rules file where 90% is irrelevant
+- **Keeps context lean** — 10 focused notes cost far fewer tokens than a 500-line rules file where 90% is irrelevant
 - **Independent aging** — one note can be promoted or archived without affecting others
 - **Composability** — small typed notes combine naturally across searches to build a complete picture
 
@@ -15,9 +15,9 @@ Each note in open-zk-kb captures a single idea. This "atomic note" approach (ins
 
 Every note in the system exists in one of three states:
 
-1.  **Fleeting**: Temporary captures, initial thoughts, or context-specific snippets. These are the "inbox" of your knowledge base. They are surfaced for review frequently to ensure they either graduate to permanent status or are retired.
-2.  **Permanent**: Validated, high-value knowledge. These notes have proven their utility through repeated access or are foundational to your workflow (like architectural decisions).
-3.  **Archived**: Notes that are no longer active but remain valuable for historical context. They are retired from the primary review queue but remain fully searchable.
+1.  **Fleeting**: Quick captures, first thoughts, or context-specific snippets. Think of these as the inbox for your knowledge base. They surface for review often so you can promote what matters and retire what doesn't.
+2.  **Permanent**: Validated knowledge your agent should keep close. These notes have proven useful through repeated access or anchor your workflow, like architectural decisions.
+3.  **Archived**: Notes you don't need in active rotation anymore, but still want for history. They leave the main review queue and stay fully searchable.
 
 ## Note Kinds & Defaults
 

--- a/docs/obsidian.md
+++ b/docs/obsidian.md
@@ -1,6 +1,6 @@
 # Obsidian Guide
 
-Your knowledge base is a fully functional [Obsidian](https://obsidian.md) vault. The [`knowledge-open`](tools-reference.md#knowledge-open) MCP tool launches it with a managed scaffold that configures a theme, plugins, navigation, and styling — no manual setup required.
+Your knowledge base isn't just for agents — you can browse it too. It's a fully functional [Obsidian](https://obsidian.md) vault. The [`knowledge-open`](tools-reference.md) MCP tool launches it with a managed scaffold that configures a theme, plugins, navigation, and styling — no manual setup required.
 
 For installation, see the [Setup Guide](setup-guide.md). For configuration options, see the [Obsidian Vault Scaffold](configuration.md#obsidian-vault-scaffold) section. Notes are organized into [9 kinds with lifecycle management](note-lifecycle.md).
 
@@ -19,7 +19,7 @@ On first launch the scaffold creates the `.obsidian/` directory with all plugins
 <p align="center">
   <img src="../assets/obsidian-home.png" alt="Knowledge Base homepage" width="720">
   <br>
-  <sub>Homepage dashboard with project stats and navigation</sub>
+  <sub>Everything at a glance: your projects, note counts, and quick navigation</sub>
 </p>
 
 ### Homepage Dashboard
@@ -57,7 +57,7 @@ Icons appear in the sidebar (via [Iconic](https://github.com/gfxholo/iconic)) an
 <p align="center">
   <img src="../assets/obsidian-preferences.png" alt="Preferences page with breadcrumbs and actions" width="720">
   <br>
-  <sub>Breadcrumb trail, kind icon, description callout, and action buttons</sub>
+  <sub>See where you are, what kind of note you're viewing, and what you can do next</sub>
 </p>
 
 ### Inline Action Buttons
@@ -149,7 +149,7 @@ obsidian:
 
 Set `readOnly: false` if you want to edit notes directly in Obsidian rather than through MCP tools.
 
-## Design Principles
+## How It Works Under the Hood
 
 - **Core notes stay markdown-native** — no Obsidian-specific markup in knowledge notes (decisions, procedures, references, etc.)
 - **Navigation notes can be richer** — `index`, `log`, and `review` files use Dataview, Inline Callouts, and plugin metadata because they are human-facing surfaces

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -1,6 +1,6 @@
 # Setup Guide
 
-This guide covers installation for all supported clients. For configuration details, see [configuration.md](configuration.md). For the full tool inventory, see the [Tools Reference](tools-reference.md).
+Get your agent remembering in under a minute. This guide covers installation for all supported clients. For configuration details, see [configuration.md](configuration.md). For the full tool inventory, see the [Tools Reference](tools-reference.md).
 
 ## Prerequisites
 - [Bun](https://bun.sh) >= 1.0.0 (required — uses `bun:sqlite` for storage)
@@ -71,7 +71,7 @@ See the [Development Guide](development.md#development-setup) for the full contr
 ## Verify Installation
 1. Restart your editor/client.
 2. Optionally run `bunx open-zk-kb@latest doctor --client <name>` to verify the local install. Add `--fix` to repair safe issues automatically.
-3. Ask your assistant: **"Run `knowledge-maintain stats`"**
+3. Ask your agent: **"Run `knowledge-maintain stats`"**
 4. You should see vault statistics (0 notes on fresh install). This confirms the 8 tools are available:
    - `knowledge-store` -- save notes to the knowledge base
    - `knowledge-search` -- full-text search across notes
@@ -84,7 +84,7 @@ See the [Development Guide](development.md#development-setup) for the full contr
 
 ## Agent Instructions
 
-During installation, open-zk-kb delivers knowledge base instructions to clients that support it. The delivery mechanism varies by client:
+During installation, open-zk-kb delivers knowledge base instructions to clients that support it. These instructions teach your agent when to search, what to store, and how to keep memory useful across sessions. The delivery mechanism varies by client:
 
 | Client | Mechanism | Location |
 |--------|-----------|----------|
@@ -92,7 +92,7 @@ During installation, open-zk-kb delivers knowledge base instructions to clients 
 | OpenCode | Managed block | `~/.config/opencode/AGENTS.md` |
 | Windsurf | Managed block | `~/.codeium/windsurf/memories/global_rules.md` |
 
-Cursor and Zed get the MCP server config automatically, but do not currently receive agent instructions.
+Cursor and Zed get the MCP server config automatically, but don't currently receive agent instructions.
 
 ### Claude Code (Skill)
 
@@ -219,7 +219,7 @@ bunx open-zk-kb@latest uninstall --client opencode --remove-vault --confirm
 | Dry run first | Add `--dry-run` to any setup command to preview changes without applying them |
 
 ## For AI Agents -- Integration Checklist
-This section is specifically for AI coding assistants setting up open-zk-kb:
+This section is specifically for agents setting up open-zk-kb:
 1. Run `bun --version` -- confirm >= 1.0.0 (if missing: `curl -fsSL https://bun.sh/install | bash`)
 2. Run `bunx open-zk-kb@latest install --client <detected-client>`
 3. Instruct user to restart their editor

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-open-zk-kb exposes eight MCP tools. Your AI assistant calls these automatically based on injected [instructions](setup-guide.md#agent-instructions) — you rarely need to invoke them manually.
+open-zk-kb exposes eight MCP tools. Your agent calls these automatically based on injected [instructions](setup-guide.md#agent-instructions) — you rarely need to invoke them manually.
 
 | Tool | What it does |
 |------|-------------|

--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,8 @@
 # open-zk-kb
 
-> Shared, persistent memory for AI assistants, built on the Zettelkasten method
+> Shared, persistent memory for agents, built on the Zettelkasten method
 
-Shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools — so context persists across sessions and clients. Stores atomic notes (decisions, preferences, patterns, procedures, context) as linked Markdown files with wiki-links, full-text search (SQLite FTS5), and local semantic embeddings.
+Shared, persistent memory for agents, built on the Zettelkasten method. One knowledge base for all your tools — so context persists across sessions and clients. Stores atomic notes (decisions, preferences, patterns, procedures, context) as linked Markdown files with wiki-links, full-text search (SQLite FTS5), and local semantic embeddings.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "open-zk-kb",
   "version": "1.1.0",
   "mcpName": "io.github.mrosnerr/open-zk-kb",
-  "description": "Shared, persistent memory for AI assistants, built on the Zettelkasten method.",
+  "description": "Persistent memory for agents. Corrections stick, context compounds, every session starts smarter.",
   "type": "module",
   "main": "dist/mcp-server.js",
   "types": "dist/mcp-server.d.ts",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,10 +1,10 @@
 # open-zk-kb
 
-Persistent AI memory across sessions. Search context before work, store preferences, decisions, and observations automatically.
+Persistent memory for your agent. Corrections stick, context compounds.
 
 ## What It Does
 
-open-zk-kb gives Claude Code a persistent knowledge base that survives across sessions. Instead of re-explaining your preferences, project decisions, or learned patterns every time, Claude remembers.
+open-zk-kb gives your agent a memory that persists across sessions. Correct it once, it remembers your preferences, decisions, and the patterns you've taught it.
 
 **Example uses:**
 - "Remember I prefer Bun over Node.js" → stored, applied in future sessions

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,5 +1,5 @@
 title: open-zk-kb
-description: Persistent knowledge base for AI coding assistants
+description: Persistent memory for agents. Corrections stick, context compounds.
 url: https://mrosnerr.github.io
 baseurl: /open-zk-kb
 theme: minima

--- a/site/_posts/2026-03-10-why-your-ai-assistant-needs-a-knowledge-base.md
+++ b/site/_posts/2026-03-10-why-your-ai-assistant-needs-a-knowledge-base.md
@@ -1,11 +1,11 @@
 ---
 layout: post
-title: "Why your AI coding assistant needs a knowledge base"
+title: "Why your agent needs a knowledge base"
 date: 2026-03-10
-description: "AI coding assistants forget everything between sessions. Here's how we built a persistent, structured memory using atomic notes, hybrid search, and local embeddings."
+description: "Agents forget everything between sessions. Here's how we built a persistent, structured memory using atomic notes, hybrid search, and local embeddings."
 ---
 
-Every AI coding assistant has the same problem: it forgets.
+Every agent has the same problem: it forgets.
 
 You explain your architecture. You justify your technology choices. You describe your preferences for error handling, naming conventions, testing strategy. And next session? Gone. You start from scratch.
 
@@ -13,23 +13,23 @@ The common workaround is a flat file — `CLAUDE.md`, `.cursorrules`, a rules fi
 
 ## The problem with flat-file memory
 
-Flat files don't scale. At 50 lines, they're fine. At 500 lines, they're burning context window and money on irrelevant information. And they have no concept of relevance — the assistant can't search for what it needs.
+Flat files don't scale. At 50 lines, they're fine. At 500 lines, they're burning context window and money on irrelevant information. And they have no concept of relevance — the agent can't search for what it needs.
 
 They also lack structure. A decision made six months ago sits next to a preference expressed yesterday. There's no way to review, archive, or promote knowledge based on how useful it's proven to be.
 
 ## What we built
 
-[open-zk-kb](https://github.com/mrosnerr/open-zk-kb) is an MCP server that gives AI coding assistants a persistent, structured knowledge base. The key ideas:
+[open-zk-kb](https://github.com/mrosnerr/open-zk-kb) is an MCP server that gives agents a persistent, structured knowledge base. The key ideas:
 
 ### One concept per note
 
 This is the most important design choice. Each note captures a single idea — one decision, one preference, one procedure. Not a document. Not a page of loosely related facts. One thing.
 
-This matters more for AI agents than it does for humans, for a few reasons:
+This matters more for agents than it does for humans, for a few reasons:
 
-1. **Precise retrieval** — when the assistant searches for "how do we handle auth?", it gets back the auth decision note. Not a giant file where auth is mentioned in paragraph 12 alongside database choices and deployment config.
+1. **Precise retrieval** — when the agent searches for "how do we handle auth?", it gets back the auth decision note. Not a giant file where auth is mentioned in paragraph 12 alongside database choices and deployment config.
 
-2. **Context window efficiency** — AI agents pay per token. Loading 10 focused notes that are each 5-10 lines is dramatically cheaper than loading a 500-line rules file where 90% is irrelevant.
+2. **Context window efficiency** — agents pay per token. Loading 10 focused notes that are each 5-10 lines is dramatically cheaper than loading a 500-line rules file where 90% is irrelevant.
 
 3. **Composability** — small, typed notes combine naturally. A search for "React patterns" might return a decision about state management, a procedure for component testing, and a preference for functional components. Each stands alone, but together they paint a complete picture.
 
@@ -39,13 +39,13 @@ This matters more for AI agents than it does for humans, for a few reasons:
 
 Notes aren't all the same. Each one has a **kind** — decision, preference, procedure, reference, resource, or observation — and a **lifecycle status**: fleeting, permanent, or archived.
 
-New knowledge starts as fleeting. If the assistant keeps referencing it, it gets promoted to permanent. If it goes stale, it gets archived. This mirrors how real knowledge works: not everything you learn is worth remembering forever. The system surfaces what matters and lets the rest fade.
+New knowledge starts as fleeting. If the agent keeps referencing it, it gets promoted to permanent. If it goes stale, it gets archived. This mirrors how real knowledge works: not everything you learn is worth remembering forever. The system surfaces what matters and lets the rest fade.
 
-The types help too. When the assistant is about to make an architectural choice, it can search specifically for past decisions. When it's setting up a new workflow, it looks for procedures. The structure makes search results more relevant.
+The types help too. When the agent is about to make an architectural choice, it can search specifically for past decisions. When it's setting up a new workflow, it looks for procedures. The structure makes search results more relevant.
 
 ### Hybrid search: full-text + semantic
 
-When the assistant needs context, it searches — not loads. The search combines two approaches:
+When the agent needs context, it searches — not loads. The search combines two approaches:
 
 1. **Full-text search** for keyword matching — fast, reliable, handles exact terms well
 2. **Local vector embeddings** for semantic similarity — finds related concepts even when the wording differs
@@ -65,12 +65,12 @@ This means your knowledge base is:
 
 ### Agent-driven, not user-driven
 
-The assistant drives everything. The installer injects instructions that teach the assistant to:
+The agent drives everything. The installer injects instructions that teach the agent to:
 - **Search before starting work** — check for relevant context
 - **Store knowledge as it discovers it** — decisions, preferences, patterns
 - **Maintain the knowledge base** — review aging notes, find duplicates, promote useful knowledge
 
-You don't interact with the knowledge base directly (though you can). The assistant learns what to remember and when to recall it.
+You don't interact with the knowledge base directly (though you can). The agent learns what to remember and when to recall it.
 
 ## The technical stack
 
@@ -80,7 +80,7 @@ You don't interact with the knowledge base directly (though you can). The assist
 - **MCP protocol** — works with any MCP-compatible client (Claude Code, Cursor, Windsurf, OpenCode, Zed)
 - **Zero configuration** — `bunx open-zk-kb@latest` handles everything
 
-The approach is inspired by the [Zettelkasten method](https://en.wikipedia.org/wiki/Zettelkasten) — a note-taking system built around atomic, linked notes that was originally designed for human researchers. It turns out the same principles (small notes, typed categories, links between ideas) work even better for AI agents, where context window limits make precision essential.
+The approach is inspired by the [Zettelkasten method](https://en.wikipedia.org/wiki/Zettelkasten) — a note-taking system built around atomic, linked notes that was originally designed for human researchers. It turns out the same principles (small notes, typed categories, links between ideas) work even better for agents, where context window limits make precision essential.
 
 ## What's next
 

--- a/site/index.md
+++ b/site/index.md
@@ -3,29 +3,27 @@ layout: home
 title: open-zk-kb
 ---
 
-# Shared, persistent memory for AI assistants
+# Your agent doesn't learn from you. This fixes that.
 
-Shared, persistent memory for AI assistants, built on the Zettelkasten method. One knowledge base for all your tools — so context persists across sessions and clients.
-
-It gives your assistant a **structured, searchable knowledge base** it queries automatically — so your preferences, decisions, and context persist across every conversation.
+You correct the same mistakes, re-explain the same conventions, re-teach the same context — every session. open-zk-kb gives your agent a memory that persists, so corrections stick and every session starts smarter than the last.
 
 ## How it works
 
 1. **Install in one command** — `bunx open-zk-kb@latest`
-2. **Your assistant stores knowledge** — decisions, preferences, patterns, procedures
+2. **Your agent stores what it learns** — corrections, preferences, decisions, gotchas
 3. **Next session, it searches first** — relevant context surfaces automatically
 
-Notes are Markdown files with YAML frontmatter. A SQLite index provides full-text search, with local vector embeddings for semantic matching. No API key needed. No cloud required.
+Your agent gets sharper the longer you use it — for *your* specific workflow.
 
-## Key features
+## What you get
 
-- **Hybrid search** — full-text + semantic embeddings, so results match meaning not just keywords
-- **Atomic notes** — one concept per note, typed (9 kinds) with lifecycle management (fleeting, permanent, archived)
-- **Local-first** — everything stays on your machine, no API keys required
-- **Multi-client** — Claude Code, Cursor, Windsurf, OpenCode, Zed
-- **Human-readable** — Markdown files you can browse, edit, and version control
-- **Rebuild from files** — database is an index; your `.md` files are the source of truth
-- **MIT licensed** — use it however you want
+- **Corrections that stick** — fix something once, your agent remembers across sessions and tools
+- **Works across every tool** — one knowledge base shared by Claude Code, Cursor, Windsurf, OpenCode, and Zed
+- **Finds what's relevant** — hybrid search matches meaning, not just keywords
+- **Runs locally** — no API keys, no cloud, your data stays on your machine
+- **Human-readable** — plain Markdown files you can browse, edit, and version control
+- **Browse in Obsidian** — fully themed vault with dashboard, navigation, and quick-add buttons
+- **Open source** — MIT licensed
 
 ## Quick start
 
@@ -33,7 +31,7 @@ Notes are Markdown files with YAML frontmatter. A SQLite index provides full-tex
 bunx open-zk-kb@latest
 ```
 
-The interactive installer adds the MCP server to your client and injects instructions that teach your assistant when and how to use the knowledge base.
+The interactive installer picks up your client, adds the MCP server, and injects instructions so your agent knows when and how to use the knowledge base.
 
 ## Learn more
 


### PR DESCRIPTION
## Summary

Full brand refresh across all public-facing documentation. Establishes BRAND.md as the canonical voice guide and applies it consistently to every outward-facing file.

## What changed

- **New BRAND.md** — core positioning ("your agent doesn't learn from you" / "correct it once, it sticks"), agent-general terminology, discoverability policy (jargon in metadata, plain language in copy), voice principles
- **Removed SOUL.md** — consolidated into global guidance + BRAND.md
- **README.md** — full rewrite with pain/payoff opener, Obsidian spotlight, "under the hood" for technical readers
- **All docs/** — voice pass with value-prop intros, "AI assistant" → "agent" terminology, conversational tone
- **site/index.md, site/_config.yml, blog post** — aligned with new positioning
- **plugin/README.md** — brand voice alignment
- **package.json, llms.txt, CONTRIBUTING.md** — terminology updates
- **Fixed 2 broken `#knowledge-open` anchors** in configuration.md and obsidian.md

## Key decisions

- **"Agent" not "AI assistant"** — more precise, implies an entity that should learn
- **Agent-general, not coding-specific** — open-zk-kb works for any agent, not just coding agents
- **Jargon in metadata, plain language in copy** — Zettelkasten, MCP, FTS5 stay in keywords/topics for SEO but don't lead in user-facing text
- **Blog post filename preserved** — content updated but URL slug unchanged to avoid breaking links

## Files touched (17)

BRAND.md (new), README.md, AGENTS.md, package.json, llms.txt, site/index.md, site/_config.yml, site/_posts/*, plugin/README.md, .github/CONTRIBUTING.md, docs/architecture.md, docs/configuration.md, docs/development.md, docs/note-lifecycle.md, docs/obsidian.md, docs/setup-guide.md, docs/tools-reference.md