### PR TITLE
Add explicit ./server export for OpenCode plugin resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
       "types": "./dist/opencode-plugin/index.d.ts",
       "import": "./dist/opencode-plugin/index.js"
     },
+    "./server": {
+      "types": "./dist/opencode-plugin/index.d.ts",
+      "import": "./dist/opencode-plugin/index.js"
+    },
     "./mcp-server": {
       "types": "./dist/mcp-server.d.ts",
       "import": "./dist/mcp-server.js"


### PR DESCRIPTION
## Summary
- Adds `exports["./server"]` to `package.json`, pointing to the same OpenCode plugin entrypoint as `exports["."]`

## Problem
OpenCode's plugin loader (`resolvePackageEntrypoint` in `shared.ts`) checks `exports["./server"]` first, then falls back to `main`. Our package only had `exports["."]` — no `"./server"` entry. While the `main` fallback should work (and does for `oh-my-openagent`), the plugin was not loading in practice.

Investigation confirmed:
- The npm package installs correctly in OpenCode's cache
- The module loads and runs correctly under Bun  
- The server function returns valid hooks
- Full lifecycle simulation (session.created → system.transform) produces correct KB context injection
- Yet `plugin-meta.json` has no `open-zk-kb` entry, confirming the plugin never successfully loaded

The most likely cause is that the `main` fallback path either doesn't exist in the installed OpenCode binary (v1.14.50) or fails silently in the `applyPlugin` catch block (which has a `// TODO` comment about error reporting).

## Fix
Add `exports["./server"]` — this is what OpenCode checks first and what most working plugins declare explicitly (`opencode-dynamic-context-pruning`, `opencode-plugin-otel`, `opencode-claude-auth`, `@sveltejs/opencode`, etc.).

## Verification
After merging to `dev` and publishing a new npm version:
1. Clear the OpenCode plugin cache: `rm -rf ~/.cache/opencode/packages/open-zk-kb@dev`
2. Restart OpenCode
3. Check if "Knowledge Base Context" appears in new session system prompts