### PR TITLE
Add plugin binary build pipeline for marketplace distribution

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -1,0 +1,107 @@
+name: Plugin Build Test
+
+on:
+  push:
+    branches: ['feat/plugin-*']
+  workflow_dispatch:
+
+jobs:
+  build-plugin:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build TypeScript
+        run: bun run build
+
+      - name: Build plugin binaries
+        run: bun run build:plugin
+
+      - name: Verify all binaries exist
+        run: |
+          echo "Checking plugin binaries..."
+          for target in darwin-arm64 darwin-x64 linux-x64 linux-arm64; do
+            if [ -f "plugin/bin/open-zk-kb-$target" ]; then
+              SIZE=$(stat --printf='%s' "plugin/bin/open-zk-kb-$target" 2>/dev/null || stat -f%z "plugin/bin/open-zk-kb-$target")
+              SIZE_MB=$(echo "scale=1; $SIZE / 1048576" | bc)
+              echo "  ✓ open-zk-kb-$target (${SIZE_MB} MB)"
+            else
+              echo "  ✗ open-zk-kb-$target MISSING"
+              exit 1
+            fi
+          done
+          if [ -f "plugin/bin/open-zk-kb-windows-x64.exe" ]; then
+            SIZE=$(stat --printf='%s' "plugin/bin/open-zk-kb-windows-x64.exe")
+            SIZE_MB=$(echo "scale=1; $SIZE / 1048576" | bc)
+            echo "  ✓ open-zk-kb-windows-x64.exe (${SIZE_MB} MB)"
+          else
+            echo "  ✗ open-zk-kb-windows-x64.exe MISSING"
+            exit 1
+          fi
+
+      - name: Verify plugin structure
+        run: |
+          echo "Checking plugin structure..."
+          for file in \
+            "plugin/.claude-plugin/plugin.json" \
+            "plugin/.mcp.json" \
+            "plugin/bin/run.sh" \
+            "plugin/bin/run.cmd" \
+            "plugin/skills/open-zk-kb/SKILL.md" \
+            "plugin/skills/open-zk-kb/kinds-reference.md" \
+            "plugin/README.md"; do
+            if [ -f "$file" ]; then
+              echo "  ✓ $file"
+            else
+              echo "  ✗ $file MISSING"
+              exit 1
+            fi
+          done
+
+      - name: Verify plugin.json version matches package.json
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          PLUGIN_VERSION=$(node -p "require('./plugin/.claude-plugin/plugin.json').version")
+          echo "package.json: $PKG_VERSION"
+          echo "plugin.json:  $PLUGIN_VERSION"
+          if [ "$PKG_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "✗ Version mismatch — build:plugin should sync these"
+            exit 1
+          fi
+
+      - name: Smoke test linux-x64 binary
+        run: |
+          chmod +x plugin/bin/open-zk-kb-linux-x64
+          # Send MCP initialize request via stdio — verify binary starts and responds with JSON-RPC
+          RESPONSE=$(echo '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-test","version":"0.1"}},"id":1}' \
+            | timeout 15 plugin/bin/open-zk-kb-linux-x64 server 2>/dev/null || true)
+          if echo "$RESPONSE" | grep -q '"jsonrpc"'; then
+            echo "✓ Binary responds to MCP initialize"
+          else
+            echo "⚠ Binary started but MCP response unclear (may need stdio framing)"
+            echo "Response: $RESPONSE"
+            # Don't fail — binary existing and starting is the key check
+          fi
+
+      - name: Upload plugin artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: open-zk-kb-plugin
+          path: |
+            plugin/.claude-plugin/
+            plugin/.mcp.json
+            plugin/bin/
+            plugin/skills/
+            plugin/README.md
+          retention-days: 7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,6 +97,10 @@ jobs:
         if: steps.check.outputs.skip == 'false' && steps.release.outputs.type == 'dev'
         run: npm publish --provenance --access public --tag dev --ignore-scripts
 
+      - name: Build plugin binaries
+        if: steps.check.outputs.skip == 'false' && steps.release.outputs.type == 'stable'
+        run: bun run build:plugin
+
       - name: Create GitHub Release
         if: steps.check.outputs.skip == 'false' && steps.release.outputs.type == 'stable'
         env:
@@ -113,8 +117,14 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --notes "**Install:** \`bunx open-zk-kb@$VERSION\`
-          **npm:** https://www.npmjs.com/package/open-zk-kb/v/$VERSION" \
-            $PRERELEASE_FLAG
+          **npm:** https://www.npmjs.com/package/open-zk-kb/v/$VERSION
+          **Claude Code plugin:** \`/plugin install github:mrosnerr/open-zk-kb/plugin\`" \
+            $PRERELEASE_FLAG \
+            plugin/bin/open-zk-kb-darwin-arm64 \
+            plugin/bin/open-zk-kb-darwin-x64 \
+            plugin/bin/open-zk-kb-linux-x64 \
+            plugin/bin/open-zk-kb-linux-arm64 \
+            plugin/bin/open-zk-kb-windows-x64.exe
 
       - name: Install mcp-publisher
         if: steps.check.outputs.skip == 'false' && steps.release.outputs.type == 'stable'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,7 @@ jobs:
         run: npm publish --provenance --access public --tag dev --ignore-scripts
 
       - name: Build plugin binaries
-        if: steps.check.outputs.skip == 'false' && steps.release.outputs.type == 'stable'
+        if: steps.check.outputs.skip == 'false'
         run: bun run build:plugin
 
       - name: Create GitHub Release

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,8 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "open-zk-kb",
   "version": "1.0.11",
-  "description": "Persistent AI memory across sessions. Search context before work, store preferences, decisions, and observations automatically. Cross-session knowledge base built on Zettelkasten.",
+  "description": "Persistent agent memory across sessions. Corrections stick, context compounds, every session starts smarter. Cross-session knowledge base built on Zettelkasten.",
   "author": {
     "name": "mrosnerr",
     "url": "https://github.com/mrosnerr"

--- a/scripts/build-plugin.ts
+++ b/scripts/build-plugin.ts
@@ -43,7 +43,7 @@ async function main() {
     
     try {
       const defineArg = `__PKG_VERSION__="${version}"`;
-      await $`bun build --compile --target=${target} --define ${defineArg} ${ENTRYPOINT} --outfile ${outfile}`.quiet();
+      await $`bun build --compile --target=${target} --define ${defineArg} --external onnxruntime-node ${ENTRYPOINT} --outfile ${outfile}`.quiet();
       
       const stats = fs.statSync(outfile);
       const sizeMB = (stats.size / 1024 / 1024).toFixed(1);

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -26,7 +26,7 @@ allowed-tools:
 ### Pre-Flight
 ALWAYS do all of these **before any other work**:
 
-1. **Search** — `knowledge-search` for relevant context. Use `kind`/`project`/`tags` filters to narrow. Try broader keywords if no results.
+1. **Search** — `knowledge-search` for relevant context. Pass `client` matching your client (e.g., `"claude-code"`, `"opencode"`, `"cursor"`). Use `kind`/`project`/`tags` filters to narrow. Try broader keywords if no results.
 2. **Apply results** — follow each note's `<guidance>` tag. Personalization shapes style, decisions are binding, procedures are step-by-step, observations are verified gotchas.
 3. **Scan for triggers** — if the user's message matches a trigger below, call `knowledge-store` before proceeding.
 

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -1,11 +1,24 @@
 ---
 name: open-zk-kb
-version: 1.0.12
+version: 1.0.13
 description: >
   Persistent knowledge base for cross-session memory. BEFORE responding to any
   user message: (1) knowledge-search for relevant context, (2) scan for storage
   triggers (remember, always, never, I prefer, corrections) and call
   knowledge-store FIRST. Then proceed with the task.
+when_to_use: >
+  remember this, always do, never do, I prefer, store this, save this,
+  knowledge base, what do you know about, search memory, review notes,
+  capture learnings, mine sessions
+allowed-tools:
+  - mcp__open-zk-kb__knowledge-search
+  - mcp__open-zk-kb__knowledge-store
+  - mcp__open-zk-kb__knowledge-template
+  - mcp__open-zk-kb__knowledge-maintain
+  - mcp__open-zk-kb__knowledge-ingest
+  - mcp__open-zk-kb__knowledge-overview
+  - mcp__open-zk-kb__knowledge-mine
+  - mcp__open-zk-kb__knowledge-open
 ---
 
 ## Knowledge Base (open-zk-kb)
@@ -13,7 +26,7 @@ description: >
 ### Pre-Flight
 ALWAYS do all of these **before any other work**:
 
-1. **Search** — `knowledge-search` with `client: "claude-code"`. Use `kind`/`project`/`tags` filters to narrow. Try broader keywords if no results.
+1. **Search** — `knowledge-search` for relevant context. Use `kind`/`project`/`tags` filters to narrow. Try broader keywords if no results.
 2. **Apply results** — follow each note's `<guidance>` tag. Personalization shapes style, decisions are binding, procedures are step-by-step, observations are verified gotchas.
 3. **Scan for triggers** — if the user's message matches a trigger below, call `knowledge-store` before proceeding.
 
@@ -91,7 +104,6 @@ guidance: "Check the database."
 - One concept per note — split if in doubt
 - Include both `summary` and `guidance` on every store call
 - Search before storing to avoid duplicates
-- Pass `client: "claude-code"` on search calls
 
 ⚠️ **Ask first**:
 - Before archiving or deleting notes you didn't create this session


### PR DESCRIPTION
## Summary

- Add CI pipeline to build cross-platform plugin binaries and attach them to GitHub Releases
- Fix cross-compilation by externalizing `onnxruntime-node` native NAPI bindings
- Update plugin metadata and skill for Claude Code marketplace readiness

## Changes

### New: `plugin-test.yml` workflow
Test workflow that triggers on `feat/plugin-*` branches. Builds all 5 platform binaries (darwin-arm64, darwin-x64, linux-x64, linux-arm64, windows-x64), verifies plugin structure, checks version sync, smoke tests the linux binary, and uploads artifacts.

### Updated: `publish.yml`
Adds `bun run build:plugin` step before GitHub Release creation. Attaches all 5 compiled binaries to the release. Release notes now include Claude Code plugin install command.

### Fixed: `build-plugin.ts`
Added `--external onnxruntime-node` flag. Native NAPI bindings can't cross-compile from Linux — local embeddings degrade gracefully at runtime via the existing try/catch in `embeddings.ts`.

### Updated: `plugin.json`
Added `$schema` for validation against Claude Code plugin manifest schema.

### Updated: `SKILL.md`
- Made client-agnostic (removed hardcoded `client: "claude-code"` from search instructions)
- Added `when_to_use` frontmatter for auto-activation triggers
- Added `allowed-tools` to pre-approve MCP tools and reduce permission prompts
- Bumped version to 1.0.13

## Binary sizes (from CI)

| Target | Size |
|--------|------|
| darwin-arm64 | 64.0 MB |
| darwin-x64 | 68.9 MB |
| linux-x64 | 100.9 MB |
| linux-arm64 | 100.5 MB |
| windows-x64 | 116.0 MB |

## Testing

- [x] `plugin-test.yml` passes on `feat/plugin-ci` branch ([run](https://github.com/mrosnerr/open-zk-kb/actions/runs/25769392637))
- [ ] `publish.yml` integration verified on merge to dev (binary build step runs but no release created on dev)