### PR TITLE
Add WASM embeddings support for compiled plugin binaries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
+        "onnxruntime-web": "1.25.0-dev.20260327-722743c0e2",
         "picocolors": "^1.1.1",
         "turndown": "^7.2.4",
         "yaml": "^2.3.4",
@@ -416,7 +417,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
+    "onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
 
     "onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
 
@@ -552,7 +553,7 @@
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
+    "onnxruntime-node/onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@mozilla/readability": "^0.6.0",
     "linkedom": "^0.18.12",
+    "onnxruntime-web": "1.25.0-dev.20260327-722743c0e2",
     "picocolors": "^1.1.1",
     "turndown": "^7.2.4",
     "yaml": "^2.3.4"

--- a/patches/@huggingface+transformers.patch
+++ b/patches/@huggingface+transformers.patch
@@ -1,0 +1,158 @@
+diff --git a/node_modules/@huggingface/transformers/src/backends/onnx.js b/node_modules/@huggingface/transformers/src/backends/onnx.js
+--- a/node_modules/@huggingface/transformers/src/backends/onnx.js
++++ b/node_modules/@huggingface/transformers/src/backends/onnx.js
+@@ -20,7 +20,7 @@ import { env, apis, LogLevel } from '../env.js';
+ 
+ // NOTE: Import order matters here. We need to import `onnxruntime-node` before `onnxruntime-web`.
+ // In either case, we select the default export if it exists, otherwise we use the named export.
+-import * as ONNX_NODE from 'onnxruntime-node';
++const ONNX_NODE = undefined;
+ import * as ONNX_WEB from 'onnxruntime-web/webgpu';
+ import { loadWasmBinary, loadWasmFactory } from './utils/cacheWasm.js';
+ import { isBlobURL, toAbsoluteURL } from '../utils/hub/utils.js';
+@@ -106,33 +106,9 @@ if (ORT_SYMBOL in globalThis) {
+     ONNX = globalThis[ORT_SYMBOL];
+ } else if (apis.IS_NODE_ENV) {
+-    ONNX = ONNX_NODE;
+-
+-    // Updated as of ONNX Runtime 1.23.0-dev.20250612-70f14d7670
+-    // The following table lists the supported versions of ONNX Runtime Node.js binding provided with pre-built binaries.
+-    // | EPs/Platforms         | Windows x64        | Windows arm64      | Linux x64          | Linux arm64        | MacOS x64          | MacOS arm64        |
+-    // | --------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+-    // | CPU                   | ✔️                  | ✔️                  | ✔️                  | ✔️                  | ✔️                  | ✔️                  |
+-    // | WebGPU (experimental) | ✔️                  | ✔️                  | ✔️                  | ❌                  | ✔️                  | ✔️                  |
+-    // | DirectML              | ✔️                  | ✔️                  | ❌                  | ❌                  | ❌                  | ❌                  |
+-    // | CUDA                  | ❌                  | ❌                  | ✔️ (CUDA v12)       | ❌                  | ❌                  | ❌                  |
+-    // | CoreML                | ❌                  | ❌                  | ❌                  | ❌                  | ✔️                  | ✔️                  |
+-    switch (process.platform) {
+-        case 'win32': // Windows x64 and Windows arm64
+-            supportedDevices.push('dml');
+-            break;
+-        case 'linux': // Linux x64 and Linux arm64
+-            if (process.arch === 'x64') {
+-                supportedDevices.push('cuda');
+-            }
+-            break;
+-        case 'darwin': // MacOS x64 and MacOS arm64
+-            supportedDevices.push('coreml');
+-            break;
+-    }
+-
+-    supportedDevices.push('webgpu');
+-    supportedDevices.push('cpu');
+-    defaultDevices = ['cpu'];
++    ONNX = ONNX_WEB;
++
++    supportedDevices.push('wasm');
++    defaultDevices = ['wasm'];
+ } else {
+     ONNX = ONNX_WEB;
+ 
+diff --git a/node_modules/@huggingface/transformers/src/utils/image.js b/node_modules/@huggingface/transformers/src/utils/image.js
+--- a/node_modules/@huggingface/transformers/src/utils/image.js
++++ b/node_modules/@huggingface/transformers/src/utils/image.js
+@@ -14,7 +14,7 @@ import { Tensor } from './tensor.js';
+ import { saveBlob } from './io.js';
+ 
+ // Will be empty (or not used) if running in browser or web-worker
+-import sharp from 'sharp';
++const sharp = undefined;
+ import { logger } from './logger.js';
+ 
+ let createCanvasFunction;
+@@ -48,7 +48,9 @@ if (apis.IS_WEB_ENV) {
+         return newImage;
+     };
+ } else {
+-    throw new Error('Unable to load image processing library.');
++    loadImageFunction = async () => {
++        throw new Error('Image processing is unavailable in this build.');
++    };
+ }
+ 
+ // Defined here: https://github.com/python-pillow/Pillow/blob/a405e8406b83f8bfb8916e93971edc7407b8b1ff/src/libImaging/Imaging.h#L262-L268
+diff --git a/node_modules/@huggingface/transformers/src/utils/model-loader.js b/node_modules/@huggingface/transformers/src/utils/model-loader.js
+--- a/node_modules/@huggingface/transformers/src/utils/model-loader.js
++++ b/node_modules/@huggingface/transformers/src/utils/model-loader.js
+@@ -45,7 +45,7 @@ export async function getCoreModelFile(pretrained_model_name_or_path, name, opti
+     const baseName = `${name}${suffix}.onnx`;
+     const fullPath = `${options.subfolder ?? ''}/${baseName}`;
+ 
+-    return await getModelFile(pretrained_model_name_or_path, fullPath, true, options, apis.IS_NODE_ENV);
++    return await getModelFile(pretrained_model_name_or_path, fullPath, true, options, false);
+ }
+ 
+ /**
+@@ -70,5 +70,5 @@ export async function getModelDataFiles(
+     const baseName = `${name}${suffix}.onnx`;
+-    const return_path = apis.IS_NODE_ENV;
++    const return_path = false;
+ 
+     /** @type {Promise<string|{path: string, data: Uint8Array}>[]} */
+     let externalDataPromises = [];
+diff --git a/node_modules/@huggingface/transformers/dist/transformers.node.mjs b/node_modules/@huggingface/transformers/dist/transformers.node.mjs
+--- a/node_modules/@huggingface/transformers/dist/transformers.node.mjs
++++ b/node_modules/@huggingface/transformers/dist/transformers.node.mjs
+@@ -7542,6 +7542,6 @@ var float16ToFloat32 = (() => {
+ 
+ // src/backends/onnx.js
+-import * as ONNX_NODE from "onnxruntime-node";
++const ONNX_NODE = undefined;
+ 
+ // ../../node_modules/.pnpm/onnxruntime-web@1.25.0-dev.20260327-722743c0e2/node_modules/onnxruntime-web/dist/ort.webgpu.bundle.min.mjs
+ var ort_webgpu_bundle_min_exports = {};
+@@ -11557,23 +11557,9 @@ var ORT_SYMBOL = /* @__PURE__ */ Symbol.for("onnxruntime");
+ if (ORT_SYMBOL in globalThis) {
+   ONNX = globalThis[ORT_SYMBOL];
+ } else if (apis.IS_NODE_ENV) {
+-  ONNX = ONNX_NODE;
+-  switch (process.platform) {
+-    case "win32":
+-      supportedDevices.push("dml");
+-      break;
+-    case "linux":
+-      if (process.arch === "x64") {
+-        supportedDevices.push("cuda");
+-      }
+-      break;
+-    case "darwin":
+-      supportedDevices.push("coreml");
+-      break;
+-  }
+-  supportedDevices.push("webgpu");
+-  supportedDevices.push("cpu");
+-  defaultDevices = ["cpu"];
++  ONNX = ort_webgpu_bundle_min_exports;
++  supportedDevices.push("wasm");
++  defaultDevices = ["wasm"];
+ } else {
+   ONNX = ort_webgpu_bundle_min_exports;
+   if (apis.IS_WEBNN_AVAILABLE) {
+@@ -17728,6 +17714,6 @@ var AutomaticSpeechRecognitionPipeline = class extends ChunkPipeline {
+ 
+ // src/utils/image.js
+-import sharp from "sharp";
++const sharp = undefined;
+ var createCanvasFunction;
+ var ImageDataClass;
+ var loadImageFunction;
+@@ -17751,6 +17737,8 @@ if (apis.IS_WEB_ENV) {
+     return newImage;
+   };
+ } else {
+-  throw new Error("Unable to load image processing library.");
++  loadImageFunction = async () => {
++    throw new Error("Image processing is unavailable in this build.");
++  };
+ }
+ var RESAMPLING_MAPPING = {
+@@ -22396,3 +22384,3 @@
+   const fullPath = `${options.subfolder ?? ""}/${baseName}`;
+-  return await getModelFile(pretrained_model_name_or_path, fullPath, true, options, apis.IS_NODE_ENV);
++  return await getModelFile(pretrained_model_name_or_path, fullPath, true, options, false);
+ }
+@@ -22401,3 +22389,3 @@
+-  const return_path = apis.IS_NODE_ENV;
++  const return_path = false;
+   let externalDataPromises = [];
+   const num_chunks = resolveExternalDataFormat(use_external_data_format, baseName, name);

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "open-zk-kb",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Persistent agent memory across sessions. Corrections stick, context compounds, every session starts smarter. Cross-session knowledge base built on Zettelkasten.",
   "author": {
     "name": "mrosnerr",

--- a/scripts/build-plugin.ts
+++ b/scripts/build-plugin.ts
@@ -79,13 +79,24 @@ function runPatch(reverse = false): void {
   cleanupPatchArtifacts();
 }
 
-function needsTransformersPatch(): boolean {
+function applyTransformersPatch(): boolean {
   if (isTransformersPatchApplied()) {
     console.log('  Transformers patch already applied');
     return false;
   }
 
-  return true;
+  console.log('  Applying Transformers WASM patch...');
+  try {
+    runPatch();
+    return true;
+  } catch (error) {
+    try {
+      runPatch(true);
+    } catch (restoreError) {
+      console.error(`Failed to restore Transformers source after patch failure: ${restoreError instanceof Error ? restoreError.message : String(restoreError)}`);
+    }
+    throw error;
+  }
 }
 
 async function main() {
@@ -102,11 +113,7 @@ async function main() {
   let shouldRestoreTransformers = false;
 
   try {
-    shouldRestoreTransformers = needsTransformersPatch();
-    if (shouldRestoreTransformers) {
-      console.log('  Applying Transformers WASM patch...');
-      runPatch();
-    }
+    shouldRestoreTransformers = applyTransformersPatch();
 
     // Ensure plugin/bin directory exists
     fs.mkdirSync(PLUGIN_BIN, { recursive: true });

--- a/scripts/build-plugin.ts
+++ b/scripts/build-plugin.ts
@@ -20,6 +20,75 @@ const PLUGIN_BIN = path.join(PLUGIN_DIR, 'bin');
 const PLUGIN_SKILLS = path.join(PLUGIN_DIR, 'skills', 'open-zk-kb');
 const SOURCE_SKILLS = path.join(ROOT, 'skills', 'open-zk-kb');
 const ENTRYPOINT = path.join(ROOT, 'src', 'mcp-server.ts');
+const TRANSFORMERS_PATCH = path.join(ROOT, 'patches', '@huggingface+transformers.patch');
+const TRANSFORMERS_ONNX = path.join(ROOT, 'node_modules', '@huggingface', 'transformers', 'src', 'backends', 'onnx.js');
+const TRANSFORMERS_IMAGE = path.join(ROOT, 'node_modules', '@huggingface', 'transformers', 'src', 'utils', 'image.js');
+const TRANSFORMERS_MODEL_LOADER = path.join(ROOT, 'node_modules', '@huggingface', 'transformers', 'src', 'utils', 'model-loader.js');
+const TRANSFORMERS_DIST = path.join(ROOT, 'node_modules', '@huggingface', 'transformers', 'dist', 'transformers.node.mjs');
+const PATCHED_TRANSFORMERS_FILES = [TRANSFORMERS_ONNX, TRANSFORMERS_IMAGE, TRANSFORMERS_MODEL_LOADER, TRANSFORMERS_DIST];
+
+function cleanupPatchArtifacts(): void {
+  for (const file of PATCHED_TRANSFORMERS_FILES) {
+    fs.rmSync(`${file}.orig`, { force: true });
+    fs.rmSync(`${file}.rej`, { force: true });
+  }
+}
+
+function isTransformersPatchApplied(): boolean {
+  if (
+    !fs.existsSync(TRANSFORMERS_ONNX)
+    || !fs.existsSync(TRANSFORMERS_IMAGE)
+    || !fs.existsSync(TRANSFORMERS_MODEL_LOADER)
+    || !fs.existsSync(TRANSFORMERS_DIST)
+  ) {
+    return false;
+  }
+
+  const onnxSource = fs.readFileSync(TRANSFORMERS_ONNX, 'utf-8');
+  const imageSource = fs.readFileSync(TRANSFORMERS_IMAGE, 'utf-8');
+  const modelLoaderSource = fs.readFileSync(TRANSFORMERS_MODEL_LOADER, 'utf-8');
+  const distSource = fs.readFileSync(TRANSFORMERS_DIST, 'utf-8');
+  return onnxSource.includes('const ONNX_NODE = undefined;')
+    && imageSource.includes('Image processing is unavailable in this build.')
+    && modelLoaderSource.includes('getModelFile(pretrained_model_name_or_path, fullPath, true, options, false)')
+    && modelLoaderSource.includes('const return_path = false;')
+    && distSource.includes('const ONNX_NODE = undefined;')
+    && distSource.includes('ONNX = ort_webgpu_bundle_min_exports;')
+    && distSource.includes('Image processing is unavailable in this build.')
+    && distSource.includes('getModelFile(pretrained_model_name_or_path, fullPath, true, options, false)')
+    && distSource.includes('const return_path = false;');
+}
+
+function runPatch(reverse = false): void {
+  const args = reverse
+    ? ['-R', '-p1', '-i', TRANSFORMERS_PATCH]
+    : ['-p1', '-i', TRANSFORMERS_PATCH];
+  const result = Bun.spawnSync({
+    cmd: ['patch', ...args],
+    cwd: ROOT,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  if (result.exitCode !== 0) {
+    const stdout = new TextDecoder().decode(result.stdout).trim();
+    const stderr = new TextDecoder().decode(result.stderr).trim();
+    throw new Error(`Failed to ${reverse ? 'reverse' : 'apply'} Transformers patch: ${stderr || stdout}`);
+  }
+
+  cleanupPatchArtifacts();
+}
+
+function applyTransformersPatch(): boolean {
+  if (isTransformersPatchApplied()) {
+    console.log('  Transformers patch already applied');
+    return false;
+  }
+
+  console.log('  Applying Transformers WASM patch...');
+  runPatch();
+  return true;
+}
 
 async function main() {
   // Get version from package.json
@@ -32,46 +101,53 @@ async function main() {
   }
 
   console.log(`Building open-zk-kb v${version} for Claude Code plugin...\n`);
+  const shouldRestoreTransformers = applyTransformersPatch();
 
-  // Ensure plugin/bin directory exists
-  fs.mkdirSync(PLUGIN_BIN, { recursive: true });
+  try {
+    // Ensure plugin/bin directory exists
+    fs.mkdirSync(PLUGIN_BIN, { recursive: true });
 
-  // Build for each target
-  for (const { target, output } of TARGETS) {
-    const outfile = path.join(PLUGIN_BIN, output);
-    console.log(`  Building ${target}...`);
-    
-    try {
-      const defineArg = `__PKG_VERSION__="${version}"`;
-      await $`bun build --compile --target=${target} --define ${defineArg} --external onnxruntime-node ${ENTRYPOINT} --outfile ${outfile}`.quiet();
-      
-      const stats = fs.statSync(outfile);
-      const sizeMB = (stats.size / 1024 / 1024).toFixed(1);
-      console.log(`    ✓ ${output} (${sizeMB} MB)`);
-    } catch (error) {
-      console.error(`    ✗ Failed to build ${target}:`, error);
-      process.exit(1);
+    // Build for each target
+    for (const { target, output } of TARGETS) {
+      const outfile = path.join(PLUGIN_BIN, output);
+      console.log(`  Building ${target}...`);
+
+      try {
+        const defineArg = `__PKG_VERSION__="${version}"`;
+        await $`bun build --compile --target=${target} --define ${defineArg} --external onnxruntime-node --external sharp ${ENTRYPOINT} --outfile ${outfile}`.quiet();
+
+        const stats = fs.statSync(outfile);
+        const sizeMB = (stats.size / 1024 / 1024).toFixed(1);
+        console.log(`    ✓ ${output} (${sizeMB} MB)`);
+      } catch (error) {
+        throw new Error(`Failed to build ${target}: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+      }
+    }
+
+    // Update plugin.json version
+    const pluginJsonPath = path.join(PLUGIN_DIR, '.claude-plugin', 'plugin.json');
+    const pluginJson = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'));
+    pluginJson.version = version;
+    fs.writeFileSync(pluginJsonPath, JSON.stringify(pluginJson, null, 2) + '\n');
+    console.log(`\n  Updated plugin.json version to ${version}`);
+
+    // Copy skills from source to plugin (clean first to remove stale files)
+    console.log('\n  Copying skills...');
+    fs.rmSync(PLUGIN_SKILLS, { recursive: true, force: true });
+    fs.cpSync(SOURCE_SKILLS, PLUGIN_SKILLS, { recursive: true });
+    for (const file of fs.readdirSync(PLUGIN_SKILLS)) {
+      console.log(`    ✓ ${file}`);
+    }
+
+    console.log('\n✓ Plugin build complete!');
+    console.log(`  Binaries: ${PLUGIN_BIN}`);
+    console.log(`  Skills: ${PLUGIN_SKILLS}`);
+  } finally {
+    if (shouldRestoreTransformers) {
+      console.log('\n  Restoring Transformers source...');
+      runPatch(true);
     }
   }
-
-  // Update plugin.json version
-  const pluginJsonPath = path.join(PLUGIN_DIR, '.claude-plugin', 'plugin.json');
-  const pluginJson = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'));
-  pluginJson.version = version;
-  fs.writeFileSync(pluginJsonPath, JSON.stringify(pluginJson, null, 2) + '\n');
-  console.log(`\n  Updated plugin.json version to ${version}`);
-
-  // Copy skills from source to plugin (clean first to remove stale files)
-  console.log('\n  Copying skills...');
-  fs.rmSync(PLUGIN_SKILLS, { recursive: true, force: true });
-  fs.cpSync(SOURCE_SKILLS, PLUGIN_SKILLS, { recursive: true });
-  for (const file of fs.readdirSync(PLUGIN_SKILLS)) {
-    console.log(`    ✓ ${file}`);
-  }
-
-  console.log('\n✓ Plugin build complete!');
-  console.log(`  Binaries: ${PLUGIN_BIN}`);
-  console.log(`  Skills: ${PLUGIN_SKILLS}`);
 }
 
 main().catch((err) => {

--- a/scripts/build-plugin.ts
+++ b/scripts/build-plugin.ts
@@ -79,14 +79,12 @@ function runPatch(reverse = false): void {
   cleanupPatchArtifacts();
 }
 
-function applyTransformersPatch(): boolean {
+function needsTransformersPatch(): boolean {
   if (isTransformersPatchApplied()) {
     console.log('  Transformers patch already applied');
     return false;
   }
 
-  console.log('  Applying Transformers WASM patch...');
-  runPatch();
   return true;
 }
 
@@ -101,9 +99,15 @@ async function main() {
   }
 
   console.log(`Building open-zk-kb v${version} for Claude Code plugin...\n`);
-  const shouldRestoreTransformers = applyTransformersPatch();
+  let shouldRestoreTransformers = false;
 
   try {
+    shouldRestoreTransformers = needsTransformersPatch();
+    if (shouldRestoreTransformers) {
+      console.log('  Applying Transformers WASM patch...');
+      runPatch();
+    }
+
     // Ensure plugin/bin directory exists
     fs.mkdirSync(PLUGIN_BIN, { recursive: true });
 

--- a/src/assets.d.ts
+++ b/src/assets.d.ts
@@ -1,0 +1,9 @@
+declare module '*.mjs' {
+  const path: string;
+  export default path;
+}
+
+declare module '*.wasm' {
+  const path: string;
+  export default path;
+}

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -3,7 +3,11 @@
 // Falls back gracefully when no provider is configured.
 
 import { logToFile } from './logger.js';
+import { wasmBinPath, wasmMjsPath } from './onnx-wasm-paths.js';
 import type { FeatureExtractionPipeline } from '@huggingface/transformers';
+
+type TransformersModule = typeof import('@huggingface/transformers');
+type PipelineOptions = Parameters<TransformersModule['pipeline']>[2];
 
 export interface EmbeddingConfig {
   provider: 'local' | 'api';
@@ -31,6 +35,27 @@ let localPipeline: FeatureExtractionPipeline | null = null;
 let localPipelineLoading: Promise<FeatureExtractionPipeline | null> | null = null;
 let loadedModelName: string | null = null;
 
+function isCompiledBinary(): boolean {
+  return typeof Bun !== 'undefined' && Bun.main?.startsWith('/$bunfs/') === true;
+}
+
+function configureCompiledBinaryWasm(env: TransformersModule['env']): void {
+  if (!isCompiledBinary()) return;
+
+  const ortWasm = env.backends.onnx.wasm;
+  if (!ortWasm) {
+    logToFile('ERROR', 'ONNX WASM backend unavailable in compiled binary');
+    return;
+  }
+
+  ortWasm.numThreads = 1;
+  ortWasm.proxy = false;
+  ortWasm.wasmPaths = {
+    mjs: `file://${wasmMjsPath}`,
+    wasm: `file://${wasmBinPath}`,
+  };
+}
+
 function getModelCacheDir(): string {
   const xdgCache = process.env.XDG_CACHE_HOME || (
     process.env.HOME ? `${process.env.HOME}/.cache` : '/tmp'
@@ -47,7 +72,11 @@ async function getLocalPipeline(modelName: string): Promise<FeatureExtractionPip
     try {
       const { pipeline, env } = await import('@huggingface/transformers');
       env.cacheDir = getModelCacheDir();
-      localPipeline = await pipeline('feature-extraction', modelName, { dtype: 'q8' }) as FeatureExtractionPipeline;
+      configureCompiledBinaryWasm(env);
+      const pipelineOptions: PipelineOptions = isCompiledBinary()
+        ? { dtype: 'q8', device: 'wasm' }
+        : { dtype: 'q8' };
+      localPipeline = await pipeline('feature-extraction', modelName, pipelineOptions) as FeatureExtractionPipeline;
       logToFile('INFO', 'Local embedding model loaded', { model: modelName, cacheDir: env.cacheDir });
       return localPipeline;
     } catch (error) {

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -5,6 +5,7 @@
 import { logToFile } from './logger.js';
 import { wasmBinPath, wasmMjsPath } from './onnx-wasm-paths.js';
 import type { FeatureExtractionPipeline } from '@huggingface/transformers';
+import { pathToFileURL } from 'node:url';
 
 type TransformersModule = typeof import('@huggingface/transformers');
 type PipelineOptions = Parameters<TransformersModule['pipeline']>[2];
@@ -51,8 +52,8 @@ function configureCompiledBinaryWasm(env: TransformersModule['env']): void {
   ortWasm.numThreads = 1;
   ortWasm.proxy = false;
   ortWasm.wasmPaths = {
-    mjs: `file://${wasmMjsPath}`,
-    wasm: `file://${wasmBinPath}`,
+    mjs: pathToFileURL(wasmMjsPath).href,
+    wasm: pathToFileURL(wasmBinPath).href,
   };
 }
 

--- a/src/onnx-wasm-paths.ts
+++ b/src/onnx-wasm-paths.ts
@@ -1,0 +1,4 @@
+import wasmMjsPath from '../node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.asyncify.mjs' with { type: 'file' };
+import wasmBinPath from '../node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.asyncify.wasm' with { type: 'file' };
+
+export { wasmMjsPath, wasmBinPath };

--- a/src/onnx-wasm-paths.ts
+++ b/src/onnx-wasm-paths.ts
@@ -1,4 +1,4 @@
-import wasmMjsPath from '../node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.asyncify.mjs' with { type: 'file' };
-import wasmBinPath from '../node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.asyncify.wasm' with { type: 'file' };
+import wasmMjsPath from 'onnxruntime-web/ort-wasm-simd-threaded.asyncify.mjs' with { type: 'file' };
+import wasmBinPath from 'onnxruntime-web/ort-wasm-simd-threaded.asyncify.wasm' with { type: 'file' };
 
 export { wasmMjsPath, wasmBinPath };


### PR DESCRIPTION
## Summary

- enable local embeddings in compiled Claude Code plugin binaries by switching compiled builds to `onnxruntime-web` (WASM)
- keep the normal `bunx open-zk-kb server` path on native `onnxruntime-node`
- preserve the temporary dev-branch plugin binary build so we can verify the publish workflow before narrowing it back to main-only

## Changes

### WASM backend for compiled binaries
- add `onnxruntime-web` as a production dependency
- add [`src/onnx-wasm-paths.ts`](file:///Users/teal/dev/open-zk-kb/src/onnx-wasm-paths.ts) to embed the ONNX WASM assets with Bun `import ... with { type: \"file\" }`
- update [`src/embeddings.ts`](file:///Users/teal/dev/open-zk-kb/src/embeddings.ts) to detect compiled-binary mode via `Bun.main` and configure Transformers to use `device: \"wasm\"`

### Transformers patching for plugin builds
- add [`patches/@huggingface+transformers.patch`](file:///Users/teal/dev/open-zk-kb/patches/@huggingface+transformers.patch)
- patch both the source and bundled node dist entrypoints so compiled binaries select `onnxruntime-web` instead of `onnxruntime-node`
- force buffer-based model loading and stub `sharp` for compiled plugin builds
- update [`scripts/build-plugin.ts`](file:///Users/teal/dev/open-zk-kb/scripts/build-plugin.ts) to apply the patch before build, externalize `sharp`, and restore `node_modules` afterward

### Type support
- add [`src/assets.d.ts`](file:///Users/teal/dev/open-zk-kb/src/assets.d.ts) for Bun file-asset imports

## Verification

- `bun run build` ✅
- `bun run lint` ✅
- `bun test` ✅ (906 pass, 54 skip, 0 fail)
- `bun run build:plugin` ✅ (all 5 targets built)
- local `open-zk-kb-darwin-arm64` binary responds to MCP initialize ✅
- compiled binary exercised local embeddings via `knowledge-mine` dry-run without `onnxruntime-node` error ✅

## Follow-up

This PR keeps the dev-branch plugin binary build active so the publish workflow can be verified on `dev` before we decide whether to narrow it back to `main` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebAssembly (WASM) runtime support for local embeddings processing, enabling efficient computation in compiled environments
  * Added support for Bun compiled binaries with optimized ONNX runtime configuration

* **Chores**
  * Bumped plugin version to 1.1.0
  * Added ONNX runtime web dependency for improved performance and compatibility
  * Updated build process to support WASM backend configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mrosnerr/open-zk-kb/pull/142)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->