### PR TITLE
Add storage-policy guidance to agent docs

### DIFF
--- a/templates/install/agent-instructions-compact.md
+++ b/templates/install/agent-instructions-compact.md
@@ -2,6 +2,8 @@
 
 ALWAYS use the open-zk-kb MCP tools for persistent memory across sessions.
 
+Use open-zk-kb for cross-session agent memory; use project files for domain research or software docs. When both apply, store concise guidance in the KB and full analysis in project docs.
+
 - **FIRST**: Before every response: (1) `knowledge-search` for relevant context (always pass `client: "{{CLIENT_NAME}}"`), (2) follow each note's `<guidance>` tag, (3) scan for storage triggers (remember, always, never, I prefer, corrections) and call `knowledge-store` BEFORE other work.
 - **Store knowledge**: `knowledge-store` — **one concept per note**, include `summary` and `guidance`. Multiple findings = multiple calls. For structured kinds, `knowledge-template --kind {kind}` shows expected sections (e.g. decision: Context/Options/Decision/Tradeoffs/Consequences).
   - Kinds (target words): personalization (~50), decision (~150), observation (~100), reference (~120), procedure (~150), resource (~50), domain (~500 — project operating manual, one per project). Note: index and log are auto-generated — never create manually.

--- a/templates/install/agent-instructions-compact.md
+++ b/templates/install/agent-instructions-compact.md
@@ -2,7 +2,7 @@
 
 ALWAYS use the open-zk-kb MCP tools for persistent memory across sessions.
 
-Use open-zk-kb for cross-session agent memory; use project files for domain research or software docs. When both apply, store concise guidance in the KB and full analysis in project docs.
+Use open-zk-kb for concise cross-session agent memory. Put full project analysis in the project's existing knowledge location — docs, specs, ADRs, wikis, notes, or another convention. When both apply, store the agent-facing takeaway in the KB and the full project-facing artifact in project-local files.
 
 - **FIRST**: Before every response: (1) `knowledge-search` for relevant context (always pass `client: "{{CLIENT_NAME}}"`), (2) follow each note's `<guidance>` tag, (3) scan for storage triggers (remember, always, never, I prefer, corrections) and call `knowledge-store` BEFORE other work.
 - **Store knowledge**: `knowledge-store` — **one concept per note**, include `summary` and `guidance`. Multiple findings = multiple calls. For structured kinds, `knowledge-template --kind {kind}` shows expected sections (e.g. decision: Context/Options/Decision/Tradeoffs/Consequences).

--- a/templates/install/agent-instructions-full.md
+++ b/templates/install/agent-instructions-full.md
@@ -2,7 +2,7 @@
 
 ALWAYS use the open-zk-kb MCP tools to maintain persistent memory across sessions.
 
-Use open-zk-kb for cross-session agent memory (preferences, gotchas, decisions); use project files for domain research or software docs. When both apply, store concise guidance in the KB and put full analysis in project docs.
+Use open-zk-kb for concise cross-session agent memory: preferences, gotchas, decisions, and reusable guidance. Put full project analysis in the project's existing knowledge location — docs, specs, ADRs, wikis, notes, or another convention. When both apply, store the agent-facing takeaway in the KB and the full project-facing artifact in project-local files.
 
 ### Pre-Flight: Before Responding to Any Message
 

--- a/templates/install/agent-instructions-full.md
+++ b/templates/install/agent-instructions-full.md
@@ -2,6 +2,8 @@
 
 ALWAYS use the open-zk-kb MCP tools to maintain persistent memory across sessions.
 
+Use open-zk-kb for cross-session agent memory (preferences, gotchas, decisions); use project files for domain research or software docs. When both apply, store concise guidance in the KB and put full analysis in project docs.
+
 ### Pre-Flight: Before Responding to Any Message
 
 ALWAYS do both of these **before any other work**:

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -360,6 +360,8 @@ describe('setup.ts', () => {
     expect(content).toContain('OPEN-ZK-KB:END');
     expect(content).toContain('knowledge-search');
     expect(content).toContain('knowledge-store');
+    expect(content).toContain('Use open-zk-kb for cross-session agent memory');
+    expect(content).toContain('use project files for domain research or software docs');
   });
 
   it('install preserves existing content in agent docs file', async () => {
@@ -438,6 +440,8 @@ describe('setup.ts', () => {
     expect(content).toContain('OPEN-ZK-KB:START');
     // Compact version has the triggers line but no "Capture Checkpoints" section
     expect(content).toContain('Triggers');
+    expect(content).toContain('Use open-zk-kb for cross-session agent memory');
+    expect(content).toContain('use project files for domain research or software docs');
     expect(content).not.toContain('Capture Checkpoints');
   });
 

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -360,8 +360,9 @@ describe('setup.ts', () => {
     expect(content).toContain('OPEN-ZK-KB:END');
     expect(content).toContain('knowledge-search');
     expect(content).toContain('knowledge-store');
-    expect(content).toContain('Use open-zk-kb for cross-session agent memory');
-    expect(content).toContain('use project files for domain research or software docs');
+    expect(content).toContain('Use open-zk-kb for concise cross-session agent memory');
+    expect(content).toContain("project's existing knowledge location");
+    expect(content).toContain('docs, specs, ADRs, wikis, notes, or another convention');
   });
 
   it('install preserves existing content in agent docs file', async () => {
@@ -440,8 +441,9 @@ describe('setup.ts', () => {
     expect(content).toContain('OPEN-ZK-KB:START');
     // Compact version has the triggers line but no "Capture Checkpoints" section
     expect(content).toContain('Triggers');
-    expect(content).toContain('Use open-zk-kb for cross-session agent memory');
-    expect(content).toContain('use project files for domain research or software docs');
+    expect(content).toContain('Use open-zk-kb for concise cross-session agent memory');
+    expect(content).toContain("project's existing knowledge location");
+    expect(content).toContain('docs, specs, ADRs, wikis, notes, or another convention');
     expect(content).not.toContain('Capture Checkpoints');
   });
 


### PR DESCRIPTION
## Summary
- Add storage-policy guidance to full and compact managed agent-docs templates
- Cover the new guidance in setup installer tests for both template variants

## Verification
- bun test tests/setup.test.ts
- bun run build
- bun run lint
- bun test

Closes #139