### PR TITLE
Add Pi and OMP client support with knowledge-get tool

### DIFF
--- a/.agents/plans/discovery-rollout.md
+++ b/.agents/plans/discovery-rollout.md
@@ -33,8 +33,8 @@ Dev is 271 commits ahead — this plan executes AFTER that release lands.
   tagline: Shared persistent memory for AI assistants, built on Zettelkasten
   description: >-
     Zettelkasten-based knowledge base with SQLite FTS5, local embeddings,
-    Markdown files, Obsidian integration, and 8 MCP tools.
-    Works with OpenCode, Claude Code, Cursor, Windsurf, and Zed.
+    Markdown files, Obsidian integration, and 9 MCP tools.
+    Works with OpenCode, Claude Code, Cursor, Windsurf, Zed, Pi, and OMP.
   ```
 - **Why first**: Smallest review queue, OpenCode-native, YAML-only PR
 - **Effort**: 15 min
@@ -43,7 +43,7 @@ Dev is 271 commits ahead — this plan executes AFTER that release lands.
 
 - **Repo**: `punkpeye/awesome-mcp-servers`
 - **Process**: Fork, edit README.md, add entry in Knowledge & Memory section (alphabetical), PR
-- **Format**: `- [mrosnerr/open-zk-kb](https://github.com/mrosnerr/open-zk-kb) 📇 🏠 - Zettelkasten-based persistent memory with SQLite FTS5, local embeddings, Obsidian integration. 8 MCP tools across 5 AI clients.`
+- **Format**: `- [mrosnerr/open-zk-kb](https://github.com/mrosnerr/open-zk-kb) 📇 🏠 - Zettelkasten-based persistent memory with SQLite FTS5, local embeddings, Obsidian integration. 9 MCP tools across 7 AI clients.`
 - **Fast-track**: Add `🤖🤖🤖` to PR title for automated merge
 - **Category**: Knowledge & Memory (159 entries, alphabetical ordering)
 - **Effort**: 20 min
@@ -94,6 +94,14 @@ Submit to whichever are still active at time of execution:
 Batch these — most are "paste URL" submissions.
 - **Effort**: 30 min total
 
+### 3C. OMP Marketplace
+
+- **Docs**: https://omp.sh/docs/extension-authoring → "Ship it through a marketplace"
+- **Format**: Git repo with `.claude-plugin/marketplace.json` catalog
+- **Pre-work**: Migrate `pi` → `omp` key in `package.json` (legacy `pi.extensions` still works but `omp.extensions` is recommended). Handle dual-load concern: if someone installs via both `omp install` AND MCP config, the extension bridge and MCP server would create duplicate tools. Extension should detect OMP and skip tool registration when MCP is already available.
+- **Effort**: 1-2 hours (includes package.json migration + duplicate-detection logic + marketplace catalog PR)
+- **Blocked on**: Resolving the extension vs MCP dual-load conflict first
+
 ---
 
 ## Phase 4: Content (Week 2 post-release)
@@ -107,7 +115,7 @@ Batch these — most are "paste URL" submissions.
   - Zettelkasten as a knowledge structure for agents
   - Dual storage architecture (SQLite + Markdown)
   - Local embeddings without API keys
-  - Multi-client challenge (5 clients, different config formats)
+  - Multi-client challenge (7 clients, different config formats)
 - **Do NOT**: Pitch the project in the intro. Let the engineering speak.
 - **Effort**: 2-4 hours
 

--- a/.agents/plans/discovery-rollout.md
+++ b/.agents/plans/discovery-rollout.md
@@ -1,0 +1,225 @@
+# Discovery Platform Rollout
+
+## Gate
+
+**Blocked until**: `dev` merged to `main` and v1.1.0 published to npm.
+Dev is 271 commits ahead — this plan executes AFTER that release lands.
+
+## Current State (May 2026)
+
+- npm: published (v1.0.11, 656 downloads/month)
+- Everything else: absent
+- Direct competitor `zettelkasten-mcp` (150 stars, Python, less capable) is already listed on awesome-mcp-servers
+
+## Why v1.1.0 First
+
+1. 271 commits of unreleased work — listings should point to the best version
+2. README/docs may change during merge — submission content should be final
+3. One-command install (`bunx open-zk-kb@latest`) should resolve to latest
+
+---
+
+## Phase 1: Awesome Lists (Day 1 post-release)
+
+### 1A. awesome-opencode (6.7K stars)
+
+- **Repo**: `awesome-opencode/awesome-opencode`
+- **Process**: Create YAML file in `data/plugins/`, open PR
+- **File**: `data/plugins/open-zk-kb.yaml`
+- **Content**:
+  ```yaml
+  name: open-zk-kb
+  repo: https://github.com/mrosnerr/open-zk-kb
+  tagline: Shared persistent memory for AI assistants, built on Zettelkasten
+  description: >-
+    Zettelkasten-based knowledge base with SQLite FTS5, local embeddings,
+    Markdown files, Obsidian integration, and 8 MCP tools.
+    Works with OpenCode, Claude Code, Cursor, Windsurf, and Zed.
+  ```
+- **Why first**: Smallest review queue, OpenCode-native, YAML-only PR
+- **Effort**: 15 min
+
+### 1B. awesome-mcp-servers (86.7K stars)
+
+- **Repo**: `punkpeye/awesome-mcp-servers`
+- **Process**: Fork, edit README.md, add entry in Knowledge & Memory section (alphabetical), PR
+- **Format**: `- [mrosnerr/open-zk-kb](https://github.com/mrosnerr/open-zk-kb) 📇 🏠 - Zettelkasten-based persistent memory with SQLite FTS5, local embeddings, Obsidian integration. 8 MCP tools across 5 AI clients.`
+- **Fast-track**: Add `🤖🤖🤖` to PR title for automated merge
+- **Category**: Knowledge & Memory (159 entries, alphabetical ordering)
+- **Effort**: 20 min
+
+---
+
+## Phase 2: MCP Registries (Day 1-2 post-release)
+
+### 2A. Smithery.ai (8.6K servers)
+
+- **Status**: Ghost profile exists (empty page at `smithery.ai/server/mrosnerr/open-zk-kb`)
+- **Fix**: Add `smithery.yaml` to repo root OR publish at `smithery.ai/servers/new`
+- **Competitors present**: Synapse Layer (2,130 uses), DejaView (669), mem0 (139 verified)
+- **Effort**: 20 min
+
+### 2B. Glama.ai (23K servers, 1,198 in Knowledge & Memory)
+
+- **Process**: Click "Add Server" — auto-indexes from GitHub
+- **May need**: proper MCP manifest or `server.json` in repo
+- **Effort**: 10 min
+
+### 2C. mcp.so (20K servers)
+
+- **Process**: Open GitHub issue at `chatmcp/mcpso` with repo URL
+- **Effort**: 10 min
+
+---
+
+## Phase 3: Stretch Targets (Week 1 post-release)
+
+### 3A. GitHub MCP Registry (97 curated servers)
+
+- **Repo**: `modelcontextprotocol/registry`
+- **Process**: PR with server metadata
+- **Reality check**: Very high bar — only 97 servers, mostly major orgs (Microsoft, Stripe, Figma)
+- **Worth attempting**: Yes, but expect rejection. The attempt itself may surface what's needed for future acceptance
+- **Effort**: 30 min
+
+### 3B. Secondary Directories
+
+Submit to whichever are still active at time of execution:
+- mcpservers.org (by wong2)
+- mcprepository.com
+- mcp-hunt.com (Product Hunt style)
+- opentools.com
+- pulsemcp.com (community hub + newsletter)
+
+Batch these — most are "paste URL" submissions.
+- **Effort**: 30 min total
+
+---
+
+## Phase 4: Content (Week 2 post-release)
+
+### 4A. Technical Blog Post
+
+- **Title idea**: "Building Cross-Session Memory for AI Coding Assistants"
+- **Platform**: dev.to or personal blog (cross-post to Hashnode)
+- **Angle**: Technical deep-dive, not marketing. Cover:
+  - Why AI assistants forget (the problem)
+  - Zettelkasten as a knowledge structure for agents
+  - Dual storage architecture (SQLite + Markdown)
+  - Local embeddings without API keys
+  - Multi-client challenge (5 clients, different config formats)
+- **Do NOT**: Pitch the project in the intro. Let the engineering speak.
+- **Effort**: 2-4 hours
+
+### 4B. Plugin for anthropics/financial-services
+
+- **What**: A "persistent memory" plugin that uses open-zk-kb as the backend
+- **Why**: 20K stars, open plugin architecture, financial agents need memory
+- **Format**: Markdown plugin following their `plugins/` structure
+- **Effort**: 1-2 hours
+- **Risk**: May be rejected, but the PR itself gets eyeballs
+
+---
+
+## Checklist (copy to issue when executing)
+
+- [ ] Gate: v1.1.0 released to npm from main
+- [ ] Phase 1A: PR to awesome-opencode
+- [ ] Phase 1B: PR to awesome-mcp-servers
+- [ ] Phase 2A: Smithery listing fixed
+- [ ] Phase 2B: Glama.ai listed
+- [ ] Phase 2C: mcp.so listed
+- [ ] Phase 3A: GitHub MCP Registry PR (stretch)
+- [ ] Phase 3B: Secondary directories batch
+- [ ] Phase 4A: Blog post published
+- [ ] Phase 4B: financial-services plugin PR (stretch)
+
+## Success Metrics (30 days post-rollout)
+
+- Listed on 5+ discovery platforms (from current 1)
+- GitHub stars: 50+ (from 1)
+- npm downloads: 2,000+/month (from 656)
+- At least 1 awesome-list PR merged
+
+---
+
+## Appendix: Competitive Intelligence
+
+### Case Study: OpenAgentsControl (darrenhinde/OpenAgentsControl)
+
+**Stats**: 3,979 stars, 328 forks, created Aug 2025, last commit Mar 25 2026 (stale 7+ weeks).
+
+Investigated to understand how a solo-dev project in the same ecosystem gained ~4K stars.
+
+#### Star Growth Pattern
+
+```
+Aug 2025  repo created
+Oct 31    ⭐ #1         2.5 months to first star
+Dec 30    ⭐ #100       ~2 months
+Jan 19    ⭐ #500       3 weeks ← YouTube-driven acceleration
+Feb 17    ⭐ #1,000     ~1 month
+Mar 28    ⭐ #2,000     ~6 weeks
+May 7     ⭐ #3,000     ~6 weeks (steady)
+May 12    ⭐ #3,979     slowing, no commits in 7 weeks
+```
+
+#### What Drove Growth
+
+1. **YouTube funnel** — "15 Minutes to Fix Your AI Dev Workflow" got 39.9K views (Oct 2025). Built audience before OAC launched, then funneled to repo
+2. **30KB README as sales page** — hero image, problem/solution framing, before/after code, comparison table naming Cursor/Copilot/Aider, explicit "Star the repo ⭐" CTA (twice), social proof badges
+3. **GitHub topic SEO** — 9 topics targeting high-volume searches: `ai-agents`, `ai-agents-framework`, `code-generation`, `developer-tools`, `opencode`
+4. **Ecosystem piggybacking** — rode OpenCode's growth, positioned as "the missing control layer"
+5. **Consistent personal brand** — "DarrenBuildsAI" across YouTube, X, Threads, LinkedIn, GitHub
+6. **Auto-indexed directories** — Context7, DeepWiki, Nerq (84/100), PT-Edge (64/100), Sourcevana, SourcePulse
+
+#### What It Does NOT Have
+
+- awesome-mcp-servers: not listed
+- awesome-opencode: not listed
+- Reddit: zero posts
+- HackerNews: never submitted
+- ProductHunt: no launch
+- Newsletters: not featured
+- npm downloads: ~0 (installs via `curl | bash`)
+- Community contributors: 15 people, mostly 1-commit drive-bys
+- 88.5% of commits from solo author
+
+#### Key Insight
+
+Stars ≠ users. OAC has ~4K stars and ~0 npm downloads. open-zk-kb has 1 star and 656 npm downloads/month. **We have more real users; they have more vanity metrics.** The gap is discovery and marketing, not product quality.
+
+#### Tactics Worth Adopting
+
+| Tactic | Priority | Notes |
+|---|---|---|
+| YouTube demo video | High | One good video drove OAC's entire growth curve |
+| GitHub topic optimization | High | Free. Add `ai-memory`, `cross-session-memory` to existing topics |
+| Comparison table in README | Medium | Names competitors, appears in search results. Risk: can look petty |
+| Hero image in README | Low | Nice-to-have. We already have demo GIF + Obsidian screenshot |
+| Consistent cross-platform brand | Low | Long-term play, not urgent |
+
+#### Tactics to Skip
+
+| Tactic | Why |
+|---|---|
+| 30KB marketing README | Ours is clean and technical. Don't bloat. A separate landing page is better |
+| `curl \| bash` install | We already have `bunx` which is superior |
+| Comparison table trash-talking | OAC's table misrepresents competitors ("Oh My OpenCode: Fully autonomous, No approval gates, High token usage"). Inaccurate comparisons damage trust |
+
+### Case Study: anthropics/financial-services
+
+**Stats**: 20,228 stars, 2,654 forks, created Feb 2026 (~2.5 months old).
+
+#### Why It Has 20K Stars
+
+Pure brand leverage. Anthropic's name = instant credibility and distribution.
+
+- Content is mostly markdown & YAML — plugins, skills, templates. No build step
+- Technically shallow compared to open-zk-kb (no real code, no tests, no CI logic)
+- Has partner integrations (LSEG, S&P Global) that add institutional credibility
+- Targets financial services — high-value audience that amplifies reach
+
+#### Applicable Tactic
+
+- **Build a "persistent memory" plugin for their repo** — their 20K eyeballs, open plugin architecture, financial agents genuinely need cross-session memory. Even a rejected PR gets visibility (Phase 4B in plan)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -70,7 +70,7 @@ src/
 ├── tool-handlers.ts    # Shared handler functions
 ├── storage/            # NoteRepository — SQLite + FTS5 + filesystem
 ├── config.ts           # Configuration loading
-├── setup.ts            # CLI installer for 5 clients
+├── setup.ts            # CLI installer for 7 clients
 └── types.ts            # TypeScript interfaces and types
 ```
 
@@ -118,7 +118,7 @@ PRs are reviewed by automated tools (CodeRabbit, Cubic) and maintainers. Here's 
 
 ## CI Pipeline
 
-All PRs run: build, lint, unit tests, and **smoke tests** (install/uninstall for all 5 clients, MCP protocol verification, and a full KB round-trip).
+All PRs run: build, lint, unit tests, and **smoke tests** (install/uninstall for all 7 clients, MCP protocol verification, and a full KB round-trip).
 
 You can run smoke tests locally:
 ```bash

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,18 @@ opencode.json
 .opencode/agents/*
 !.opencode/agents/reviewer.md
 .claude/
-.sisyphus/
+# Agent runtime state (ephemeral). Plans and other tracked assets stay visible.
+.agents/tmp/
+.agents/cache/
+.agents/local/
+.agents/private/
+.agents/**/.env*
+.agents/**/*secret*
+.agents/**/*secrets*
+.agents/**/*token*
+.agents/**/*credential*
+.agents/**/*.local.md
+.agents/**/*.private.md
 CONTEXT_*.md
 
 # Local test workspace (isolated OpenCode sessions for plugin dev)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ EVAL=1 bun test tests/eval/eval.test.ts --timeout 120000  # Agent eval suite
 | Configuration | `src/config.ts` | YAML config with defaults |
 | Types/interfaces | `src/types.ts` | NoteKind, NoteStatus, Lifecycle, AppConfig |
 | Note rendering | `src/prompts.ts` | XML format for agent consumption |
-| Install/uninstall CLI | `src/setup.ts` | 5 clients: opencode, claude-code, cursor, windsurf, zed |
+| Install/uninstall CLI | `src/setup.ts` | 7 clients: opencode, claude-code, cursor, windsurf, zed, pi, omp |
 | Tests | `tests/` | bun:test with harness + fixtures |
 
 ## Code Map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ For any new feature, ask in order:
 - **CI uses Bun** (`.github/workflows/ci.yml`)
 - **Install via CLI**: `bun run setup install --client <name>` — single mechanism via `src/setup.ts`
 - **Wiki-links**: Obsidian-compatible `[[slug|display]]` format with backlink tracking in `note_links` table
-- **Knowledge capture**: Claude Code and OMP use skills; OpenCode, Windsurf, and Pi use injected managed blocks (`AGENTS.md` or `RULES.md`). Calling models use `knowledge-store` directly.
+- **Knowledge capture**: Claude Code and OMP use skills; OpenCode, Windsurf, and Pi use injected managed blocks (`AGENTS.md` or `rules/`). Calling models use `knowledge-store` directly.
 - **Claude Code skill**: Instructions delivered as a skill at `~/.claude/skills/open-zk-kb/`. Template files in `skills/open-zk-kb/`.
 - **Local embeddings**: MiniLM-L6-v2 (~23MB) enabled by default via `@huggingface/transformers`. No API key required. Opt-in to API embeddings via `config.yaml`.
 - **9 MCP tools**: knowledge-store, knowledge-search, knowledge-get, knowledge-template, knowledge-mine, knowledge-maintain, knowledge-ingest, knowledge-overview, knowledge-open

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,6 @@ For any new feature, ask in order:
 - **Knowledge capture**: Claude Code uses skills (`~/.claude/skills/open-zk-kb/`); other clients use injected `AGENTS.md` instructions. Calling models use `knowledge-store` directly.
 - **Claude Code skill**: Instructions delivered as a skill at `~/.claude/skills/open-zk-kb/`. Template files in `skills/open-zk-kb/`.
 - **Local embeddings**: MiniLM-L6-v2 (~23MB) enabled by default via `@huggingface/transformers`. No API key required. Opt-in to API embeddings via `config.yaml`.
-- **8 MCP tools**: knowledge-store, knowledge-search, knowledge-template, knowledge-mine, knowledge-maintain, knowledge-ingest, knowledge-overview, knowledge-open
+- **9 MCP tools**: knowledge-store, knowledge-search, knowledge-get, knowledge-template, knowledge-mine, knowledge-maintain, knowledge-ingest, knowledge-overview, knowledge-open
 - **Auto-generated notes**: `index` (per-project catalog, wikilinks grouped by kind) and `log` (per-project append-only event log) are auto-generated on project-scoped events. Agents cannot create them manually.
 - **Human vs agent surfaces**: Obsidian is the primary human browsing layer; agents primarily use MCP tools backed by SQLite/indexed metadata rather than navigating raw vault files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ For any new feature, ask in order:
 - **CI uses Bun** (`.github/workflows/ci.yml`)
 - **Install via CLI**: `bun run setup install --client <name>` — single mechanism via `src/setup.ts`
 - **Wiki-links**: Obsidian-compatible `[[slug|display]]` format with backlink tracking in `note_links` table
-- **Knowledge capture**: Claude Code uses skills (`~/.claude/skills/open-zk-kb/`); other clients use injected `AGENTS.md` instructions. Calling models use `knowledge-store` directly.
+- **Knowledge capture**: Claude Code and OMP use skills; OpenCode, Windsurf, and Pi use injected managed blocks (`AGENTS.md` or `RULES.md`). Calling models use `knowledge-store` directly.
 - **Claude Code skill**: Instructions delivered as a skill at `~/.claude/skills/open-zk-kb/`. Template files in `skills/open-zk-kb/`.
 - **Local embeddings**: MiniLM-L6-v2 (~23MB) enabled by default via `@huggingface/transformers`. No API key required. Opt-in to API embeddings via `config.yaml`.
 - **9 MCP tools**: knowledge-store, knowledge-search, knowledge-get, knowledge-template, knowledge-mine, knowledge-maintain, knowledge-ingest, knowledge-overview, knowledge-open

--- a/BRAND.md
+++ b/BRAND.md
@@ -120,7 +120,7 @@ Use these as building blocks. Mix and match per context.
 - Context compounds — what you teach it once, it knows forever.
 
 ### The Differentiators
-- Works across Claude Code, Cursor, Windsurf, OpenCode, and Zed.
+- Works across Claude Code, Cursor, Windsurf, OpenCode, Zed, Pi, and OMP.
 - Local-first — no API keys, no cloud, works offline.
 - Human-readable — plain Markdown files you can browse in Obsidian.
 - Open source, MIT licensed.

--- a/BRAND.md
+++ b/BRAND.md
@@ -145,7 +145,7 @@ Use these as building blocks. Mix and match per context.
 > "You know how every new chat, you have to re-explain your whole project? And your agent keeps making the same mistakes you've already corrected? I built the thing that fixes that. You correct it once, it remembers. And it gets better the more you use it."
 
 ### Technical Pitch (to developers)
-> "It's an MCP server that gives agents persistent, structured memory. Local SQLite + Markdown, hybrid search, works across five clients. Your agent checks it every message — preferences, decisions, gotchas, corrections, all there."
+> "It's an MCP server that gives agents persistent, structured memory. Local SQLite + Markdown, hybrid search, works across seven clients. Your agent checks it every message — preferences, decisions, gotchas, corrections, all there."
 
 ## What We Don't Say
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Your agent starts from zero every session. No memory, no learning curve. You cor
 open-zk-kb fixes that.
 
 - **Correct it once, it sticks** — your agent stores corrections, preferences, and decisions. Next session, it already knows.
-- **Works across every tool** — one knowledge base shared by [Claude Code, Cursor, Windsurf, OpenCode, and Zed](docs/setup-guide.md)
+- **Works across every tool** — one knowledge base shared by [Claude Code, Cursor, Windsurf, OpenCode, Zed, Pi, and OMP](docs/setup-guide.md)
 - **Finds what's relevant** — hybrid search matches meaning, not just keywords, so only useful context surfaces
 - **Runs locally** — no API keys, no cloud, works offline. Your data stays on your machine.
 - **Human-readable** — plain Markdown files [you can browse, edit, and version control](docs/architecture.md#dual-storage-model)
@@ -61,7 +61,7 @@ That's it. The interactive installer:
 2. Installs knowledge base instructions so your agent knows when and how to use it
 3. Creates a local vault at `~/.local/share/open-zk-kb`
 
-Supported clients: **OpenCode**, **Claude Code**, **Cursor**, **Windsurf**, **Zed**
+Supported clients: **OpenCode**, **Claude Code**, **Cursor**, **Windsurf**, **Zed**, **Pi**, **OMP**
 
 See the [Setup Guide](docs/setup-guide.md) for manual installation and troubleshooting.
 
@@ -80,7 +80,7 @@ Search combines SQLite FTS5 full-text indexing with local vector embeddings (Min
 ## Documentation
 
 - [Setup Guide](docs/setup-guide.md) — installation, client-specific setup, troubleshooting
-- [Tools Reference](docs/tools-reference.md) — all 8 MCP tools with parameters and examples
+- [Tools Reference](docs/tools-reference.md) — all 9 MCP tools with parameters and examples
 - [Note Lifecycle](docs/note-lifecycle.md) — note kinds, statuses, review system
 - [Configuration](docs/configuration.md) — embeddings, vault, Obsidian scaffold
 - [Obsidian Guide](docs/obsidian.md) — managed scaffold, plugins, navigation

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,7 +90,7 @@ During setup, open-zk-kb delivers knowledge base instructions to guide the AI to
 * **OpenCode** uses an MCP entry in `~/.config/opencode/opencode.json` plus a managed markdown block injected into `~/.config/opencode/AGENTS.md`. The managed block is wrapped in comment-delimited markers (`<!-- OPEN-ZK-KB:START -->` / `<!-- OPEN-ZK-KB:END -->`). See `injectAgentDocs()` in `src/agent-docs.ts` and the OpenCode helpers in `src/setup.ts`.
 * **Windsurf** uses a managed markdown block injected into `~/.codeium/windsurf/memories/global_rules.md`. Blocks are wrapped in comment-delimited markers (`<!-- OPEN-ZK-KB:START -->` / `<!-- OPEN-ZK-KB:END -->`). See `injectAgentDocs()` in `src/agent-docs.ts`.
 * **Pi** does not support MCP natively. open-zk-kb ships as a Pi package extension (`src/pi/extension.ts`) that bridges the MCP server into Pi-native tools. Managed instructions are injected into `~/.pi/agent/AGENTS.md`.
-* **OMP** uses standard MCP config at `~/.omp/agent/mcp.json`, a skill at `~/.omp/agent/skills/open-zk-kb/`, and a compact managed block in `~/.omp/agent/RULES.md`.
+* **OMP** uses standard MCP config at `~/.omp/agent/mcp.json`, a skill at `~/.omp/agent/skills/open-zk-kb/`, and a compact managed rule file at `~/.omp/agent/rules/open-zk-kb.md` (with YAML frontmatter for `alwaysApply`).
 * **Cursor and Zed** currently receive MCP config only.
 * **Instruction templates**: `templates/agent-instructions-full.md` (~420 tokens) and `templates/agent-instructions-compact.md` (~140 tokens) ship with the package for OpenCode/Windsurf/Pi/OMP. The skill uses its own `SKILL.md` + supporting files in `skills/open-zk-kb/`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ Obsidian plays a separate role: it is the primary human browsing and interaction
 ┌──────────▼──────────┐
 │   MCP Server        │
 │   (mcp-server.ts)   │
-│   - 8 MCP tools     │
+│   - 9 MCP tools     │
 │   - stdio transport │
 └──────────┬──────────┘
            │
@@ -29,6 +29,7 @@ Obsidian plays a separate role: it is the primary human browsing and interaction
 │   (tool-handlers.ts)│
 │   handleStore()     │
 │   handleSearch()    │
+│   handleGet()       │
 │   handleMaintain()  │
 │   handleIngest()    │
 │   handleOverview()  │

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ This distinction is intentional. Core knowledge notes (`decision`, `procedure`, 
 The MCP server provides a reactive interface to the knowledge base:
 
 * **Transport**: Uses `@modelcontextprotocol/sdk` with stdio transport.
-* **Tools**: Registers [eight core tools](tools-reference.md): `knowledge-store`, `knowledge-search`, `knowledge-template`, `knowledge-mine`, `knowledge-maintain`, `knowledge-ingest`, `knowledge-overview`, and `knowledge-open`.
+* **Tools**: Registers [nine core tools](tools-reference.md): `knowledge-store`, `knowledge-search`, `knowledge-get`, `knowledge-template`, `knowledge-mine`, `knowledge-maintain`, `knowledge-ingest`, `knowledge-overview`, and `knowledge-open`.
 * **Initialization**: Uses a lazy singleton pattern where the `NoteRepository` is initialized only upon the first tool call.
 * **Embeddings**: Generated locally by default via `@huggingface/transformers` (WASM backend, no native deps).
     * **Model**: `Xenova/all-MiniLM-L6-v2` (quantized q8, ~23MB).
@@ -89,8 +89,10 @@ During setup, open-zk-kb delivers knowledge base instructions to guide the AI to
 * **Claude Code** uses a native [Claude Code skill](https://code.claude.com/docs/en/skills) installed to `~/.claude/skills/open-zk-kb/`. Claude auto-loads the instructions when it detects KB-related intent (preferences, decisions, lookups). The skill description is always in context (~80 tokens); full instructions load on-demand. See `installSkill()` in `src/setup.ts`.
 * **OpenCode** uses an MCP entry in `~/.config/opencode/opencode.json` plus a managed markdown block injected into `~/.config/opencode/AGENTS.md`. The managed block is wrapped in comment-delimited markers (`<!-- OPEN-ZK-KB:START -->` / `<!-- OPEN-ZK-KB:END -->`). See `injectAgentDocs()` in `src/agent-docs.ts` and the OpenCode helpers in `src/setup.ts`.
 * **Windsurf** uses a managed markdown block injected into `~/.codeium/windsurf/memories/global_rules.md`. Blocks are wrapped in comment-delimited markers (`<!-- OPEN-ZK-KB:START -->` / `<!-- OPEN-ZK-KB:END -->`). See `injectAgentDocs()` in `src/agent-docs.ts`.
+* **Pi** does not support MCP natively. open-zk-kb ships as a Pi package extension (`src/pi/extension.ts`) that bridges the MCP server into Pi-native tools. Managed instructions are injected into `~/.pi/agent/AGENTS.md`.
+* **OMP** uses standard MCP config at `~/.omp/agent/mcp.json`, a skill at `~/.omp/agent/skills/open-zk-kb/`, and a compact managed block in `~/.omp/agent/RULES.md`.
 * **Cursor and Zed** currently receive MCP config only.
-* **Instruction templates**: `templates/agent-instructions-full.md` (~420 tokens) and `templates/agent-instructions-compact.md` (~140 tokens) ship with the package for OpenCode/Windsurf. The skill uses its own `SKILL.md` + supporting files in `skills/open-zk-kb/`.
+* **Instruction templates**: `templates/agent-instructions-full.md` (~420 tokens) and `templates/agent-instructions-compact.md` (~140 tokens) ship with the package for OpenCode/Windsurf/Pi/OMP. The skill uses its own `SKILL.md` + supporting files in `skills/open-zk-kb/`.
 
 ## Configuration Architecture
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -102,7 +102,7 @@ src/
 ├── embeddings.ts       # Vector embedding support
 ├── logger.ts           # File-based logging (never stdout)
 ├── prompts.ts          # Note rendering to XML format
-├── setup.ts            # CLI installer for 5 clients
+├── setup.ts            # CLI installer for 7 clients
 ├── types.ts            # TypeScript interfaces
 └── utils/
     ├── path.ts         # Path expansion, XDG resolution

--- a/docs/development.md
+++ b/docs/development.md
@@ -47,7 +47,7 @@ bun run build
 bun run setup install --client <name> --force
 ```
 
-Replace `<name>` with your client: `opencode`, `claude-code`, `cursor`, `windsurf`, or `zed`.
+Replace `<name>` with your client: `opencode`, `claude-code`, `cursor`, `windsurf`, `zed`, `pi`, or `omp`.
 
 The installer auto-detects the source checkout (via `.git` presence) and wires everything to local paths:
 - **MCP server** → your local `dist/mcp-server.js`
@@ -91,7 +91,7 @@ See [Release Channels](setup-guide.md#release-channels) for more details.
 ```
 src/
 ├── mcp-server.ts       # MCP server entry point (stdio transport)
-├── tool-handlers.ts    # Shared logic for all 8 tools
+├── tool-handlers.ts    # Shared logic for all 9 tools
 ├── storage/
 │   ├── NoteRepository.ts  # Core CRUD, FTS5, link tracking
 │   ├── IndexBuilder.ts    # Auto-generates per-project index notes

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -110,9 +110,9 @@ During installation, open-zk-kb delivers knowledge base instructions to clients 
 | OpenCode | Managed block | `~/.config/opencode/AGENTS.md` |
 | Windsurf | Managed block | `~/.codeium/windsurf/memories/global_rules.md` |
 | Pi | Managed block | `~/.pi/agent/AGENTS.md` |
-| OMP | Skill + Managed block | `~/.omp/agent/skills/open-zk-kb/` + `~/.omp/agent/RULES.md` |
+| OMP | Skill + Managed rule | `~/.omp/agent/skills/open-zk-kb/` + `~/.omp/agent/rules/open-zk-kb.md` |
 
-Cursor and Zed get the MCP server config automatically, but don't currently receive agent instructions. Pi gets a package extension plus managed `AGENTS.md` instructions. OMP gets a skill plus managed `RULES.md` instructions.
+Cursor and Zed get the MCP server config automatically, but don't currently receive agent instructions. Pi gets a package extension plus managed `AGENTS.md` instructions. OMP gets a skill plus a managed rule file at `~/.omp/agent/rules/open-zk-kb.md`.
 
 ### Claude Code (Skill)
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -13,7 +13,7 @@ Run the interactive installer:
 bunx open-zk-kb@latest
 ```
 
-This presents a multi-select prompt — use Space to select clients, Enter to confirm. Supported clients: OpenCode, Claude Code, Cursor, Windsurf, Zed, and Pi.
+This presents a multi-select prompt — use Space to select clients, Enter to confirm. Supported clients: OpenCode, Claude Code, Cursor, Windsurf, Zed, Pi, and OMP.
 
 > **Note**: The installer automatically copies `config.example.yaml` to `~/.config/open-zk-kb/config.yaml` if no config file exists yet. Local embeddings (MiniLM, 23MB) are enabled by default and require no API key.
 
@@ -83,6 +83,7 @@ See the [Development Guide](development.md#development-setup) for the full contr
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
 | Zed | `~/.config/zed/settings.json` |
 | Pi | `~/.pi/agent/settings.json` |
+| OMP | `~/.omp/agent/mcp.json` |
 
 ## Verify Installation
 1. Restart your editor/client.
@@ -109,8 +110,9 @@ During installation, open-zk-kb delivers knowledge base instructions to clients 
 | OpenCode | Managed block | `~/.config/opencode/AGENTS.md` |
 | Windsurf | Managed block | `~/.codeium/windsurf/memories/global_rules.md` |
 | Pi | Managed block | `~/.pi/agent/AGENTS.md` |
+| OMP | Skill + Managed block | `~/.omp/agent/skills/open-zk-kb/` + `~/.omp/agent/RULES.md` |
 
-Cursor and Zed get the MCP server config automatically, but don't currently receive agent instructions. Pi gets a package extension plus managed `AGENTS.md` instructions.
+Cursor and Zed get the MCP server config automatically, but don't currently receive agent instructions. Pi gets a package extension plus managed `AGENTS.md` instructions. OMP gets a skill plus managed `RULES.md` instructions.
 
 ### Claude Code (Skill)
 
@@ -242,4 +244,4 @@ This section is specifically for agents setting up open-zk-kb:
 2. Run `bunx open-zk-kb@latest install --client <detected-client>`
 3. Instruct user to restart their editor
 4. Verify by calling `knowledge-maintain stats`
-5. Knowledge capture is driven by agent instructions (skill for Claude Code, managed block for OpenCode/Windsurf) provided during setup. Calling models use MCP tools directly, primarily querying the SQLite-backed server layer rather than browsing raw vault files.
+5. Knowledge capture is driven by agent instructions (skill for Claude Code and OMP, managed block for OpenCode/Windsurf/Pi, package extension for Pi) provided during setup. Calling models use MCP tools directly, primarily querying the SQLite-backed server layer rather than browsing raw vault files.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -13,9 +13,25 @@ Run the interactive installer:
 bunx open-zk-kb@latest
 ```
 
-This presents a multi-select prompt — use Space to select clients, Enter to confirm. Supported clients: OpenCode, Claude Code, Cursor, Windsurf, Zed.
+This presents a multi-select prompt — use Space to select clients, Enter to confirm. Supported clients: OpenCode, Claude Code, Cursor, Windsurf, Zed, and Pi.
 
 > **Note**: The installer automatically copies `config.example.yaml` to `~/.config/open-zk-kb/config.yaml` if no config file exists yet. Local embeddings (MiniLM, 23MB) are enabled by default and require no API key.
+
+### Pi Installation
+
+Pi does not include native MCP support, so open-zk-kb ships as a Pi package extension that bridges the existing MCP server into Pi-native `knowledge-*` tools:
+
+```bash
+pi install npm:open-zk-kb
+```
+
+The open-zk-kb installer can also wire Pi settings and managed `AGENTS.md` instructions:
+
+```bash
+bunx open-zk-kb@latest install --client pi
+```
+
+Restart Pi after either install path so it can load the package extension.
 
 ### Manual Installation (for any MCP client)
 
@@ -53,7 +69,7 @@ bun run build
 bun run setup install --client <name> --force
 ```
 
-The installer auto-detects the source checkout (via `.git` presence) and wires your client to local paths — the MCP server points at `dist/mcp-server.js`, and agent instructions are injected where the client supports managed instructions.
+The installer auto-detects the source checkout (via `.git` presence) and wires your client to local paths — the MCP server points at `dist/mcp-server.js`, Pi uses the local package path, and agent instructions are injected where the client supports managed instructions.
 
 See the [Development Guide](development.md#development-setup) for the full contributor workflow.
 
@@ -66,12 +82,13 @@ See the [Development Guide](development.md#development-setup) for the full contr
 | Cursor | `~/.cursor/mcp.json` |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
 | Zed | `~/.config/zed/settings.json` |
+| Pi | `~/.pi/agent/settings.json` |
 
 ## Verify Installation
 1. Restart your editor/client.
 2. Optionally run `bunx open-zk-kb@latest doctor --client <name>` to verify the local install. Add `--fix` to repair safe issues automatically.
 3. Ask your agent: **"Run `knowledge-maintain stats`"**
-4. You should see vault statistics (0 notes on fresh install). This confirms the 8 tools are available:
+4. You should see vault statistics (0 notes on fresh install). This confirms the knowledge tools are available:
    - `knowledge-store` -- save notes to the knowledge base
    - `knowledge-search` -- full-text search across notes
    - `knowledge-template` -- canonical note template for a kind
@@ -79,6 +96,7 @@ See the [Development Guide](development.md#development-setup) for the full contr
    - `knowledge-maintain` -- stats, review, promote, archive, rebuild
    - `knowledge-ingest` -- extract article content from URLs or HTML
    - `knowledge-overview` -- project entry point with auto-generated index and recent log
+   - `knowledge-get` -- fetch a specific note by id
    - `knowledge-open` -- open the vault in Obsidian for visual browsing (see [Obsidian Guide](obsidian.md))
 
 ## Agent Instructions
@@ -90,8 +108,9 @@ During installation, open-zk-kb delivers knowledge base instructions to clients 
 | Claude Code | [Skill](https://code.claude.com/docs/en/skills) | `~/.claude/skills/open-zk-kb/SKILL.md` |
 | OpenCode | Managed block | `~/.config/opencode/AGENTS.md` |
 | Windsurf | Managed block | `~/.codeium/windsurf/memories/global_rules.md` |
+| Pi | Managed block | `~/.pi/agent/AGENTS.md` |
 
-Cursor and Zed get the MCP server config automatically, but don't currently receive agent instructions.
+Cursor and Zed get the MCP server config automatically, but don't currently receive agent instructions. Pi gets a package extension plus managed `AGENTS.md` instructions.
 
 ### Claude Code (Skill)
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-open-zk-kb exposes eight MCP tools. Your agent calls these automatically based on injected [instructions](setup-guide.md#agent-instructions) — you rarely need to invoke them manually.
+open-zk-kb exposes nine MCP tools. Your agent calls these automatically based on injected [instructions](setup-guide.md#agent-instructions) — you rarely need to invoke them manually.
 
 | Tool | What it does |
 |------|-------------|
@@ -12,6 +12,7 @@ open-zk-kb exposes eight MCP tools. Your agent calls these automatically based o
 | `knowledge-template` | Get the canonical note template for a specific kind |
 | `knowledge-mine` | Bulk-screen candidates from session history for duplicates and store |
 | `knowledge-open` | Open the vault in [Obsidian](obsidian.md) with a scaffolded theme, plugins, and homepage |
+| [`knowledge-get`](#knowledge-get) | Retrieve a single note by its exact ID |
 
 Notes use [9 kinds with lifecycle management](note-lifecycle.md). For configuration options, see the [Configuration Reference](configuration.md).
 
@@ -275,4 +276,34 @@ Get a project overview combining the auto-generated index (a catalog of all proj
   "project": "my-app",
   "logEntries": 5
 }
+```
+---
+
+## knowledge-get
+
+Retrieve a single note by its exact ID. Faster and more precise than knowledge-search. Use when you already know the note ID (e.g. from search results, context hints, or wikilink references).
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `noteId` | string | Yes | Exact note ID to retrieve |
+| `model` | string | No | Your model identifier. Enables richer responses for capable models |
+
+### What happens
+
+1. Looks up the note by ID in the SQLite index
+2. Returns the full note content in the same format as search results
+3. Returns an error message if no note exists with the given ID
+
+### When to use
+
+- **Following references**: Search results and overview pages contain note IDs. Use `knowledge-get` to retrieve referenced notes without a full search.
+- **After store**: The `knowledge-store` response includes the new note's ID. Use `knowledge-get` to verify or retrieve it later.
+- **Compact rendering hints**: When `renderNoteForAgent` shows a truncated content preview with a hint, use `knowledge-get` with the note's ID to get the full content.
+
+### Example
+
+```json
+{ "noteId": "2026030919130100" }
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -14,7 +14,7 @@ bunx open-zk-kb@latest
 
 The interactive installer adds the MCP server to your client config and installs knowledge base instructions.
 
-## MCP Tools (8 tools)
+## MCP Tools (9 tools)
 
 ### knowledge-search
 Search the knowledge base for relevant context. Uses full-text search (SQLite FTS5) and local semantic embeddings (MiniLM-L6-v2). No API key required.
@@ -77,6 +77,12 @@ Open the knowledge base vault in Obsidian. Detects Obsidian installation, regist
 Parameters:
 - project (string, optional): Project to focus on after opening
 
+### knowledge-get
+Retrieve a single note by its exact ID. Faster and more precise than knowledge-search. Use when you already know the note ID (e.g. from search results or context hints).
+
+Parameters:
+- noteId (string, required): Exact note ID to retrieve
+
 ## Zettelkasten Concepts
 
 The Zettelkasten ("slip box") method stores one atomic concept per note, with explicit links between related ideas. This enables emergent knowledge discovery as the network grows.
@@ -99,7 +105,7 @@ Notes follow the Zettelkasten lifecycle: fleeting (temporary captures) → perma
 
 ## Supported Clients
 
-OpenCode, Claude Code, Cursor, Windsurf, Zed
+OpenCode, Claude Code, Cursor, Windsurf, Zed, Pi, OMP
 
 ## Links
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,16 @@
     "./mcp-server": {
       "types": "./dist/mcp-server.d.ts",
       "import": "./dist/mcp-server.js"
+    },
+    "./pi-extension": {
+      "types": "./dist/pi/extension.d.ts",
+      "import": "./dist/pi/extension.js"
     }
+  },
+  "pi": {
+    "extensions": [
+      "./dist/pi/extension.js"
+    ]
   },
   "sideEffects": false,
   "bin": {
@@ -98,6 +107,8 @@
     "llm",
     "claude-code",
     "opencode",
+    "pi-package",
+    "pi-coding-agent",
     "cursor",
     "windsurf",
     "ai-coding-assistant",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,6 +1,8 @@
 {
-  "open-zk-kb": {
-    "command": "${CLAUDE_PLUGIN_ROOT}/bin/run.sh",
-    "args": ["server"]
+  "mcpServers": {
+    "open-zk-kb": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/run.sh",
+      "args": ["server"]
+    }
   }
 }

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -8,8 +8,8 @@ TypeScript source for the MCP server (`mcp-server.ts`), with core logic in `tool
 
 ```
 src/
-├── mcp-server.ts          # MCP stdio server — 8 tools via @modelcontextprotocol/sdk
-├── tool-handlers.ts       # Shared: handleStore, handleSearch, handleTemplate, handleMine, handleMaintain, handleIngest, handleOverview, handleOpen
+├── mcp-server.ts          # MCP stdio server — 9 tools via @modelcontextprotocol/sdk
+├── tool-handlers.ts       # Shared: handleStore, handleSearch, handleGet, handleTemplate, handleMine, handleMaintain, handleIngest, handleOverview, handleOpen
 ├── storage/
 │   ├── NoteRepository.ts  # Core CRUD + FTS5 + link tracking (~1,370 LOC)
 │   ├── IndexBuilder.ts    # Auto-generates per-project index notes

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -34,7 +34,7 @@ src/
 ```
 Client request → mcp-server.ts
                         ↓
-               tool-handlers.ts (handleStore/Search/Mine/Maintain/Ingest/Overview/Open)
+               tool-handlers.ts (handleStore/Search/Get/Mine/Maintain/Ingest/Overview/Open)
                         ↓
                NoteRepository.store/search/getStats/...
                     ↓              ↓

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -25,7 +25,7 @@ src/
 ├── logger.ts              # logToFile() — file-based, never stdout
 ├── prompts.ts             # renderNoteForAgent() — XML <note> format
 ├── schema.ts              # SchemaManager — PRAGMA user_version (v6)
-├── setup.ts               # CLI install/uninstall for 5 clients (bun run setup)
+├── setup.ts               # CLI install/uninstall for 7 clients (bun run setup)
 └── types.ts               # NoteKind, NoteStatus, Lifecycle, AppConfig
 ```
 

--- a/src/agent-docs-targets.ts
+++ b/src/agent-docs-targets.ts
@@ -7,6 +7,10 @@ export interface AgentDocsTarget {
   name: string;
   filePath: string;
   instructionSize: InstructionSize;
+  /** Content prepended before the managed block when creating the file (e.g. YAML frontmatter for OMP rules) */
+  preamble?: string;
+  /** Stale file path to clean up when migrating to a new location */
+  legacyFilePath?: string;
 }
 
 export function getAgentDocsTargets(): AgentDocsTarget[] {
@@ -35,8 +39,10 @@ export function getAgentDocsTargets(): AgentDocsTarget[] {
     {
       client: 'omp',
       name: 'OMP',
-      filePath: path.join(expandPath('~/.omp/agent'), 'RULES.md'),
+      filePath: path.join(expandPath('~/.omp/agent'), 'rules', 'open-zk-kb.md'),
       instructionSize: 'compact',
+      preamble: '---\nalwaysApply: true\ndescription: Knowledge base (open-zk-kb) persistent memory instructions\n---\n',
+      legacyFilePath: path.join(expandPath('~/.omp/agent'), 'RULES.md'),
     },
   ];
 }

--- a/src/agent-docs-targets.ts
+++ b/src/agent-docs-targets.ts
@@ -3,7 +3,7 @@ import { expandPath } from './utils/path.js';
 import type { InstructionSize } from './agent-docs.js';
 
 export interface AgentDocsTarget {
-  client: 'opencode' | 'windsurf';
+  client: 'opencode' | 'windsurf' | 'omp';
   name: string;
   filePath: string;
   instructionSize: InstructionSize;
@@ -24,6 +24,12 @@ export function getAgentDocsTargets(): AgentDocsTarget[] {
       client: 'windsurf',
       name: 'Windsurf',
       filePath: path.join(expandPath('~/.codeium'), 'windsurf', 'memories', 'global_rules.md'),
+      instructionSize: 'compact',
+    },
+    {
+      client: 'omp',
+      name: 'OMP',
+      filePath: path.join(expandPath('~/.omp/agent'), 'RULES.md'),
       instructionSize: 'compact',
     },
   ];

--- a/src/agent-docs-targets.ts
+++ b/src/agent-docs-targets.ts
@@ -3,7 +3,7 @@ import { expandPath } from './utils/path.js';
 import type { InstructionSize } from './agent-docs.js';
 
 export interface AgentDocsTarget {
-  client: 'opencode' | 'windsurf' | 'omp';
+  client: 'opencode' | 'windsurf' | 'pi' | 'omp';
   name: string;
   filePath: string;
   instructionSize: InstructionSize;
@@ -25,6 +25,12 @@ export function getAgentDocsTargets(): AgentDocsTarget[] {
       name: 'Windsurf',
       filePath: path.join(expandPath('~/.codeium'), 'windsurf', 'memories', 'global_rules.md'),
       instructionSize: 'compact',
+    },
+    {
+      client: 'pi',
+      name: 'Pi',
+      filePath: path.join(expandPath('~/.pi/agent'), 'AGENTS.md'),
+      instructionSize: 'full',
     },
     {
       client: 'omp',

--- a/src/agent-docs.ts
+++ b/src/agent-docs.ts
@@ -200,8 +200,9 @@ function appendManagedBlock(content: string, replacement: string): string {
  * If the file doesn't exist, it is created.
  * Content outside the managed block is preserved.
  * @param version - Version string to embed in the start marker (e.g., "1.0.0")
+ * @param preamble - Content prepended before the managed block when creating the file (e.g. YAML frontmatter)
  */
-export function injectAgentDocs(filePath: string, size: InstructionSize = 'full', dryRun?: boolean, clientName?: string, version?: string): { action: 'created' | 'updated' | 'unchanged'; filePath: string } {
+export function injectAgentDocs(filePath: string, size: InstructionSize = 'full', dryRun?: boolean, clientName?: string, version?: string, preamble?: string): { action: 'created' | 'updated' | 'unchanged'; filePath: string } {
   let existing = '';
   const fileExists = fs.existsSync(filePath);
 
@@ -235,7 +236,7 @@ export function injectAgentDocs(filePath: string, size: InstructionSize = 'full'
     newContent = spliceManagedBlock(existing, template);
     action = 'updated';
   } else {
-    newContent = template + '\n';
+    newContent = (preamble ?? '') + template + '\n';
     action = 'created';
   }
 

--- a/src/client-heuristics.ts
+++ b/src/client-heuristics.ts
@@ -5,7 +5,7 @@
 // to hide notes scoped to other clients during search.
 
 /** Known client identifiers. Used for soft validation — unrecognized clients are warned, not rejected. */
-export const KNOWN_CLIENTS = new Set(['opencode', 'claude-code', 'cursor', 'windsurf', 'zed']);
+export const KNOWN_CLIENTS = new Set(['opencode', 'claude-code', 'cursor', 'windsurf', 'zed', 'omp']);
 
 /** Returns true if the client name is recognized. 'all' is always valid. */
 export function isKnownClient(client: string): boolean {
@@ -19,6 +19,7 @@ export const CLIENT_CONTENT_PATTERNS: Record<string, RegExp[]> = {
   'cursor':      [/\.cursor\//],
   'windsurf':    [/\.codeium\/windsurf\//],
   'zed':         [/\.config\/zed\//],
+  'omp':         [/\.omp\//],
 };
 
 export const CLIENT_TAG_PREFIX = 'client:';

--- a/src/client-heuristics.ts
+++ b/src/client-heuristics.ts
@@ -5,7 +5,7 @@
 // to hide notes scoped to other clients during search.
 
 /** Known client identifiers. Used for soft validation — unrecognized clients are warned, not rejected. */
-export const KNOWN_CLIENTS = new Set(['opencode', 'claude-code', 'cursor', 'windsurf', 'zed', 'omp']);
+export const KNOWN_CLIENTS = new Set(['opencode', 'claude-code', 'cursor', 'windsurf', 'zed', 'pi', 'omp']);
 
 /** Returns true if the client name is recognized. 'all' is always valid. */
 export function isKnownClient(client: string): boolean {
@@ -19,6 +19,7 @@ export const CLIENT_CONTENT_PATTERNS: Record<string, RegExp[]> = {
   'cursor':      [/\.cursor\//],
   'windsurf':    [/\.codeium\/windsurf\//],
   'zed':         [/\.config\/zed\//],
+  'pi':          [/\.pi\//],
   'omp':         [/\.omp\//],
 };
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 // mcp-server.ts - MCP stdio server
-// Exposes knowledge-store, knowledge-search, knowledge-mine, knowledge-maintain as MCP tools.
+// Exposes knowledge-store, knowledge-search, knowledge-get, knowledge-mine, knowledge-maintain as MCP tools.
 // Stdout is the MCP transport — use logToFile() for all logging.
 
 if (typeof globalThis.Bun === 'undefined') {
@@ -340,6 +340,38 @@ server.registerTool(
   },
 );
 
+// ---- knowledge-get ----
+
+const getSchema = z.object({
+  noteId: z.string().describe('Exact note ID to retrieve'),
+  model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
+});
+
+server.registerTool(
+  'knowledge-get',
+  {
+    description: 'Retrieve a single note by its exact ID. Faster and more precise than knowledge-search. Use when you already know the note ID (e.g. from injected context hints).',
+    inputSchema: getSchema as unknown as AnySchema,
+  },
+  async (args: z.infer<typeof getSchema>) => {
+    try {
+      const result = handleGet({
+        noteId: args.noteId,
+        model: args.model,
+      }, await getOrCreateRepo());
+      return { content: [{ type: 'text' as const, text: result }] };
+    } catch (error) {
+      logToFile('ERROR', 'knowledge-get failed', {
+        error: error instanceof Error ? error.message : String(error),
+      }, config);
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+        isError: true,
+      };
+    }
+  },
+);
+
 // ---- knowledge-maintain ----
 
 const maintainSchema = z.object({
@@ -427,32 +459,6 @@ server.registerTool(
       return { content: [{ type: 'text' as const, text: result }] };
     } catch (error) {
       logToFile('ERROR', 'knowledge-mine failed', {
-        error: error instanceof Error ? error.message : String(error),
-      }, config);
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-        isError: true,
-      };
-    }
-  },
-);
-
-const getSchema = z.object({
-  noteId: z.string().describe('Exact note ID to retrieve'),
-});
-
-server.registerTool(
-  'knowledge-get',
-  {
-    description: 'Retrieve a single note by its exact ID. Faster and more precise than knowledge-search. Use when you already know the note ID (e.g. from injected context hints).',
-    inputSchema: getSchema as unknown as AnySchema,
-  },
-  async (args: z.infer<typeof getSchema>) => {
-    try {
-      const result = handleGet({ noteId: args.noteId }, await getOrCreateRepo());
-      return { content: [{ type: 'text' as const, text: result }] };
-    } catch (error) {
-      logToFile('ERROR', 'knowledge-get failed', {
         error: error instanceof Error ? error.message : String(error),
       }, config);
       return {

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -1,0 +1,373 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { StdioServerParameters } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { CompatibilityCallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+
+interface JsonSchema {
+  type: 'object';
+  properties?: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+interface PiToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  details?: Record<string, unknown>;
+  isError?: boolean;
+}
+
+interface PiToolDefinition {
+  name: string;
+  label: string;
+  description: string;
+  promptSnippet?: string;
+  promptGuidelines?: string[];
+  parameters: JsonSchema;
+  executionMode?: 'sequential' | 'parallel';
+  execute(
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<PiToolResult>;
+}
+
+interface PiExtensionApi {
+  registerTool(tool: PiToolDefinition): void;
+  on(event: 'session_shutdown', handler: () => void | Promise<void>): void;
+  on(event: 'before_agent_start', handler: (event: BeforeAgentStartEvent) => BeforeAgentStartResult | Promise<BeforeAgentStartResult>): void;
+}
+
+interface BeforeAgentStartEvent {
+  systemPrompt: string;
+}
+
+interface BeforeAgentStartResult {
+  systemPrompt?: string;
+}
+
+interface BridgeOptions {
+  server: StdioServerParameters;
+  clientName: string;
+}
+
+type ToolName = typeof TOOL_DEFINITIONS[number]['name'];
+
+const STRING_ARRAY_SCHEMA = {
+  type: 'array',
+  items: { type: 'string' },
+};
+
+const CANDIDATE_SCHEMA = {
+  type: 'object',
+  properties: {
+    kind: { type: 'string' },
+    title: { type: 'string' },
+    content: { type: 'string' },
+    summary: { type: 'string' },
+    guidance: { type: 'string' },
+    project: { type: 'string' },
+    tags: STRING_ARRAY_SCHEMA,
+    source: { type: 'string' },
+  },
+  required: ['kind', 'title', 'content', 'summary', 'guidance'],
+  additionalProperties: false,
+};
+
+const TOOL_DEFINITIONS = [
+  {
+    name: 'knowledge-store',
+    label: 'Store Knowledge',
+    description: 'Store or update a concise persistent knowledge note for future agent sessions.',
+    promptSnippet: 'Store or update durable cross-session memory in open-zk-kb.',
+    parameters: objectSchema({
+      kind: enumSchema(['personalization', 'decision', 'procedure', 'reference', 'resource', 'observation', 'domain']),
+      title: { type: 'string' },
+      content: { type: 'string' },
+      summary: { type: 'string' },
+      guidance: { type: 'string' },
+      project: { type: 'string' },
+      tags: STRING_ARRAY_SCHEMA,
+      existingId: { type: 'string' },
+      lifecycle: enumSchema(['living', 'snapshot', 'append-only']),
+    }, ['kind', 'title', 'content', 'summary', 'guidance']),
+  },
+  {
+    name: 'knowledge-ingest',
+    label: 'Ingest Knowledge Source',
+    description: 'Extract article-style content from a URL or supplied HTML for storage in open-zk-kb.',
+    promptSnippet: 'Extract URL or HTML content before storing useful resources in open-zk-kb.',
+    parameters: objectSchema({
+      url: { type: 'string' },
+      html: { type: 'string' },
+      title: { type: 'string' },
+    }),
+  },
+  {
+    name: 'knowledge-search',
+    label: 'Search Knowledge',
+    description: 'Search persistent cross-session memory with full-text and semantic retrieval.',
+    promptSnippet: 'Search open-zk-kb for relevant prior context and guidance.',
+    parameters: objectSchema({
+      query: { type: 'string' },
+      client: { type: 'string' },
+      project: { type: 'string' },
+      kind: enumSchema(['personalization', 'decision', 'procedure', 'reference', 'resource', 'observation', 'domain', 'index', 'log']),
+      tags: STRING_ARRAY_SCHEMA,
+      limit: { type: 'number' },
+      mode: enumSchema(['keyword', 'semantic', 'hybrid']),
+    }, ['query']),
+  },
+  {
+    name: 'knowledge-overview',
+    label: 'Knowledge Overview',
+    description: 'Get a project knowledge overview: generated index and recent log entries.',
+    promptSnippet: 'Load an open-zk-kb project overview at the start of project work.',
+    parameters: objectSchema({
+      project: { type: 'string' },
+      logEntries: { type: 'number' },
+    }, ['project']),
+  },
+  {
+    name: 'knowledge-open',
+    label: 'Open Knowledge Note',
+    description: 'Open a specific knowledge note or the vault in Obsidian when available.',
+    promptSnippet: 'Open open-zk-kb notes for human review when requested.',
+    parameters: objectSchema({
+      noteId: { type: 'string' },
+      path: { type: 'string' },
+    }),
+  },
+  {
+    name: 'knowledge-maintain',
+    label: 'Maintain Knowledge',
+    description: 'Run knowledge base maintenance actions such as stats, review, promote, archive, delete, embed, and broken-links.',
+    promptSnippet: 'Inspect or maintain open-zk-kb health and lifecycle state.',
+    parameters: objectSchema({
+      action: enumSchema(['stats', 'review', 'promote', 'archive', 'delete', 'embed', 'broken-links']),
+      noteId: { type: 'string' },
+      limit: { type: 'number' },
+      dry_run: { type: 'boolean' },
+    }, ['action']),
+  },
+  {
+    name: 'knowledge-mine',
+    label: 'Mine Knowledge',
+    description: 'Bulk-screen candidate memories from prior sessions for deduplication before storage.',
+    promptSnippet: 'Mine previous sessions for candidate open-zk-kb notes.',
+    parameters: objectSchema({
+      candidates: {
+        type: 'array',
+        items: CANDIDATE_SCHEMA,
+      },
+      dry_run: { type: 'boolean' },
+      project: { type: 'string' },
+    }, ['candidates']),
+  },
+  {
+    name: 'knowledge-get',
+    label: 'Get Knowledge Note',
+    description: 'Fetch a specific knowledge note by note id.',
+    promptSnippet: 'Fetch a specific open-zk-kb note by id.',
+    parameters: objectSchema({
+      noteId: { type: 'string' },
+    }, ['noteId']),
+  },
+  {
+    name: 'knowledge-template',
+    label: 'Knowledge Template',
+    description: 'Get the canonical note template for a knowledge kind before storing structured memory.',
+    promptSnippet: 'Load an open-zk-kb note template before storing structured knowledge.',
+    parameters: objectSchema({
+      kind: enumSchema(['personalization', 'decision', 'procedure', 'reference', 'resource', 'observation', 'domain']),
+    }, ['kind']),
+  },
+] as const;
+
+const PROMPT_GUIDELINES = [
+  'Use knowledge-search before work that may benefit from prior cross-session memory; pass client: "pi" for Pi-specific context.',
+  'Use knowledge-store immediately when the user asks you to remember a preference, decision, procedure, observation, reference, or useful resource.',
+  'Use knowledge-template before knowledge-store when creating a structured note kind for the first time in a session.',
+];
+
+function objectSchema(properties: Record<string, unknown>, required: string[] = []): JsonSchema {
+  return {
+    type: 'object',
+    properties,
+    required,
+    additionalProperties: false,
+  };
+}
+
+function enumSchema(values: string[]): Record<string, unknown> {
+  return { type: 'string', enum: values };
+}
+
+function defaultServerParameters(): StdioServerParameters {
+  const extensionDir = path.dirname(fileURLToPath(import.meta.url));
+  const cliPath = path.resolve(extensionDir, '..', 'cli.js');
+  return {
+    command: 'bun',
+    args: [cliPath, 'server'],
+    cwd: process.cwd(),
+    stderr: 'pipe',
+  };
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function hasContent(result: unknown): result is { content: Array<unknown>; isError?: boolean; structuredContent?: Record<string, unknown> } {
+  return Boolean(result && typeof result === 'object' && 'content' in result && Array.isArray((result as { content?: unknown }).content));
+}
+
+function textFromMcpContent(content: unknown[]): string {
+  const parts = content.map((item) => {
+    if (!item || typeof item !== 'object') {
+      return String(item);
+    }
+    const record = item as Record<string, unknown>;
+    if (record.type === 'text' && typeof record.text === 'string') {
+      return record.text;
+    }
+    if (record.type === 'resource' && record.resource && typeof record.resource === 'object') {
+      const resource = record.resource as Record<string, unknown>;
+      if (typeof resource.text === 'string') {
+        return resource.text;
+      }
+    }
+    return JSON.stringify(record);
+  });
+  return parts.join('\n');
+}
+
+class OpenZkKbMcpBridge {
+  private client: Client | undefined;
+  private transport: StdioClientTransport | undefined;
+  private connecting: Promise<Client> | undefined;
+  private stderrTail = '';
+
+  constructor(private readonly options: BridgeOptions) {}
+
+  async callTool(name: ToolName, args: Record<string, unknown>, signal?: AbortSignal): Promise<PiToolResult> {
+    if (signal?.aborted) {
+      return { content: [{ type: 'text', text: 'Cancelled' }], isError: true };
+    }
+
+    try {
+      const client = await this.getClient();
+      const result = await client.callTool(
+        { name, arguments: args },
+        CompatibilityCallToolResultSchema,
+        signal ? { signal } : undefined,
+      );
+
+      if (hasContent(result)) {
+        return {
+          content: [{ type: 'text', text: textFromMcpContent(result.content) }],
+          details: result.structuredContent ? { structuredContent: result.structuredContent } : undefined,
+          isError: result.isError,
+        };
+      }
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result) }],
+      };
+    } catch (error) {
+      await this.reset();
+      const stderr = this.stderrTail.trim();
+      const suffix = stderr ? `\n\nServer stderr:\n${stderr}` : '';
+      return {
+        content: [{ type: 'text', text: `open-zk-kb Pi bridge failed: ${formatError(error)}${suffix}` }],
+        isError: true,
+      };
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.reset();
+  }
+
+  private async getClient(): Promise<Client> {
+    if (this.client) {
+      return this.client;
+    }
+
+    if (!this.connecting) {
+      this.connecting = this.connect();
+    }
+
+    return this.connecting;
+  }
+
+  private async connect(): Promise<Client> {
+    const client = new Client({ name: this.options.clientName, version: '1.0.0' });
+    const transport = new StdioClientTransport(this.options.server);
+    this.transport = transport;
+    this.captureStderr(transport);
+    await client.connect(transport);
+    this.client = client;
+    this.connecting = undefined;
+    return client;
+  }
+
+  private captureStderr(transport: StdioClientTransport): void {
+    const stderr = transport.stderr;
+    if (!stderr) {
+      return;
+    }
+    stderr.on('data', (chunk: Buffer | string) => {
+      this.stderrTail = `${this.stderrTail}${chunk.toString()}`.slice(-4000);
+    });
+  }
+
+  private async reset(): Promise<void> {
+    const transport = this.transport;
+    this.client = undefined;
+    this.transport = undefined;
+    this.connecting = undefined;
+    if (transport) {
+      await transport.close().catch(() => undefined);
+    }
+  }
+}
+
+export function createOpenZkKbPiExtension(options?: Partial<BridgeOptions>) {
+  return (pi: PiExtensionApi): void => {
+    const bridge = new OpenZkKbMcpBridge({
+      server: options?.server ?? defaultServerParameters(),
+      clientName: options?.clientName ?? 'open-zk-kb-pi',
+    });
+
+    for (const definition of TOOL_DEFINITIONS) {
+      pi.registerTool({
+        name: definition.name,
+        label: definition.label,
+        description: definition.description,
+        promptSnippet: definition.promptSnippet,
+        promptGuidelines: PROMPT_GUIDELINES,
+        parameters: definition.parameters,
+        executionMode: 'sequential',
+        execute: (_toolCallId, params, signal) => bridge.callTool(definition.name, params, signal),
+      });
+    }
+
+    pi.on('before_agent_start', (event) => {
+      if (event.systemPrompt.includes('OPEN-ZK-KB:START') || event.systemPrompt.includes('knowledge-search')) {
+        return {};
+      }
+      return {
+        systemPrompt: `${event.systemPrompt}\n\nOpen-zk-kb persistent memory is available through the knowledge-* tools. Search first with knowledge-search when prior context may matter, pass client: "pi", and store durable user preferences, decisions, procedures, observations, references, and resources with knowledge-store.`,
+      };
+    });
+
+    pi.on('session_shutdown', () => bridge.close());
+  };
+}
+
+export default createOpenZkKbPiExtension();

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -62,7 +62,7 @@ const STRING_ARRAY_SCHEMA = {
 const CANDIDATE_SCHEMA = {
   type: 'object',
   properties: {
-    kind: { type: 'string' },
+    kind: { type: 'string', enum: ['personalization', 'decision', 'procedure', 'reference', 'resource', 'observation', 'domain'] },
     title: { type: 'string' },
     content: { type: 'string' },
     summary: { type: 'string' },

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -89,8 +89,11 @@ const TOOL_DEFINITIONS = [
       guidance: { type: 'string' },
       project: { type: 'string' },
       tags: STRING_ARRAY_SCHEMA,
-      existingId: { type: 'string' },
       lifecycle: enumSchema(['living', 'snapshot', 'append-only']),
+      client: { type: 'string' },
+      status: enumSchema(['fleeting', 'permanent', 'archived']),
+      related: STRING_ARRAY_SCHEMA,
+      model: { type: 'string' },
     }, ['kind', 'title', 'content', 'summary', 'guidance']),
   },
   {
@@ -101,7 +104,7 @@ const TOOL_DEFINITIONS = [
     parameters: objectSchema({
       url: { type: 'string' },
       html: { type: 'string' },
-      title: { type: 'string' },
+      model: { type: 'string' },
     }),
   },
   {
@@ -116,7 +119,9 @@ const TOOL_DEFINITIONS = [
       kind: enumSchema(['personalization', 'decision', 'procedure', 'reference', 'resource', 'observation', 'domain', 'index', 'log']),
       tags: STRING_ARRAY_SCHEMA,
       limit: { type: 'number' },
-      mode: enumSchema(['keyword', 'semantic', 'hybrid']),
+      status: enumSchema(['fleeting', 'permanent', 'archived']),
+      lifecycle: enumSchema(['living', 'snapshot', 'append-only']),
+      model: { type: 'string' },
     }, ['query']),
   },
   {
@@ -127,28 +132,32 @@ const TOOL_DEFINITIONS = [
     parameters: objectSchema({
       project: { type: 'string' },
       logEntries: { type: 'number' },
+      model: { type: 'string' },
     }, ['project']),
   },
   {
     name: 'knowledge-open',
-    label: 'Open Knowledge Note',
-    description: 'Open a specific knowledge note or the vault in Obsidian when available.',
+    label: 'Open in Obsidian',
+    description: 'Open the knowledge base vault in Obsidian for visual browsing. Detects Obsidian installation and launches it pointed at the vault.',
     promptSnippet: 'Open open-zk-kb notes for human review when requested.',
     parameters: objectSchema({
-      noteId: { type: 'string' },
-      path: { type: 'string' },
+      project: { type: 'string' },
     }),
   },
   {
     name: 'knowledge-maintain',
     label: 'Maintain Knowledge',
-    description: 'Run knowledge base maintenance actions such as stats, review, promote, archive, delete, embed, and broken-links.',
+    description: 'Run knowledge base maintenance actions: stats, promote, archive, delete, rebuild, format, upgrade, upgrade-read, upgrade-apply, review, dedupe, embed, agent-docs, scope-audit, orphans, broken-links, migrate-layout, upgrade-vault, full.',
     promptSnippet: 'Inspect or maintain open-zk-kb health and lifecycle state.',
     parameters: objectSchema({
-      action: enumSchema(['stats', 'review', 'promote', 'archive', 'delete', 'embed', 'broken-links']),
+      action: enumSchema(['stats', 'promote', 'archive', 'delete', 'rebuild', 'format', 'upgrade', 'upgrade-read', 'upgrade-apply', 'review', 'dedupe', 'embed', 'agent-docs', 'scope-audit', 'orphans', 'broken-links', 'migrate-layout', 'upgrade-vault', 'full']),
       noteId: { type: 'string' },
       limit: { type: 'number' },
-      dry_run: { type: 'boolean' },
+      dryRun: { type: 'boolean' },
+      filter: enumSchema(['fleeting', 'permanent']),
+      days: { type: 'number' },
+      telemetry: { type: 'boolean' },
+      model: { type: 'string' },
     }, ['action']),
   },
   {
@@ -163,15 +172,17 @@ const TOOL_DEFINITIONS = [
       },
       dry_run: { type: 'boolean' },
       project: { type: 'string' },
+      model: { type: 'string' },
     }, ['candidates']),
   },
   {
     name: 'knowledge-get',
     label: 'Get Knowledge Note',
-    description: 'Fetch a specific knowledge note by note id.',
-    promptSnippet: 'Fetch a specific open-zk-kb note by id.',
+    description: 'Retrieve a single note by its exact ID. Faster and more precise than knowledge-search. Use when you already know the note ID (e.g. from injected context hints).',
+    promptSnippet: 'Fetch a specific open-zk-kb note by id for fast retrieval.',
     parameters: objectSchema({
       noteId: { type: 'string' },
+      model: { type: 'string' },
     }, ['noteId']),
   },
   {
@@ -180,7 +191,9 @@ const TOOL_DEFINITIONS = [
     description: 'Get the canonical note template for a knowledge kind before storing structured memory.',
     promptSnippet: 'Load an open-zk-kb note template before storing structured knowledge.',
     parameters: objectSchema({
-      kind: enumSchema(['personalization', 'decision', 'procedure', 'reference', 'resource', 'observation', 'domain']),
+      kind: enumSchema(['personalization', 'decision', 'procedure', 'reference', 'resource', 'observation', 'domain', 'index', 'log']),
+      project: { type: 'string' },
+      model: { type: 'string' },
     }, ['kind']),
   },
 ] as const;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -56,6 +56,8 @@ export interface ClientConfig {
   skillPath?: string;
   /** Paths where a previous install may have left a managed block that should be cleaned up. */
   staleAgentDocsPaths?: string[];
+  /** Content prepended before the managed block when creating the file (e.g. YAML frontmatter for OMP rules) */
+  preamble?: string;
 }
 
 const PI_PACKAGE_NAME = 'open-zk-kb';
@@ -115,9 +117,13 @@ export const CLIENT_CONFIGS: Record<McpClient, ClientConfig> = {
     mcpPath: ['mcpServers', 'open-zk-kb'],
     mcpFormat: 'standard',
     skillPath: path.join(expandPath('~/.omp'), 'agent', 'skills', 'open-zk-kb'),
-    agentDocsPath: path.join(expandPath('~/.omp'), 'agent', 'RULES.md'),
+    agentDocsPath: path.join(expandPath('~/.omp'), 'agent', 'rules', 'open-zk-kb.md'),
     instructionSize: 'compact',
-    staleAgentDocsPaths: [path.join(expandPath('~/.omp'), 'agent', 'AGENTS.md')],
+    preamble: '---\nalwaysApply: true\ndescription: Knowledge base (open-zk-kb) persistent memory instructions\n---\n',
+    staleAgentDocsPaths: [
+      path.join(expandPath('~/.omp'), 'agent', 'AGENTS.md'),
+      path.join(expandPath('~/.omp'), 'agent', 'RULES.md'),
+    ],
   },
 };
 
@@ -843,7 +849,7 @@ export function doctor(args: DoctorArgs = {}): string {
         if (!inspection.exists) {
           if (args.fix) {
             const size = clientConfig.instructionSize || 'full';
-            injectAgentDocs(clientConfig.agentDocsPath, size, false, client, PKG_VERSION);
+            injectAgentDocs(clientConfig.agentDocsPath, size, false, client, PKG_VERSION, clientConfig.preamble);
             pushCheck('FIXED', `${clientConfig.name}: restored managed instructions in ${clientConfig.agentDocsPath}`);
           } else {
             pushCheck('WARN', `${clientConfig.name}: managed instructions missing at ${clientConfig.agentDocsPath}`);
@@ -852,7 +858,7 @@ export function doctor(args: DoctorArgs = {}): string {
           pushCheck('OK', `${clientConfig.name}: managed instructions are healthy in ${clientConfig.agentDocsPath}`);
         } else if (args.fix) {
           const size = clientConfig.instructionSize || 'full';
-          injectAgentDocs(clientConfig.agentDocsPath, size, false, client, PKG_VERSION);
+          injectAgentDocs(clientConfig.agentDocsPath, size, false, client, PKG_VERSION, clientConfig.preamble);
           pushCheck('FIXED', `${clientConfig.name}: repaired managed instructions in ${clientConfig.agentDocsPath}`);
         } else if (inspection.status === 'missing') {
           pushCheck('WARN', `${clientConfig.name}: instruction file exists but has no managed block at ${clientConfig.agentDocsPath}`);
@@ -1020,7 +1026,7 @@ export function install(args: InstallArgs): string {
       agentDocsSkippedSymlink = symlinkTarget;
     } else {
       const size = args.instructionSize || clientConfig.instructionSize || 'full';
-      agentDocsResult = injectAgentDocs(clientConfig.agentDocsPath, size, args.dryRun, args.client, PKG_VERSION);
+      agentDocsResult = injectAgentDocs(clientConfig.agentDocsPath, size, args.dryRun, args.client, PKG_VERSION, clientConfig.preamble);
     }
   }
   // Clean up managed blocks from stale locations (e.g. OMP: AGENTS.md → RULES.md migration)

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -113,7 +113,7 @@ export const CLIENT_CONFIGS: Record<McpClient, ClientConfig> = {
     mcpPath: ['mcpServers', 'open-zk-kb'],
     mcpFormat: 'standard',
     skillPath: path.join(expandPath('~/.omp'), 'agent', 'skills', 'open-zk-kb'),
-    agentDocsPath: path.join(expandPath('~/.omp'), 'agent', 'AGENTS.md'),
+    agentDocsPath: path.join(expandPath('~/.omp'), 'agent', 'RULES.md'),
     instructionSize: 'full',
   },
 };

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -868,6 +868,7 @@ export function doctor(args: DoctorArgs = {}): string {
     if (clientConfig.staleAgentDocsPaths) {
       for (const stalePath of clientConfig.staleAgentDocsPaths) {
         if (stalePath === clientConfig.agentDocsPath) continue;
+        if (resolveSymlinkTarget(stalePath)) continue; // don't modify shared files via symlink
         const staleInspection = inspectAgentDocs(stalePath);
         if (staleInspection.exists && staleInspection.status !== 'missing') {
           if (args.fix) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -814,14 +814,16 @@ export function doctor(args: DoctorArgs = {}): string {
         }
 
         // Check for stale CLAUDE.md managed block (pre-skill migration)
-        const oldAgentDocsPath = getLegacyClaudeMdPath();
-        const oldInspection = inspectAgentDocs(oldAgentDocsPath);
-        if (oldInspection.exists && oldInspection.status !== 'missing') {
-          if (args.fix) {
-            migrateFromAgentDocs(oldAgentDocsPath, false);
-            pushCheck('FIXED', `${clientConfig.name}: removed stale CLAUDE.md managed block`);
-          } else {
-            pushCheck('WARN', `${clientConfig.name}: stale CLAUDE.md managed block found — run with --fix to remove`);
+        if (client === 'claude-code') {
+          const oldAgentDocsPath = getLegacyClaudeMdPath();
+          const oldInspection = inspectAgentDocs(oldAgentDocsPath);
+          if (oldInspection.exists && oldInspection.status !== 'missing') {
+            if (args.fix) {
+              migrateFromAgentDocs(oldAgentDocsPath, false);
+              pushCheck('FIXED', `${clientConfig.name}: removed stale CLAUDE.md managed block`);
+            } else {
+              pushCheck('WARN', `${clientConfig.name}: stale CLAUDE.md managed block found — run with --fix to remove`);
+            }
           }
         }
       }
@@ -915,6 +917,10 @@ export function install(args: InstallArgs): string {
     }
   }
 
+  const removedStaleOpenCodePlugins = !usesPiPackage && clientConfig.mcpFormat === 'opencode'
+    ? removeStaleOpenCodePluginEntries(config)
+    : false;
+
   const existing = usesPiPackage
     ? validatePiPackageConfig(config, piPackageSource ?? '').length === 0
     : clientConfig.mcpPath ? getNestedValue(config, clientConfig.mcpPath) !== undefined : false;
@@ -936,9 +942,8 @@ export function install(args: InstallArgs): string {
 
   if (args.dryRun) {
     let output = usesPiPackage
-      ? `Dry run: Would add Pi package source to ${clientConfig.configPath}:\n${piPackageSource}`
+      ? `Dry run: Would add Pi package source to ${clientConfig.configPath}:\n${piPackageSource}\nNote: Also run \`pi install ${piPackageSource}\` — Pi does not support MCP natively`
       : `Dry run: Would add to ${clientConfig.configPath}:\n${JSON.stringify(mcpEntry, null, 2)}`;
-    }
     if (clientConfig.skillPath) {
       output += `\nWould install skill to ${clientConfig.skillPath}`;
     }
@@ -1002,8 +1007,10 @@ export function install(args: InstallArgs): string {
   if (clientConfig.skillPath) {
     skillResult = installSkill(clientConfig.skillPath, args.dryRun);
 
-    // Migrate away from old CLAUDE.md managed block if present
-    migrationResult = migrateFromAgentDocs(getLegacyClaudeMdPath(), args.dryRun);
+    // Migrate away from old CLAUDE.md managed block if present (Claude Code only)
+    if (args.client === 'claude-code') {
+      migrationResult = migrateFromAgentDocs(getLegacyClaudeMdPath(), args.dryRun);
+    }
   }
   let agentDocsSkippedSymlink: string | null = null;
   if (clientConfig.agentDocsPath) {
@@ -1055,12 +1062,15 @@ export function install(args: InstallArgs): string {
     output += `Templates: ${templatesCopied} files → ${vaultTemplatesDir}\n`;
   }
   output += `\nNext steps:\n`;
-  const restartTarget = usesPiPackage ? 'Pi to load the package extension' : `${clientConfig.name} to load the MCP server`;
+  let step = 1;
   if (configCopied) {
-    output += `1. Review ${configYamlPath} if you want to customize settings or use API embeddings\n`;
-    output += `2. Restart ${restartTarget}\n`;
+    output += `${step++}. Review ${configYamlPath} if you want to customize settings or use API embeddings\n`;
+  }
+  if (usesPiPackage) {
+    output += `${step++}. Run \`pi install ${piPackageSource}\` if you haven't already (Pi does not support MCP natively — this installs the package extension)\n`;
+    output += `${step}. Restart Pi to load the package extension\n`;
   } else {
-    output += `1. Restart ${restartTarget}\n`;
+    output += `${step}. Restart ${clientConfig.name} to load the MCP server\n`;
   }
   
   return output;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -19,7 +19,7 @@ function detectNpmTag(): 'dev' | 'latest' {
 const xdgConfigHome = process.env.XDG_CONFIG_HOME || expandPath('~/.config');
 const xdgDataHome = process.env.XDG_DATA_HOME || expandPath('~/.local/share');
 
-export type McpClient = 'opencode' | 'claude-code' | 'cursor' | 'windsurf' | 'zed';
+export type McpClient = 'opencode' | 'claude-code' | 'cursor' | 'windsurf' | 'zed' | 'pi' | 'omp';
 
 export interface InstallArgs {
   client: McpClient;
@@ -27,6 +27,8 @@ export interface InstallArgs {
   force?: boolean;
   dryRun?: boolean;
   instructionSize?: InstructionSize;
+  /** Inject agent docs even when the path is a symlink to a shared file. */
+  injectSharedAgentDocs?: boolean;
 }
 
 export interface UninstallArgs {
@@ -45,14 +47,16 @@ export interface ClientConfig {
   name: string;
   configPath: string;
   configFormat: 'json' | 'jsonc';
-  mcpPath: string[];
-  mcpFormat: 'opencode' | 'standard';
+  integration?: 'mcp' | 'pi-package';
+  mcpPath?: string[];
+  mcpFormat?: 'opencode' | 'standard';
   agentDocsPath?: string;
   instructionSize?: InstructionSize;
   /** Path where a Claude Code skill directory should be installed (e.g. ~/.claude/skills/open-zk-kb) */
   skillPath?: string;
 }
 
+const PI_PACKAGE_NAME = 'open-zk-kb';
 export const CLIENT_CONFIGS: Record<McpClient, ClientConfig> = {
   'opencode': {
     name: 'OpenCode',
@@ -94,9 +98,27 @@ export const CLIENT_CONFIGS: Record<McpClient, ClientConfig> = {
     mcpPath: ['context_servers', 'open-zk-kb'],
     mcpFormat: 'standard',
   },
+  'pi': {
+    name: 'Pi',
+    configPath: path.join(expandPath('~/.pi'), 'agent', 'settings.json'),
+    configFormat: 'json',
+    integration: 'pi-package',
+    agentDocsPath: path.join(expandPath('~/.pi'), 'agent', 'AGENTS.md'),
+    instructionSize: 'full',
+  },
+  'omp': {
+    name: 'OMP',
+    configPath: path.join(expandPath('~/.omp'), 'agent', 'mcp.json'),
+    configFormat: 'json',
+    mcpPath: ['mcpServers', 'open-zk-kb'],
+    mcpFormat: 'standard',
+    skillPath: path.join(expandPath('~/.omp'), 'agent', 'skills', 'open-zk-kb'),
+    agentDocsPath: path.join(expandPath('~/.omp'), 'agent', 'AGENTS.md'),
+    instructionSize: 'full',
+  },
 };
 
-const ALL_CLIENTS: McpClient[] = ['opencode', 'claude-code', 'cursor', 'windsurf', 'zed'];
+const ALL_CLIENTS: McpClient[] = ['opencode', 'claude-code', 'cursor', 'windsurf', 'zed', 'pi', 'omp'];
 
 const CLIENT_PROMPT_OPTIONS: Array<{ value: McpClient; label: string; hint: string }> = [
   { value: 'opencode', label: 'OpenCode', hint: 'MCP server + managed instructions' },
@@ -104,6 +126,8 @@ const CLIENT_PROMPT_OPTIONS: Array<{ value: McpClient; label: string; hint: stri
   { value: 'cursor', label: 'Cursor', hint: 'MCP server integration' },
   { value: 'windsurf', label: 'Windsurf', hint: 'MCP server integration' },
   { value: 'zed', label: 'Zed', hint: 'MCP server integration' },
+  { value: 'pi', label: 'Pi', hint: 'Pi package + managed instructions' },
+  { value: 'omp', label: 'OMP', hint: 'MCP server + skill' },
 ];
 
 type McpEntry =
@@ -118,6 +142,10 @@ type McpEntry =
     };
 
 function buildMcpEntry(clientConfig: ClientConfig, serverPath?: string): McpEntry {
+  if (!clientConfig.mcpFormat) {
+    throw new Error(`${clientConfig.name} does not use MCP config entries`);
+  }
+
   if (!serverPath) {
     const tag = detectNpmTag();
     if (clientConfig.mcpFormat === 'opencode') {
@@ -212,6 +240,113 @@ function formatServerCommand(serverPath?: string): string {
   return serverPath ? `bun run ${serverPath}` : `bunx open-zk-kb@${detectNpmTag()} server`;
 }
 
+function buildPiPackageSource(): string {
+  const projectRoot = detectProjectRoot();
+  if (projectRoot) {
+    return projectRoot;
+  }
+
+  const tag = detectNpmTag();
+  return tag === 'dev' ? `npm:${PI_PACKAGE_NAME}@dev` : `npm:${PI_PACKAGE_NAME}`;
+}
+
+function getPackageArray(config: JsonObject): unknown[] | undefined {
+  return Array.isArray(config.packages) ? config.packages : undefined;
+}
+
+function packageSourceValue(entry: unknown): string | undefined {
+  if (typeof entry === 'string') {
+    return entry;
+  }
+
+  if (isJsonObject(entry) && typeof entry.source === 'string') {
+    return entry.source;
+  }
+
+  return undefined;
+}
+
+function isOpenZkKbPiPackageSource(source: string): boolean {
+  if (source === PI_PACKAGE_NAME || source === `npm:${PI_PACKAGE_NAME}` || source.startsWith(`npm:${PI_PACKAGE_NAME}@`)) {
+    return true;
+  }
+
+  if (source.startsWith('file://')) {
+    try {
+      return isOpenZkKbLocalPackagePath(fileURLToPath(source));
+    } catch {
+      return false;
+    }
+  }
+
+  return path.isAbsolute(source) && isOpenZkKbLocalPackagePath(source);
+}
+
+function isOpenZkKbLocalPackagePath(source: string): boolean {
+  const normalized = path.normalize(source);
+  return path.basename(normalized) === PI_PACKAGE_NAME;
+}
+
+function normalizePiPackages(config: JsonObject, desiredSource: string): void {
+  const existing = getPackageArray(config) ?? [];
+  const preserved = existing.filter((entry) => {
+    const source = packageSourceValue(entry);
+    return source === undefined || !isOpenZkKbPiPackageSource(source);
+  });
+  config.packages = [...preserved, desiredSource];
+}
+
+function removePiPackage(config: JsonObject): void {
+  const existing = getPackageArray(config);
+  if (!existing) {
+    return;
+  }
+
+  const preserved = existing.filter((entry) => {
+    const source = packageSourceValue(entry);
+    return source === undefined || !isOpenZkKbPiPackageSource(source);
+  });
+
+  if (preserved.length === 0) {
+    delete config.packages;
+    return;
+  }
+
+  config.packages = preserved;
+}
+
+function validatePiPackageConfig(config: JsonObject, expectedSource: string): string[] {
+  if (!("packages" in config)) {
+    return ['missing packages array'];
+  }
+
+  if (!Array.isArray(config.packages)) {
+    return ['packages is not an array'];
+  }
+
+  const matches = config.packages
+    .map(packageSourceValue)
+    .filter((source): source is string => source !== undefined && isOpenZkKbPiPackageSource(source));
+
+  if (matches.length === 0) {
+    return ['missing open-zk-kb package source'];
+  }
+
+  if (matches.length > 1) {
+    return ['duplicate open-zk-kb package sources'];
+  }
+
+  if (matches[0] !== expectedSource) {
+    return [`expected package source "${expectedSource}"`];
+  }
+
+  return [];
+}
+
+function isPiPackageClient(clientConfig: ClientConfig): boolean {
+  return clientConfig.integration === 'pi-package';
+}
+
 /**
  * Check if open-zk-kb is already installed for a given client.
  */
@@ -224,7 +359,13 @@ function isClientInstalled(client: McpClient): boolean {
   
   try {
     const content = fs.readFileSync(clientConfig.configPath, 'utf-8');
-    const config = JSON.parse(content);
+    const config = parseJsonObject(content);
+    if (isPiPackageClient(clientConfig)) {
+      return validatePiPackageConfig(config, buildPiPackageSource()).length === 0;
+    }
+    if (!clientConfig.mcpPath) {
+      return false;
+    }
     const entry = getNestedValue(config, clientConfig.mcpPath);
     return entry !== undefined;
   } catch {
@@ -299,6 +440,18 @@ function getVaultPath(): string {
 
 function getConfigYamlPath(): string {
   return path.join(xdgConfigHome, 'open-zk-kb', 'config.yaml');
+}
+
+/**
+ * If the path is a symlink, return the resolved target. Otherwise return null.
+ */
+function resolveSymlinkTarget(filePath: string): string | null {
+  try {
+    if (fs.lstatSync(filePath).isSymbolicLink()) {
+      return fs.realpathSync(filePath);
+    }
+  } catch { /* path doesn't exist */ }
+  return null;
 }
 
 // --- Skill installation helpers (Claude Code) ---
@@ -500,6 +653,9 @@ function inferServerPathFromEntry(clientConfig: ClientConfig, entry: unknown): s
 }
 
 function repairClientConfig(clientConfig: ClientConfig, config: Record<string, unknown>, existingEntry: unknown): void {
+  if (!clientConfig.mcpPath) {
+    throw new Error(`${clientConfig.name} does not use MCP config entries`);
+  }
   const inferredServerPath = inferServerPathFromEntry(clientConfig, existingEntry);
   const repairedEntry = buildMcpEntry(clientConfig, inferredServerPath);
   setNestedValue(config, clientConfig.mcpPath, repairedEntry);
@@ -569,30 +725,49 @@ export function doctor(args: DoctorArgs = {}): string {
     } else {
       try {
         const content = fs.readFileSync(clientConfig.configPath, 'utf-8');
-        const config = JSON.parse(content) as Record<string, unknown>;
-        const entry = getNestedValue(config, clientConfig.mcpPath);
+        const config = parseJsonObject(content);
 
-        if (!entry) {
-          pushCheck('INFO', `${clientConfig.name}: open-zk-kb is not configured in ${clientConfig.configPath}`);
-        } else {
-          const issues = validateMcpEntry(clientConfig, entry);
-          if (issues.length === 0) {
+        if (isPiPackageClient(clientConfig)) {
+          const packageIssues = validatePiPackageConfig(config, buildPiPackageSource());
+          if (packageIssues.length === 0) {
             configured = true;
-            pushCheck('OK', `${clientConfig.name}: MCP config looks healthy in ${clientConfig.configPath}`);
-            if (clientConfig.mcpFormat === 'opencode' && removeStaleOpenCodePluginEntries(config)) {
-              if (args.fix) {
-                fs.writeFileSync(clientConfig.configPath, JSON.stringify(config, null, 2));
-                pushCheck('FIXED', `${clientConfig.name}: removed stale open-zk-kb plugin entries from ${clientConfig.configPath}`);
-              } else {
-                pushCheck('WARN', `${clientConfig.name}: stale open-zk-kb plugin entries remain in ${clientConfig.configPath} — run with --fix to remove`);
-              }
-            }
-          } else if (args.fix) {
-            repairClientConfig(clientConfig, config, entry);
+            pushCheck('OK', `${clientConfig.name}: package source looks healthy in ${clientConfig.configPath}`);
+          } else if (args.fix && getPackageArray(config)?.some((entry) => {
+            const source = packageSourceValue(entry);
+            return source !== undefined && isOpenZkKbPiPackageSource(source);
+          })) {
+            normalizePiPackages(config, buildPiPackageSource());
+            fs.writeFileSync(clientConfig.configPath, JSON.stringify(config, null, 2));
             configured = true;
-            pushCheck('FIXED', `${clientConfig.name}: repaired MCP config in ${clientConfig.configPath}`);
+            pushCheck('FIXED', `${clientConfig.name}: repaired package source in ${clientConfig.configPath}`);
           } else {
-            pushCheck('ERROR', `${clientConfig.name}: MCP config is invalid (${issues.join(', ')})`);
+            pushCheck('INFO', `${clientConfig.name}: open-zk-kb package is not configured in ${clientConfig.configPath}`);
+          }
+        } else if (clientConfig.mcpPath) {
+          const entry = getNestedValue(config, clientConfig.mcpPath);
+
+          if (!entry) {
+            pushCheck('INFO', `${clientConfig.name}: open-zk-kb is not configured in ${clientConfig.configPath}`);
+          } else {
+            const issues = validateMcpEntry(clientConfig, entry);
+            if (issues.length === 0) {
+              configured = true;
+              pushCheck('OK', `${clientConfig.name}: MCP config looks healthy in ${clientConfig.configPath}`);
+              if (clientConfig.mcpFormat === 'opencode' && removeStaleOpenCodePluginEntries(config)) {
+                if (args.fix) {
+                  fs.writeFileSync(clientConfig.configPath, JSON.stringify(config, null, 2));
+                  pushCheck('FIXED', `${clientConfig.name}: removed stale open-zk-kb plugin entries from ${clientConfig.configPath}`);
+                } else {
+                  pushCheck('WARN', `${clientConfig.name}: stale open-zk-kb plugin entries remain in ${clientConfig.configPath} — run with --fix to remove`);
+                }
+              }
+            } else if (args.fix) {
+              repairClientConfig(clientConfig, config, entry);
+              configured = true;
+              pushCheck('FIXED', `${clientConfig.name}: repaired MCP config in ${clientConfig.configPath}`);
+            } else {
+              pushCheck('ERROR', `${clientConfig.name}: MCP config is invalid (${issues.join(', ')})`);
+            }
           }
         }
       } catch (error) {
@@ -601,7 +776,7 @@ export function doctor(args: DoctorArgs = {}): string {
     }
 
     if (clientConfig.skillPath) {
-      // Skill-based client (Claude Code)
+      // Skill-based client (e.g. Claude Code, OMP)
       if (!configured) {
         if (fs.existsSync(clientConfig.skillPath)) {
           pushCheck('INFO', `${clientConfig.name}: skill exists at ${clientConfig.skillPath}, but open-zk-kb is not installed for this client`);
@@ -647,8 +822,12 @@ export function doctor(args: DoctorArgs = {}): string {
           }
         }
       }
-    } else if (clientConfig.agentDocsPath) {
-      if (!configured) {
+    }
+    if (clientConfig.agentDocsPath) {
+      const symlinkTarget = resolveSymlinkTarget(clientConfig.agentDocsPath);
+      if (symlinkTarget) {
+        pushCheck('INFO', `${clientConfig.name}: agent docs path is a symlink (→ ${symlinkTarget}) — skipping to avoid modifying a shared file`);
+      } else if (!configured) {
         if (fs.existsSync(clientConfig.agentDocsPath)) {
           pushCheck('INFO', `${clientConfig.name}: instruction file exists at ${clientConfig.agentDocsPath}, but open-zk-kb is not installed for this client`);
         } else {
@@ -676,7 +855,8 @@ export function doctor(args: DoctorArgs = {}): string {
           pushCheck('WARN', `${clientConfig.name}: managed instructions need repair (${inspection.status}) in ${clientConfig.agentDocsPath}`);
         }
       }
-    } else {
+    }
+    if (!clientConfig.skillPath && !clientConfig.agentDocsPath) {
       pushCheck('INFO', `${clientConfig.name}: managed instructions are not currently supported`);
     }
   }
@@ -697,10 +877,12 @@ export function doctor(args: DoctorArgs = {}): string {
 
 export function install(args: InstallArgs): string {
   const clientConfig = CLIENT_CONFIGS[args.client];
-  const serverPath = args.serverPath || detectServerPath();
+  const usesPiPackage = isPiPackageClient(clientConfig);
+  const serverPath = usesPiPackage ? args.serverPath : args.serverPath || detectServerPath();
+  const piPackageSource = usesPiPackage ? buildPiPackageSource() : null;
   const vaultPath = getVaultPath();
   
-  if (serverPath && !fs.existsSync(serverPath)) {
+  if (!usesPiPackage && serverPath && !fs.existsSync(serverPath)) {
     throw new Error(`Server not found at: ${serverPath}`);
   }
   
@@ -715,10 +897,9 @@ export function install(args: InstallArgs): string {
     }
   }
 
-  const existing = getNestedValue(config, clientConfig.mcpPath);
-  const removedStaleOpenCodePlugins = clientConfig.mcpFormat === 'opencode'
-    ? removeStaleOpenCodePluginEntries(config)
-    : false;
+  const existing = usesPiPackage
+    ? validatePiPackageConfig(config, piPackageSource ?? '').length === 0
+    : clientConfig.mcpPath ? getNestedValue(config, clientConfig.mcpPath) !== undefined : false;
 
   if (existing && !args.force) {
     if (removedStaleOpenCodePlugins && !args.dryRun) {
@@ -728,7 +909,7 @@ export function install(args: InstallArgs): string {
     return `Already installed for ${clientConfig.name}. Use --force to overwrite.`;
   }
   
-  const mcpEntry = buildMcpEntry(clientConfig, serverPath);
+  const mcpEntry = usesPiPackage ? null : buildMcpEntry(clientConfig, serverPath);
   
   const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const templatesDir = path.join(projectRoot, 'templates');
@@ -736,14 +917,20 @@ export function install(args: InstallArgs): string {
   const templateFileCount = fs.existsSync(templatesDir) ? fs.readdirSync(templatesDir).filter(f => f.endsWith('.md')).length : 0;
 
   if (args.dryRun) {
-    let output = `Dry run: Would add to ${clientConfig.configPath}:\n${JSON.stringify(mcpEntry, null, 2)}`;
-    if (removedStaleOpenCodePlugins) {
-      output += '\nWould remove stale open-zk-kb plugin entries';
+    let output = usesPiPackage
+      ? `Dry run: Would add Pi package source to ${clientConfig.configPath}:\n${piPackageSource}`
+      : `Dry run: Would add to ${clientConfig.configPath}:\n${JSON.stringify(mcpEntry, null, 2)}`;
     }
     if (clientConfig.skillPath) {
       output += `\nWould install skill to ${clientConfig.skillPath}`;
-    } else if (clientConfig.agentDocsPath) {
-      output += `\nWould inject agent docs into ${clientConfig.agentDocsPath}`;
+    }
+    if (clientConfig.agentDocsPath) {
+      const symlinkTarget = resolveSymlinkTarget(clientConfig.agentDocsPath);
+      if (!symlinkTarget || args.injectSharedAgentDocs) {
+        output += `\nWould inject agent docs into ${clientConfig.agentDocsPath}`;
+      } else {
+        output += `\nWould skip agent docs (${clientConfig.agentDocsPath} → ${symlinkTarget})`;
+      }
     }
     if (templateFileCount > 0) {
       output += `\nWould copy ${templateFileCount} template files to ${vaultTemplatesDir}`;
@@ -751,7 +938,11 @@ export function install(args: InstallArgs): string {
     return output;
   }
   
-  setNestedValue(config, clientConfig.mcpPath, mcpEntry);
+  if (usesPiPackage) {
+    normalizePiPackages(config, piPackageSource ?? buildPiPackageSource());
+  } else if (clientConfig.mcpPath) {
+    setNestedValue(config, clientConfig.mcpPath, mcpEntry);
+  }
   
   const configDir = path.dirname(clientConfig.configPath);
   if (!fs.existsSync(configDir)) {
@@ -795,20 +986,34 @@ export function install(args: InstallArgs): string {
 
     // Migrate away from old CLAUDE.md managed block if present
     migrationResult = migrateFromAgentDocs(getLegacyClaudeMdPath(), args.dryRun);
-  } else if (clientConfig.agentDocsPath) {
-    const size = args.instructionSize || clientConfig.instructionSize || 'full';
-    agentDocsResult = injectAgentDocs(clientConfig.agentDocsPath, size, args.dryRun, args.client, PKG_VERSION);
+  }
+  let agentDocsSkippedSymlink: string | null = null;
+  if (clientConfig.agentDocsPath) {
+    const symlinkTarget = resolveSymlinkTarget(clientConfig.agentDocsPath);
+    if (symlinkTarget && !args.injectSharedAgentDocs) {
+      agentDocsSkippedSymlink = symlinkTarget;
+    } else {
+      const size = args.instructionSize || clientConfig.instructionSize || 'full';
+      agentDocsResult = injectAgentDocs(clientConfig.agentDocsPath, size, args.dryRun, args.client, PKG_VERSION);
+    }
   }
 
   let output = `Installed open-zk-kb for ${clientConfig.name}\n\n`;
   output += `Config: ${clientConfig.configPath}\n`;
   output += `Vault: ${vaultPath}\n`;
-  output += `Server: ${formatServerCommand(serverPath)}\n`;
+  if (usesPiPackage) {
+    output += `Package: ${piPackageSource}\n`;
+  } else {
+    output += `Server: ${formatServerCommand(serverPath)}\n`;
+  }
   if (skillResult) {
     output += `Skill: ${skillResult.skillPath} (${skillResult.action})\n`;
   }
   if (agentDocsResult) {
     output += `Agent docs: ${agentDocsResult.filePath} (${agentDocsResult.action})\n`;
+  }
+  if (agentDocsSkippedSymlink) {
+    output += `Agent docs: skipped (${clientConfig.agentDocsPath} → ${agentDocsSkippedSymlink})\n`;
   }
   if (migrationResult?.migrated) {
     output += `Migration: removed old CLAUDE.md managed block${migrationResult.fileDeleted ? ' (file deleted — was empty)' : ''}\n`;
@@ -817,11 +1022,12 @@ export function install(args: InstallArgs): string {
     output += `Templates: ${templatesCopied} files → ${vaultTemplatesDir}\n`;
   }
   output += `\nNext steps:\n`;
+  const restartTarget = usesPiPackage ? 'Pi to load the package extension' : `${clientConfig.name} to load the MCP server`;
   if (configCopied) {
     output += `1. Review ${configYamlPath} if you want to customize settings or use API embeddings\n`;
-    output += `2. Restart ${clientConfig.name} to load the MCP server\n`;
+    output += `2. Restart ${restartTarget}\n`;
   } else {
-    output += `1. Restart ${clientConfig.name} to load the MCP server\n`;
+    output += `1. Restart ${restartTarget}\n`;
   }
   
   return output;
@@ -829,6 +1035,7 @@ export function install(args: InstallArgs): string {
 
 export function uninstall(args: UninstallArgs): string {
   const clientConfig = CLIENT_CONFIGS[args.client];
+  const usesPiPackage = isPiPackageClient(clientConfig);
   const vaultPath = getVaultPath();
   
   if (!fs.existsSync(clientConfig.configPath)) {
@@ -843,7 +1050,9 @@ export function uninstall(args: UninstallArgs): string {
     throw new Error(`Failed to parse ${clientConfig.configPath}: ${e}`, { cause: e });
   }
 
-  const existing = getNestedValue(config, clientConfig.mcpPath);
+  const existing = usesPiPackage
+    ? validatePiPackageConfig(config, buildPiPackageSource()).length === 0
+    : clientConfig.mcpPath ? getNestedValue(config, clientConfig.mcpPath) !== undefined : false;
   if (!existing) {
     return `open-zk-kb not configured for ${clientConfig.name}`;
   }
@@ -852,7 +1061,8 @@ export function uninstall(args: UninstallArgs): string {
     let output = `Dry run: Would remove from ${clientConfig.configPath}\n`;
     if (clientConfig.skillPath) {
       output += `Would remove skill from ${clientConfig.skillPath}\n`;
-    } else if (clientConfig.agentDocsPath) {
+    }
+    if (clientConfig.agentDocsPath && !resolveSymlinkTarget(clientConfig.agentDocsPath)) {
       output += `Would remove agent docs from ${clientConfig.agentDocsPath}\n`;
     }
     if (args.removeVault) {
@@ -887,20 +1097,25 @@ export function uninstall(args: UninstallArgs): string {
     }
   }
   
-  deleteNestedValue(config, clientConfig.mcpPath);
+  if (usesPiPackage) {
+    removePiPackage(config);
+  } else if (clientConfig.mcpPath) {
+    deleteNestedValue(config, clientConfig.mcpPath);
+  }
   if (clientConfig.mcpFormat === 'opencode') {
     removeStaleOpenCodePluginEntries(config);
   }
 
   fs.writeFileSync(clientConfig.configPath, JSON.stringify(config, null, 2));
 
-  // Remove skill or agent docs depending on client
+  // Remove skill and/or agent docs depending on client
   let skillResult: { action: string; skillPath: string } | null = null;
   let agentDocsResult: { action: string; filePath: string } | null = null;
 
   if (clientConfig.skillPath) {
     skillResult = removeSkill(clientConfig.skillPath, args.dryRun);
-  } else if (clientConfig.agentDocsPath) {
+  }
+  if (clientConfig.agentDocsPath && !resolveSymlinkTarget(clientConfig.agentDocsPath)) {
     agentDocsResult = removeAgentDocs(clientConfig.agentDocsPath, args.dryRun);
   }
 
@@ -949,13 +1164,13 @@ server:
 
 doctor:
   Check install health for one client or all clients
-  --client <name>      Check a specific client (opencode, claude-code, cursor, windsurf, zed)
+  --client <name>      Check a specific client (opencode, claude-code, cursor, windsurf, zed, pi, omp)
   --fix                Repair safe doctor findings when possible
 
 install:
   (no flags)           Interactive client selection
-  --client <name>      Install for specific client (opencode, claude-code, cursor, windsurf, zed)
-  --server-path <path> Path to dist/mcp-server.js (auto-detected)
+  --client <name>      Install for specific client (opencode, claude-code, cursor, windsurf, zed, pi, omp)
+  --server-path <path> Path to dist/mcp-server.js (auto-detected; MCP clients only)
   --instructions <size> Agent instruction size: compact (~140 tokens) or full (~420 tokens)
   --force              Overwrite existing config
   --dry-run            Preview changes without applying
@@ -963,7 +1178,7 @@ install:
 
 uninstall:
   (no flags)           Interactive client selection
-  --client <name>      Uninstall from specific client
+  --client <name>      Uninstall from specific client (opencode, claude-code, cursor, windsurf, zed, pi, omp)
   --remove-vault       Also delete the knowledge base data
   --confirm            Required with --remove-vault
   --dry-run            Preview changes without applying
@@ -1023,15 +1238,53 @@ export async function runSetupCli(rawArgs: string[] = process.argv.slice(2)): Pr
       client = clientArg;
     }
 
+    /** Prompt for symlinked agent docs and install a single client. */
+    async function installWithSymlinkPrompt(
+      client: McpClient,
+      opts: { serverPath?: string; force?: boolean; dryRun?: boolean; instructionSize?: InstructionSize; yes?: boolean },
+    ): Promise<string> {
+      const clientConfig = CLIENT_CONFIGS[client];
+      let injectSharedAgentDocs: boolean | undefined;
+
+      if (clientConfig.agentDocsPath) {
+        const symlinkTarget = resolveSymlinkTarget(clientConfig.agentDocsPath);
+        if (symlinkTarget) {
+          if (opts.yes) {
+            // Non-interactive: skip by default
+            injectSharedAgentDocs = false;
+          } else {
+            const answer = await p.confirm({
+              message: `${clientConfig.name}: agent docs path is a symlink:\n  ${color.dim(`${clientConfig.agentDocsPath} → ${symlinkTarget}`)}\n  Inject managed instructions into the shared file?`,
+              initialValue: false,
+            });
+            if (p.isCancel(answer)) {
+              p.cancel('Setup cancelled.');
+              process.exit(0);
+            }
+            injectSharedAgentDocs = answer;
+          }
+        }
+      }
+
+      return install({
+        client,
+        serverPath: opts.serverPath,
+        force: opts.force,
+        dryRun: opts.dryRun,
+        instructionSize: opts.instructionSize,
+        injectSharedAgentDocs,
+      });
+    }
+
     if (client) {
-      const result = install({ client, serverPath, force, dryRun, instructionSize });
+      const result = await installWithSymlinkPrompt(client, { serverPath, force, dryRun, instructionSize, yes });
       console.log(result);
       return;
     }
 
     if (yes) {
       for (const client of ALL_CLIENTS) {
-        const result = install({ client, serverPath, force, dryRun, instructionSize });
+        const result = await installWithSymlinkPrompt(client, { serverPath, force, dryRun, instructionSize, yes: true });
         console.log(result);
       }
       return;
@@ -1063,7 +1316,7 @@ export async function runSetupCli(rawArgs: string[] = process.argv.slice(2)): Pr
 
     for (const client of selected) {
       try {
-        install({ client, serverPath, force, dryRun, instructionSize });
+        await installWithSymlinkPrompt(client, { serverPath, force, dryRun, instructionSize });
         p.log.success(`Installed for ${CLIENT_CONFIGS[client].name}`);
       } catch (e) {
         p.log.error(`${CLIENT_CONFIGS[client].name}: ${e instanceof Error ? e.message : e}`);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -54,6 +54,8 @@ export interface ClientConfig {
   instructionSize?: InstructionSize;
   /** Path where a Claude Code skill directory should be installed (e.g. ~/.claude/skills/open-zk-kb) */
   skillPath?: string;
+  /** Paths where a previous install may have left a managed block that should be cleaned up. */
+  staleAgentDocsPaths?: string[];
 }
 
 const PI_PACKAGE_NAME = 'open-zk-kb';
@@ -114,7 +116,8 @@ export const CLIENT_CONFIGS: Record<McpClient, ClientConfig> = {
     mcpFormat: 'standard',
     skillPath: path.join(expandPath('~/.omp'), 'agent', 'skills', 'open-zk-kb'),
     agentDocsPath: path.join(expandPath('~/.omp'), 'agent', 'RULES.md'),
-    instructionSize: 'full',
+    instructionSize: 'compact',
+    staleAgentDocsPaths: [path.join(expandPath('~/.omp'), 'agent', 'AGENTS.md')],
   },
 };
 
@@ -859,6 +862,21 @@ export function doctor(args: DoctorArgs = {}): string {
     if (!clientConfig.skillPath && !clientConfig.agentDocsPath) {
       pushCheck('INFO', `${clientConfig.name}: managed instructions are not currently supported`);
     }
+    // Check for stale managed blocks in old locations
+    if (clientConfig.staleAgentDocsPaths) {
+      for (const stalePath of clientConfig.staleAgentDocsPaths) {
+        if (stalePath === clientConfig.agentDocsPath) continue;
+        const staleInspection = inspectAgentDocs(stalePath);
+        if (staleInspection.exists && staleInspection.status !== 'missing') {
+          if (args.fix) {
+            removeAgentDocs(stalePath);
+            pushCheck('FIXED', `${clientConfig.name}: removed stale managed block from ${stalePath}`);
+          } else {
+            pushCheck('WARN', `${clientConfig.name}: stale managed block in ${stalePath} — run with --fix to remove`);
+          }
+        }
+      }
+    }
   }
 
   return [
@@ -997,6 +1015,18 @@ export function install(args: InstallArgs): string {
       agentDocsResult = injectAgentDocs(clientConfig.agentDocsPath, size, args.dryRun, args.client, PKG_VERSION);
     }
   }
+  // Clean up managed blocks from stale locations (e.g. OMP: AGENTS.md → RULES.md migration)
+  const staleCleaned: string[] = [];
+  if (clientConfig.staleAgentDocsPaths && !args.dryRun) {
+    for (const stalePath of clientConfig.staleAgentDocsPaths) {
+      if (stalePath === clientConfig.agentDocsPath) continue; // don't clean the current target
+      if (resolveSymlinkTarget(stalePath)) continue; // don't modify shared files via symlink
+      const staleResult = removeAgentDocs(stalePath);
+      if (staleResult.action === 'removed' || staleResult.action === 'file-deleted') {
+        staleCleaned.push(stalePath);
+      }
+    }
+  }
 
   let output = `Installed open-zk-kb for ${clientConfig.name}\n\n`;
   output += `Config: ${clientConfig.configPath}\n`;
@@ -1017,6 +1047,9 @@ export function install(args: InstallArgs): string {
   }
   if (migrationResult?.migrated) {
     output += `Migration: removed old CLAUDE.md managed block${migrationResult.fileDeleted ? ' (file deleted — was empty)' : ''}\n`;
+  }
+  for (const cleaned of staleCleaned) {
+    output += `Cleanup: removed stale managed block from ${cleaned}\n`;
   }
   if (templatesCopied > 0) {
     output += `Templates: ${templatesCopied} files → ${vaultTemplatesDir}\n`;

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -1625,6 +1625,8 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       // Clean up legacy file paths
       for (const target of targets) {
         if (!target.legacyFilePath || target.legacyFilePath === target.filePath) continue;
+        // Skip symlinked legacy paths to avoid modifying shared files (mirrors install/doctor guard)
+        try { if (fs.lstatSync(target.legacyFilePath).isSymbolicLink()) continue; } catch { /* doesn't exist */ }
         const legacyInspection = inspectAgentDocs(target.legacyFilePath);
         if (legacyInspection.exists && legacyInspection.status !== 'missing') {
           if (dryRun) {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -2005,6 +2005,7 @@ export interface TemplateArgs {
 
 export interface GetArgs {
   noteId: string;
+  model?: string;
 }
 
 export function handleGet(args: GetArgs, repo: NoteRepository): string {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -40,7 +40,7 @@ import type { EmbeddingConfig } from './embeddings.js';
 import { generateEmbedding, generateEmbeddingBatch, buildEmbeddingText } from './embeddings.js';
 import { getLatestVersion, isNewerVersion } from './utils/version-check.js';
 import { getAgentDocsTargets } from './agent-docs-targets.js';
-import { injectAgentDocs, inspectAgentDocs } from './agent-docs.js';
+import { injectAgentDocs, inspectAgentDocs, removeAgentDocs } from './agent-docs.js';
 import { detectClient, isVisibleToClient, getClientTags, clientTag, isKnownClient } from './client-heuristics.js';
 import { getInstalledInstructionVersions } from './instruction-versions.js';
 import { classifyModel, MODEL_HINT } from './model-capabilities.js';
@@ -1598,7 +1598,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
           if (dryRun) {
             output += '- Result: would refresh managed instructions to current template\n\n';
           } else {
-            const result = injectAgentDocs(target.filePath, target.instructionSize, false, target.client, currentVersion);
+            const result = injectAgentDocs(target.filePath, target.instructionSize, false, target.client, currentVersion, target.preamble);
             output += `- Result: ${result.action}\n\n`;
           }
           continue;
@@ -1608,7 +1608,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
           if (dryRun) {
             output += '- Result: would strip all duplicate markers and inject a single fresh block\n\n';
           } else {
-            const result = injectAgentDocs(target.filePath, target.instructionSize, false, target.client, currentVersion);
+            const result = injectAgentDocs(target.filePath, target.instructionSize, false, target.client, currentVersion, target.preamble);
             output += `- Result: ${result.action} (repaired duplicate markers)\n\n`;
           }
           continue;
@@ -1617,8 +1617,26 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         if (dryRun) {
           output += '- Result: would repair markers and append a fresh managed block while preserving other content\n\n';
         } else {
-          const result = injectAgentDocs(target.filePath, target.instructionSize, false, target.client, currentVersion);
+          const result = injectAgentDocs(target.filePath, target.instructionSize, false, target.client, currentVersion, target.preamble);
           output += `- Result: ${result.action}\n\n`;
+        }
+      }
+
+      // Clean up legacy file paths
+      for (const target of targets) {
+        if (!target.legacyFilePath || target.legacyFilePath === target.filePath) continue;
+        const legacyInspection = inspectAgentDocs(target.legacyFilePath);
+        if (legacyInspection.exists && legacyInspection.status !== 'missing') {
+          if (dryRun) {
+            output += `### ${target.name} (legacy cleanup)\n`;
+            output += `- Path: ${target.legacyFilePath}\n`;
+            output += `- Result: would remove stale managed block\n\n`;
+          } else {
+            const result = removeAgentDocs(target.legacyFilePath);
+            output += `### ${target.name} (legacy cleanup)\n`;
+            output += `- Path: ${target.legacyFilePath}\n`;
+            output += `- Result: ${result.action}\n\n`;
+          }
         }
       }
 

--- a/tests/pi-extension.test.ts
+++ b/tests/pi-extension.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createOpenZkKbPiExtension } from '../src/pi/extension.js';
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  parameters: unknown;
+  execute(toolCallId: string, params: Record<string, unknown>, signal?: AbortSignal): Promise<{
+    content: Array<{ type: 'text'; text: string }>;
+    isError?: boolean;
+  }>;
+}
+
+function writeMockMcpServer(): { dir: string; serverPath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'open-zk-kb-pi-mcp-'));
+  const serverPath = path.join(dir, 'server.mjs');
+  fs.writeFileSync(serverPath, `
+let buffer = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  buffer += chunk;
+  const lines = buffer.split('\\n');
+  buffer = lines.pop() ?? '';
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const message = JSON.parse(line);
+    if (message.method === 'notifications/initialized') continue;
+    if (message.method === 'initialize') {
+      respond(message.id, {
+        protocolVersion: message.params?.protocolVersion ?? '2025-06-18',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'mock-open-zk-kb', version: '1.0.0' }
+      });
+      continue;
+    }
+    if (message.method === 'tools/call') {
+      respond(message.id, {
+        content: [{ type: 'text', text: 'called ' + message.params.name + ' with ' + JSON.stringify(message.params.arguments) }]
+      });
+      continue;
+    }
+    respond(message.id, {});
+  }
+});
+function respond(id, result) {
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\\n');
+}
+`, 'utf-8');
+  return { dir, serverPath };
+}
+
+describe('Pi extension', () => {
+  it('registers knowledge tools and forwards calls through an MCP stdio bridge', async () => {
+    const { dir, serverPath } = writeMockMcpServer();
+    const registered: RegisteredTool[] = [];
+    const shutdownHandlers: Array<() => void | Promise<void>> = [];
+    let promptHandler: ((event: { systemPrompt: string }) => { systemPrompt?: string } | Promise<{ systemPrompt?: string }>) | undefined;
+
+    try {
+      const extension = createOpenZkKbPiExtension({
+        server: {
+          command: process.execPath,
+          args: [serverPath],
+          stderr: 'pipe',
+        },
+        clientName: 'test-open-zk-kb-pi',
+      });
+
+      extension({
+        registerTool(tool) {
+          registered.push(tool);
+        },
+        on(event, handler) {
+          if (event === 'session_shutdown') {
+            shutdownHandlers.push(handler);
+          } else if (event === 'before_agent_start') {
+            promptHandler = handler;
+          }
+        },
+      });
+
+      expect(registered.map((tool) => tool.name)).toContain('knowledge-search');
+      expect(registered.map((tool) => tool.name)).toContain('knowledge-store');
+      expect(registered.map((tool) => tool.name)).toContain('knowledge-template');
+      expect(promptHandler).toBeDefined();
+
+      const promptResult = await promptHandler?.({ systemPrompt: 'Base prompt' });
+      expect(promptResult?.systemPrompt).toContain('client: "pi"');
+
+      const tool = registered.find((candidate) => candidate.name === 'knowledge-template');
+      expect(tool).toBeDefined();
+      const result = await tool?.execute('tool-call-1', { kind: 'decision' });
+
+      expect(result?.isError).not.toBe(true);
+      expect(result?.content[0]?.text).toContain('called knowledge-template with {"kind":"decision"}');
+    } finally {
+      for (const handler of shutdownHandlers) {
+        await handler();
+      }
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -1296,4 +1296,142 @@ describe('setup.ts', () => {
     expect(output).toContain('OK OMP: managed instructions are healthy');
     expect(output).toContain('- ERROR: 0');
   });
+
+  // --- Symlink safety tests (generic, affects any client with agentDocsPath) ---
+
+  it('install skips agent docs when path is a symlink to shared file', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    // Simulate ~/.config/opencode/AGENTS.md → ~/.agents/AGENTS.md
+    const sharedFile = path.join(env.homeDir, '.agents', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+    fs.writeFileSync(sharedFile, '# Shared Global Rules\n', 'utf-8');
+
+    const agentDocsPath = path.join(env.xdgConfigHome, 'opencode', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(agentDocsPath), { recursive: true });
+    fs.symlinkSync(sharedFile, agentDocsPath);
+
+    const output = setupModule.install({
+      client: 'opencode',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    // Shared file must NOT be modified
+    const sharedContent = fs.readFileSync(sharedFile, 'utf-8');
+    expect(sharedContent).not.toContain('OPEN-ZK-KB');
+    expect(sharedContent).toBe('# Shared Global Rules\n');
+
+    // Output should report the skip with the resolved target
+    expect(output).toContain('skipped');
+    expect(output).toContain('.agents/AGENTS.md');
+  });
+
+  it('install injects into symlinked file when injectSharedAgentDocs is confirmed', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    // Simulate symlinked AGENTS.md
+    const sharedFile = path.join(env.homeDir, '.agents', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+    fs.writeFileSync(sharedFile, '# Shared Rules\n', 'utf-8');
+
+    const agentDocsPath = path.join(env.xdgConfigHome, 'opencode', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(agentDocsPath), { recursive: true });
+    fs.symlinkSync(sharedFile, agentDocsPath);
+
+    const output = setupModule.install({
+      client: 'opencode',
+      serverPath: env.fakeServerPath,
+      force: true,
+      injectSharedAgentDocs: true,
+    });
+
+    // Shared file SHOULD be modified when user confirms
+    const sharedContent = fs.readFileSync(sharedFile, 'utf-8');
+    expect(sharedContent).toContain('# Shared Rules');
+    expect(sharedContent).toContain('OPEN-ZK-KB:START');
+    expect(sharedContent).toContain('client: "opencode"');
+
+    // Output should report the injection, not a skip
+    expect(output).toContain('Agent docs:');
+    expect(output).not.toContain('skipped');
+  });
+
+  it('uninstall does not touch symlinked agent docs file', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    // Install with confirmed injection into shared file
+    const sharedFile = path.join(env.homeDir, '.agents', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+    fs.writeFileSync(sharedFile, '# Shared Rules\n', 'utf-8');
+
+    const agentDocsPath = path.join(env.xdgConfigHome, 'opencode', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(agentDocsPath), { recursive: true });
+    fs.symlinkSync(sharedFile, agentDocsPath);
+
+    setupModule.install({
+      client: 'opencode',
+      serverPath: env.fakeServerPath,
+      force: true,
+      injectSharedAgentDocs: true,
+    });
+    expect(fs.readFileSync(sharedFile, 'utf-8')).toContain('OPEN-ZK-KB:START');
+
+    // Uninstall should NOT touch the symlinked file
+    setupModule.uninstall({ client: 'opencode' });
+    const sharedContent = fs.readFileSync(sharedFile, 'utf-8');
+    expect(sharedContent).toContain('OPEN-ZK-KB:START');
+  });
+
+  it('doctor reports symlink info for client with symlinked agentDocsPath', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    // Simulate symlinked AGENTS.md for opencode
+    const sharedFile = path.join(env.homeDir, '.agents', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+    fs.writeFileSync(sharedFile, '# Shared\n', 'utf-8');
+
+    const agentDocsPath = path.join(env.xdgConfigHome, 'opencode', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(agentDocsPath), { recursive: true });
+    fs.symlinkSync(sharedFile, agentDocsPath);
+
+    setupModule.install({
+      client: 'opencode',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    const output = setupModule.doctor({ client: 'opencode' });
+    expect(output).toContain('OK OpenCode: MCP config looks healthy');
+    expect(output).toContain('INFO OpenCode: agent docs path is a symlink');
+    expect(output).toContain('- ERROR: 0');
+  });
+
+  it('non-symlinked agentDocsPath is injected and cleaned up normally', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    // Windsurf uses a non-symlinked path
+    setupModule.install({
+      client: 'windsurf',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    const agentDocsPath = path.join(env.homeDir, '.codeium', 'windsurf', 'memories', 'global_rules.md');
+    expect(fs.existsSync(agentDocsPath)).toBe(true);
+    const content = fs.readFileSync(agentDocsPath, 'utf-8');
+    expect(content).toContain('OPEN-ZK-KB:START');
+    expect(content).toContain('client: "windsurf"');
+
+    // Uninstall should clean up
+    setupModule.uninstall({ client: 'windsurf' });
+    if (fs.existsSync(agentDocsPath)) {
+      expect(fs.readFileSync(agentDocsPath, 'utf-8')).not.toContain('OPEN-ZK-KB:START');
+    }
+  });
 });

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -1180,7 +1180,7 @@ describe('setup.ts', () => {
     expect(config.mcpServers['open-zk-kb'].args).toContain('run');
   });
 
-  it('omp install injects agent docs into RULES.md AND installs skill (both)', async () => {
+  it('omp install injects agent docs into rules/open-zk-kb.md AND installs skill (both)', async () => {
     const env = createIsolatedInstallEnv();
     const setupModule = await loadFreshSetupModule();
 
@@ -1194,8 +1194,8 @@ describe('setup.ts', () => {
     const skillPath = path.join(env.homeDir, '.omp', 'agent', 'skills', 'open-zk-kb');
     expect(fs.existsSync(path.join(skillPath, 'SKILL.md'))).toBe(true);
 
-    // Agent docs should be injected into RULES.md (not AGENTS.md)
-    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    // Agent docs should be injected into rules/open-zk-kb.md (not AGENTS.md)
+    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'rules', 'open-zk-kb.md');
     expect(fs.existsSync(rulesPath)).toBe(true);
     const content = fs.readFileSync(rulesPath, 'utf-8');
     expect(content).toContain('OPEN-ZK-KB:START');
@@ -1204,6 +1204,8 @@ describe('setup.ts', () => {
     expect(content).toContain('knowledge-store');
     // Client name should be templated in
     expect(content).toContain('client: "omp"');
+    // New file should have YAML frontmatter preamble
+    expect(content).toMatch(/^---\nalwaysApply: true/);
 
     // AGENTS.md should NOT exist (not our file to create)
     const agentsMdPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
@@ -1214,11 +1216,11 @@ describe('setup.ts', () => {
     expect(output).toContain('Agent docs:');
   });
 
-  it('omp install preserves existing RULES.md content when injecting', async () => {
+  it('omp install preserves existing rules/open-zk-kb.md content when injecting', async () => {
     const env = createIsolatedInstallEnv();
     const setupModule = await loadFreshSetupModule();
 
-    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'rules', 'open-zk-kb.md');
     fs.mkdirSync(path.dirname(rulesPath), { recursive: true });
     fs.writeFileSync(rulesPath, '# My Custom Rules\n\nNever commit secrets.\n', 'utf-8');
 
@@ -1234,7 +1236,7 @@ describe('setup.ts', () => {
     expect(content).toContain('OPEN-ZK-KB:START');
   });
 
-  it('uninstall removes skill, agent docs from RULES.md, and MCP entry for omp', async () => {
+  it('uninstall removes skill, agent docs from rules/open-zk-kb.md, and MCP entry for omp', async () => {
     const env = createIsolatedInstallEnv();
     const setupModule = await loadFreshSetupModule();
 
@@ -1246,7 +1248,7 @@ describe('setup.ts', () => {
 
     const skillPath = path.join(env.homeDir, '.omp', 'agent', 'skills', 'open-zk-kb');
     const configPath = path.join(env.homeDir, '.omp', 'agent', 'mcp.json');
-    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'rules', 'open-zk-kb.md');
     expect(fs.existsSync(skillPath)).toBe(true);
     expect(fs.existsSync(configPath)).toBe(true);
     expect(fs.readFileSync(rulesPath, 'utf-8')).toContain('OPEN-ZK-KB:START');
@@ -1441,7 +1443,7 @@ describe('setup.ts', () => {
 
   // --- Stale location cleanup tests ---
 
-  it('omp install cleans up stale managed block from AGENTS.md when using RULES.md', async () => {
+  it('omp install cleans up stale managed blocks from AGENTS.md and RULES.md', async () => {
     const env = createIsolatedInstallEnv();
     const setupModule = await loadFreshSetupModule();
 
@@ -1453,6 +1455,13 @@ describe('setup.ts', () => {
       'utf-8',
     );
 
+    // Simulate a leftover managed block in the old RULES.md location
+    const staleRulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    fs.writeFileSync(staleRulesPath,
+      '<!-- OPEN-ZK-KB:START -- managed by open-zk-kb, do not edit -->\nOld RULES instructions\n<!-- OPEN-ZK-KB:END -->\n',
+      'utf-8',
+    );
+
     const output = setupModule.install({
       client: 'omp',
       serverPath: env.fakeServerPath,
@@ -1460,13 +1469,18 @@ describe('setup.ts', () => {
     });
 
     // New location should have the compact instructions
-    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'rules', 'open-zk-kb.md');
     expect(fs.readFileSync(rulesPath, 'utf-8')).toContain('OPEN-ZK-KB:START');
 
     // Old location should be cleaned up
     const staleContent = fs.readFileSync(staleAgentsPath, 'utf-8');
     expect(staleContent).toContain('# My Rules');
     expect(staleContent).not.toContain('OPEN-ZK-KB:START');
+
+    // Old RULES.md location should also be cleaned up
+    if (fs.existsSync(staleRulesPath)) {
+      expect(fs.readFileSync(staleRulesPath, 'utf-8')).not.toContain('OPEN-ZK-KB:START');
+    }
 
     // Output should mention the cleanup
     expect(output).toContain('Cleanup:');
@@ -1499,8 +1513,8 @@ describe('setup.ts', () => {
     expect(sharedContent).toContain('OPEN-ZK-KB:START'); // still has the old block
     expect(sharedContent).toContain('# Shared'); // original content preserved
 
-    // RULES.md should be created correctly
-    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    // rules/open-zk-kb.md should be created correctly
+    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'rules', 'open-zk-kb.md');
     expect(fs.readFileSync(rulesPath, 'utf-8')).toContain('OPEN-ZK-KB:START');
   });
 
@@ -1508,7 +1522,7 @@ describe('setup.ts', () => {
     const env = createIsolatedInstallEnv();
     const setupModule = await loadFreshSetupModule();
 
-    // Install normally (goes to RULES.md)
+    // Install normally (goes to rules/open-zk-kb.md)
     setupModule.install({
       client: 'omp',
       serverPath: env.fakeServerPath,
@@ -1551,7 +1565,7 @@ describe('setup.ts', () => {
     expect(cleaned).not.toContain('OPEN-ZK-KB:START');
   });
 
-  it('omp install uses compact instructions for RULES.md (not full)', async () => {
+  it('omp install uses compact instructions for rules/open-zk-kb.md (not full)', async () => {
     const env = createIsolatedInstallEnv();
     const setupModule = await loadFreshSetupModule();
 
@@ -1561,7 +1575,7 @@ describe('setup.ts', () => {
       force: true,
     });
 
-    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'rules', 'open-zk-kb.md');
     const content = fs.readFileSync(rulesPath, 'utf-8');
 
     // Compact template does NOT have these sections (they're full-only)

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -1494,11 +1494,12 @@ describe('setup.ts', () => {
       force: true,
     });
 
-    // Shared file must NOT be touched — stale cleanup uses removeAgentDocs
-    // which follows the symlink. The managed block should still be there.
-    // This is acceptable: we only clean non-symlinked stale locations.
-    // (removeAgentDocs writes to the resolved path, which is the shared file)
-    // So we verify RULES.md was created correctly:
+    // Shared file must NOT be touched — stale cleanup skips symlinks
+    const sharedContent = fs.readFileSync(sharedFile, 'utf-8');
+    expect(sharedContent).toContain('OPEN-ZK-KB:START'); // still has the old block
+    expect(sharedContent).toContain('# Shared'); // original content preserved
+
+    // RULES.md should be created correctly
     const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
     expect(fs.readFileSync(rulesPath, 'utf-8')).toContain('OPEN-ZK-KB:START');
   });

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { createTestHarness, cleanupTestHarness } from './harness.js';
 import type { TestContext } from './harness.js';
 
@@ -236,6 +237,8 @@ describe('setup.ts', () => {
     const agentDocs = fs.readFileSync(agentDocsPath, 'utf-8');
     expect(agentDocs).toContain('OPEN-ZK-KB:START');
     expect(agentDocs).toContain('client: "pi"');
+    expect(output).toContain('pi install');
+    expect(output).toContain('Pi does not support MCP natively');
   });
 
   it('Pi dry-run previews package setup without requiring an MCP server path', async () => {
@@ -250,6 +253,7 @@ describe('setup.ts', () => {
     expect(output).toContain(`Dry run: Would add Pi package source to ${path.join(env.homeDir, '.pi', 'agent', 'settings.json')}`);
     expect(output).toContain(getExpectedPiPackageSource());
     expect(output).toContain(`Would inject agent docs into ${path.join(env.homeDir, '.pi', 'agent', 'AGENTS.md')}`);
+    expect(output).toContain('Pi does not support MCP natively');
   });
 
   it('Pi uninstall removes only the open-zk-kb package source and managed instructions', async () => {

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -1176,7 +1176,7 @@ describe('setup.ts', () => {
     expect(config.mcpServers['open-zk-kb'].args).toContain('run');
   });
 
-  it('omp install injects agent docs AND installs skill (both)', async () => {
+  it('omp install injects agent docs into RULES.md AND installs skill (both)', async () => {
     const env = createIsolatedInstallEnv();
     const setupModule = await loadFreshSetupModule();
 
@@ -1190,10 +1190,10 @@ describe('setup.ts', () => {
     const skillPath = path.join(env.homeDir, '.omp', 'agent', 'skills', 'open-zk-kb');
     expect(fs.existsSync(path.join(skillPath, 'SKILL.md'))).toBe(true);
 
-    // Agent docs should also be injected
-    const agentDocsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
-    expect(fs.existsSync(agentDocsPath)).toBe(true);
-    const content = fs.readFileSync(agentDocsPath, 'utf-8');
+    // Agent docs should be injected into RULES.md (not AGENTS.md)
+    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    expect(fs.existsSync(rulesPath)).toBe(true);
+    const content = fs.readFileSync(rulesPath, 'utf-8');
     expect(content).toContain('OPEN-ZK-KB:START');
     expect(content).toContain('OPEN-ZK-KB:END');
     expect(content).toContain('knowledge-search');
@@ -1201,18 +1201,22 @@ describe('setup.ts', () => {
     // Client name should be templated in
     expect(content).toContain('client: "omp"');
 
+    // AGENTS.md should NOT exist (not our file to create)
+    const agentsMdPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
+    expect(fs.existsSync(agentsMdPath)).toBe(false);
+
     // Output should mention both
     expect(output).toContain('Skill:');
     expect(output).toContain('Agent docs:');
   });
 
-  it('omp install preserves existing AGENTS.md content when injecting', async () => {
+  it('omp install preserves existing RULES.md content when injecting', async () => {
     const env = createIsolatedInstallEnv();
     const setupModule = await loadFreshSetupModule();
 
-    const agentDocsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
-    fs.mkdirSync(path.dirname(agentDocsPath), { recursive: true });
-    fs.writeFileSync(agentDocsPath, '# My Global Rules\n\nCustom content here.\n', 'utf-8');
+    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    fs.mkdirSync(path.dirname(rulesPath), { recursive: true });
+    fs.writeFileSync(rulesPath, '# My Custom Rules\n\nNever commit secrets.\n', 'utf-8');
 
     setupModule.install({
       client: 'omp',
@@ -1220,88 +1224,15 @@ describe('setup.ts', () => {
       force: true,
     });
 
-    const content = fs.readFileSync(agentDocsPath, 'utf-8');
-    expect(content).toContain('# My Global Rules');
-    expect(content).toContain('Custom content here.');
+    const content = fs.readFileSync(rulesPath, 'utf-8');
+    expect(content).toContain('# My Custom Rules');
+    expect(content).toContain('Never commit secrets.');
     expect(content).toContain('OPEN-ZK-KB:START');
   });
 
-  it('omp install skips agent docs when path is a symlink to shared file', async () => {
+  it('uninstall removes skill, agent docs from RULES.md, and MCP entry for omp', async () => {
     const env = createIsolatedInstallEnv();
     const setupModule = await loadFreshSetupModule();
-
-    // Create a shared source file and symlink to it (mimicking ~/.agents/AGENTS.md)
-    const sharedFile = path.join(env.homeDir, '.agents', 'AGENTS.md');
-    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
-    fs.writeFileSync(sharedFile, '# Shared Global Rules\n', 'utf-8');
-
-    const agentDocsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
-    fs.mkdirSync(path.dirname(agentDocsPath), { recursive: true });
-    fs.symlinkSync(sharedFile, agentDocsPath);
-
-    const output = setupModule.install({
-      client: 'omp',
-      serverPath: env.fakeServerPath,
-      force: true,
-    });
-
-    // Shared file must NOT be modified
-    const sharedContent = fs.readFileSync(sharedFile, 'utf-8');
-    expect(sharedContent).not.toContain('OPEN-ZK-KB');
-    expect(sharedContent).toBe('# Shared Global Rules\n');
-
-    // Output should report the skip with the symlink target
-    expect(output).toContain('skipped');
-    expect(output).toContain('.agents/AGENTS.md');
-
-    // Skill should still be installed
-    const skillPath = path.join(env.homeDir, '.omp', 'agent', 'skills', 'open-zk-kb');
-    expect(fs.existsSync(path.join(skillPath, 'SKILL.md'))).toBe(true);
-  });
-
-  it('omp install injects into symlinked file when injectSharedAgentDocs is set', async () => {
-    const env = createIsolatedInstallEnv();
-    const setupModule = await loadFreshSetupModule();
-
-    // Create a shared source file and symlink
-    const sharedFile = path.join(env.homeDir, '.agents', 'AGENTS.md');
-    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
-    fs.writeFileSync(sharedFile, '# Shared Rules\n', 'utf-8');
-
-    const agentDocsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
-    fs.mkdirSync(path.dirname(agentDocsPath), { recursive: true });
-    fs.symlinkSync(sharedFile, agentDocsPath);
-
-    const output = setupModule.install({
-      client: 'omp',
-      serverPath: env.fakeServerPath,
-      force: true,
-      injectSharedAgentDocs: true,
-    });
-
-    // Shared file SHOULD be modified when user confirms
-    const sharedContent = fs.readFileSync(sharedFile, 'utf-8');
-    expect(sharedContent).toContain('# Shared Rules');
-    expect(sharedContent).toContain('OPEN-ZK-KB:START');
-    expect(sharedContent).toContain('client: "omp"');
-
-    // Output should report the injection, not a skip
-    expect(output).toContain('Agent docs:');
-    expect(output).not.toContain('skipped');
-  });
-
-  it('doctor reports symlink info for omp when AGENTS.md is symlinked', async () => {
-    const env = createIsolatedInstallEnv();
-    const setupModule = await loadFreshSetupModule();
-
-    // Create symlink setup
-    const sharedFile = path.join(env.homeDir, '.agents', 'AGENTS.md');
-    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
-    fs.writeFileSync(sharedFile, '# Shared\n', 'utf-8');
-
-    const agentDocsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
-    fs.mkdirSync(path.dirname(agentDocsPath), { recursive: true });
-    fs.symlinkSync(sharedFile, agentDocsPath);
 
     setupModule.install({
       client: 'omp',
@@ -1309,10 +1240,22 @@ describe('setup.ts', () => {
       force: true,
     });
 
-    const output = setupModule.doctor({ client: 'omp' });
-    expect(output).toContain('OK OMP: skill is healthy');
-    expect(output).toContain('INFO OMP: agent docs path is a symlink (');
-    expect(output).toContain('- ERROR: 0');
+    const skillPath = path.join(env.homeDir, '.omp', 'agent', 'skills', 'open-zk-kb');
+    const configPath = path.join(env.homeDir, '.omp', 'agent', 'mcp.json');
+    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    expect(fs.existsSync(skillPath)).toBe(true);
+    expect(fs.existsSync(configPath)).toBe(true);
+    expect(fs.readFileSync(rulesPath, 'utf-8')).toContain('OPEN-ZK-KB:START');
+
+    setupModule.uninstall({ client: 'omp' });
+    expect(fs.existsSync(skillPath)).toBe(false);
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(config.mcpServers['open-zk-kb']).toBeUndefined();
+    // Agent docs block should be removed (file deleted since it was only the managed block)
+    if (fs.existsSync(rulesPath)) {
+      const content = fs.readFileSync(rulesPath, 'utf-8');
+      expect(content).not.toContain('OPEN-ZK-KB:START');
+    }
   });
 
   it('omp install preserves existing mcpServers entries', async () => {
@@ -1336,34 +1279,6 @@ describe('setup.ts', () => {
     const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(config.mcpServers['other-server']).toBeDefined();
     expect(config.mcpServers['open-zk-kb']).toBeDefined();
-  });
-
-  it('uninstall removes skill, agent docs, and MCP entry for omp', async () => {
-    const env = createIsolatedInstallEnv();
-    const setupModule = await loadFreshSetupModule();
-
-    setupModule.install({
-      client: 'omp',
-      serverPath: env.fakeServerPath,
-      force: true,
-    });
-
-    const skillPath = path.join(env.homeDir, '.omp', 'agent', 'skills', 'open-zk-kb');
-    const configPath = path.join(env.homeDir, '.omp', 'agent', 'mcp.json');
-    const agentDocsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
-    expect(fs.existsSync(skillPath)).toBe(true);
-    expect(fs.existsSync(configPath)).toBe(true);
-    expect(fs.readFileSync(agentDocsPath, 'utf-8')).toContain('OPEN-ZK-KB:START');
-
-    setupModule.uninstall({ client: 'omp' });
-    expect(fs.existsSync(skillPath)).toBe(false);
-    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    expect(config.mcpServers['open-zk-kb']).toBeUndefined();
-    // Agent docs block should be removed (file deleted since it was only the managed block)
-    if (fs.existsSync(agentDocsPath)) {
-      const content = fs.readFileSync(agentDocsPath, 'utf-8');
-      expect(content).not.toContain('OPEN-ZK-KB:START');
-    }
   });
 
   it('doctor reports healthy skill and agent docs for omp', async () => {

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -13,7 +13,7 @@ interface EnvSnapshot {
 
 
 
-type McpClient = 'opencode' | 'claude-code' | 'cursor' | 'windsurf' | 'zed';
+type McpClient = 'opencode' | 'claude-code' | 'cursor' | 'windsurf' | 'zed' | 'omp';
 
 interface ClientCase {
   client: McpClient;
@@ -56,6 +56,12 @@ const CLIENT_CASES: ClientCase[] = [
     mcpPath: ['context_servers', 'open-zk-kb'],
     format: 'standard',
   },
+  {
+    client: 'omp',
+    getConfigPath: ({ homeDir }) => path.join(homeDir, '.omp', 'agent', 'mcp.json'),
+    mcpPath: ['mcpServers', 'open-zk-kb'],
+    format: 'standard',
+  },
 ];
 
 function getNestedValue(obj: unknown, keys: string[]): unknown {
@@ -71,6 +77,10 @@ function getNestedValue(obj: unknown, keys: string[]): unknown {
   return current;
 }
 
+function getExpectedPiPackageSource(): string {
+  const testFilePath = fileURLToPath(import.meta.url);
+  return path.resolve(path.dirname(testFilePath), '..');
+}
 describe('setup.ts', () => {
   let ctx: TestContext;
   let envSnapshot: EnvSnapshot;
@@ -142,7 +152,7 @@ describe('setup.ts', () => {
     return import(`../src/agent-docs.js?test=${Date.now()}-${Math.random()}`);
   }
 
-  it('produces correct dry-run output format for all 5 clients', async () => {
+  it('produces correct dry-run output format for all 6 MCP clients', async () => {
     const env = createIsolatedInstallEnv();
     const setupModule = await loadFreshSetupModule();
 
@@ -171,7 +181,7 @@ describe('setup.ts', () => {
     }
   });
 
-  it('creates config at expected path with correct nested keys and MCP entry formats for all 5 clients', async () => {
+  it('creates config at expected path with correct nested keys and MCP entry formats for all 6 MCP clients', async () => {
     const env = createIsolatedInstallEnv();
     const setupModule = await loadFreshSetupModule();
 
@@ -204,6 +214,64 @@ describe('setup.ts', () => {
         });
       }
     }
+  });
+
+  it('installs Pi as a package source with managed AGENTS.md instructions', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    const output = setupModule.install({
+      client: 'pi',
+      force: true,
+    });
+
+    const settingsPath = path.join(env.homeDir, '.pi', 'agent', 'settings.json');
+    const agentDocsPath = path.join(env.homeDir, '.pi', 'agent', 'AGENTS.md');
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as { packages?: string[] };
+
+    expect(output).toContain('Installed open-zk-kb for Pi');
+    expect(output).toContain(`Package: ${getExpectedPiPackageSource()}`);
+    expect(settings.packages).toEqual([getExpectedPiPackageSource()]);
+    expect(fs.existsSync(agentDocsPath)).toBe(true);
+    const agentDocs = fs.readFileSync(agentDocsPath, 'utf-8');
+    expect(agentDocs).toContain('OPEN-ZK-KB:START');
+    expect(agentDocs).toContain('client: "pi"');
+  });
+
+  it('Pi dry-run previews package setup without requiring an MCP server path', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    const output = setupModule.install({
+      client: 'pi',
+      dryRun: true,
+    });
+
+    expect(output).toContain(`Dry run: Would add Pi package source to ${path.join(env.homeDir, '.pi', 'agent', 'settings.json')}`);
+    expect(output).toContain(getExpectedPiPackageSource());
+    expect(output).toContain(`Would inject agent docs into ${path.join(env.homeDir, '.pi', 'agent', 'AGENTS.md')}`);
+  });
+
+  it('Pi uninstall removes only the open-zk-kb package source and managed instructions', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    const settingsPath = path.join(env.homeDir, '.pi', 'agent', 'settings.json');
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ packages: ['npm:other-package'] }, null, 2), 'utf-8');
+
+    setupModule.install({
+      client: 'pi',
+      force: true,
+    });
+
+    const uninstallOutput = setupModule.uninstall({ client: 'pi' });
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as { packages?: string[] };
+    const agentDocsPath = path.join(env.homeDir, '.pi', 'agent', 'AGENTS.md');
+
+    expect(uninstallOutput).toContain('Uninstalled open-zk-kb from Pi');
+    expect(settings.packages).toEqual(['npm:other-package']);
+    expect(fs.existsSync(agentDocsPath)).toBe(false);
   });
 
   it('is idempotent when install runs twice without force', async () => {
@@ -755,6 +823,22 @@ describe('setup.ts', () => {
     expect(output).toContain('- ERROR: 0');
   });
 
+  it('doctor reports a healthy Pi package install', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    setupModule.install({
+      client: 'pi',
+      force: true,
+    });
+
+    const output = setupModule.doctor({ client: 'pi' });
+
+    expect(output).toContain(`OK Pi: package source looks healthy in ${path.join(env.homeDir, '.pi', 'agent', 'settings.json')}`);
+    expect(output).toContain(`OK Pi: managed instructions are healthy in ${path.join(env.homeDir, '.pi', 'agent', 'AGENTS.md')}`);
+    expect(output).toContain('- ERROR: 0');
+  });
+
   it('doctor does not warn about unmanaged instruction files when client is not installed', async () => {
     const env = createIsolatedInstallEnv();
     const setupModule = await loadFreshSetupModule();
@@ -1049,5 +1133,252 @@ describe('setup.ts', () => {
 
     const output = setupModule.doctor({ client: 'claude-code', fix: true });
     expect(output).toContain('FIXED Claude Code: removed stale CLAUDE.md managed block');
+  });
+
+  it('install creates skill directory with SKILL.md for omp', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    const skillPath = path.join(env.homeDir, '.omp', 'agent', 'skills', 'open-zk-kb');
+    expect(fs.existsSync(skillPath)).toBe(true);
+    expect(fs.existsSync(path.join(skillPath, 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillPath, 'kinds-reference.md'))).toBe(true);
+
+    const skillContent = fs.readFileSync(path.join(skillPath, 'SKILL.md'), 'utf-8');
+    expect(skillContent).toContain('name: open-zk-kb');
+    expect(skillContent).toContain('description:');
+    expect(skillContent).toContain('knowledge-search');
+    expect(skillContent).toContain('knowledge-store');
+  });
+
+  it('install writes standard mcpServers entry for omp', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    const configPath = path.join(env.homeDir, '.omp', 'agent', 'mcp.json');
+    expect(fs.existsSync(configPath)).toBe(true);
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(config.mcpServers).toBeDefined();
+    expect(config.mcpServers['open-zk-kb']).toBeDefined();
+    expect(config.mcpServers['open-zk-kb'].command).toBe('bun');
+    expect(config.mcpServers['open-zk-kb'].args).toContain('run');
+  });
+
+  it('omp install injects agent docs AND installs skill (both)', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    const output = setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    // Skill should be installed
+    const skillPath = path.join(env.homeDir, '.omp', 'agent', 'skills', 'open-zk-kb');
+    expect(fs.existsSync(path.join(skillPath, 'SKILL.md'))).toBe(true);
+
+    // Agent docs should also be injected
+    const agentDocsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
+    expect(fs.existsSync(agentDocsPath)).toBe(true);
+    const content = fs.readFileSync(agentDocsPath, 'utf-8');
+    expect(content).toContain('OPEN-ZK-KB:START');
+    expect(content).toContain('OPEN-ZK-KB:END');
+    expect(content).toContain('knowledge-search');
+    expect(content).toContain('knowledge-store');
+    // Client name should be templated in
+    expect(content).toContain('client: "omp"');
+
+    // Output should mention both
+    expect(output).toContain('Skill:');
+    expect(output).toContain('Agent docs:');
+  });
+
+  it('omp install preserves existing AGENTS.md content when injecting', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    const agentDocsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(agentDocsPath), { recursive: true });
+    fs.writeFileSync(agentDocsPath, '# My Global Rules\n\nCustom content here.\n', 'utf-8');
+
+    setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    const content = fs.readFileSync(agentDocsPath, 'utf-8');
+    expect(content).toContain('# My Global Rules');
+    expect(content).toContain('Custom content here.');
+    expect(content).toContain('OPEN-ZK-KB:START');
+  });
+
+  it('omp install skips agent docs when path is a symlink to shared file', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    // Create a shared source file and symlink to it (mimicking ~/.agents/AGENTS.md)
+    const sharedFile = path.join(env.homeDir, '.agents', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+    fs.writeFileSync(sharedFile, '# Shared Global Rules\n', 'utf-8');
+
+    const agentDocsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(agentDocsPath), { recursive: true });
+    fs.symlinkSync(sharedFile, agentDocsPath);
+
+    const output = setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    // Shared file must NOT be modified
+    const sharedContent = fs.readFileSync(sharedFile, 'utf-8');
+    expect(sharedContent).not.toContain('OPEN-ZK-KB');
+    expect(sharedContent).toBe('# Shared Global Rules\n');
+
+    // Output should report the skip with the symlink target
+    expect(output).toContain('skipped');
+    expect(output).toContain('.agents/AGENTS.md');
+
+    // Skill should still be installed
+    const skillPath = path.join(env.homeDir, '.omp', 'agent', 'skills', 'open-zk-kb');
+    expect(fs.existsSync(path.join(skillPath, 'SKILL.md'))).toBe(true);
+  });
+
+  it('omp install injects into symlinked file when injectSharedAgentDocs is set', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    // Create a shared source file and symlink
+    const sharedFile = path.join(env.homeDir, '.agents', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+    fs.writeFileSync(sharedFile, '# Shared Rules\n', 'utf-8');
+
+    const agentDocsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(agentDocsPath), { recursive: true });
+    fs.symlinkSync(sharedFile, agentDocsPath);
+
+    const output = setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+      injectSharedAgentDocs: true,
+    });
+
+    // Shared file SHOULD be modified when user confirms
+    const sharedContent = fs.readFileSync(sharedFile, 'utf-8');
+    expect(sharedContent).toContain('# Shared Rules');
+    expect(sharedContent).toContain('OPEN-ZK-KB:START');
+    expect(sharedContent).toContain('client: "omp"');
+
+    // Output should report the injection, not a skip
+    expect(output).toContain('Agent docs:');
+    expect(output).not.toContain('skipped');
+  });
+
+  it('doctor reports symlink info for omp when AGENTS.md is symlinked', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    // Create symlink setup
+    const sharedFile = path.join(env.homeDir, '.agents', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+    fs.writeFileSync(sharedFile, '# Shared\n', 'utf-8');
+
+    const agentDocsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(agentDocsPath), { recursive: true });
+    fs.symlinkSync(sharedFile, agentDocsPath);
+
+    setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    const output = setupModule.doctor({ client: 'omp' });
+    expect(output).toContain('OK OMP: skill is healthy');
+    expect(output).toContain('INFO OMP: agent docs path is a symlink (');
+    expect(output).toContain('- ERROR: 0');
+  });
+
+  it('omp install preserves existing mcpServers entries', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    const configPath = path.join(env.homeDir, '.omp', 'agent', 'mcp.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({
+      mcpServers: {
+        'other-server': { command: 'npx', args: ['-y', 'other-server'] },
+      },
+    }, null, 2), 'utf-8');
+
+    setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(config.mcpServers['other-server']).toBeDefined();
+    expect(config.mcpServers['open-zk-kb']).toBeDefined();
+  });
+
+  it('uninstall removes skill, agent docs, and MCP entry for omp', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    const skillPath = path.join(env.homeDir, '.omp', 'agent', 'skills', 'open-zk-kb');
+    const configPath = path.join(env.homeDir, '.omp', 'agent', 'mcp.json');
+    const agentDocsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
+    expect(fs.existsSync(skillPath)).toBe(true);
+    expect(fs.existsSync(configPath)).toBe(true);
+    expect(fs.readFileSync(agentDocsPath, 'utf-8')).toContain('OPEN-ZK-KB:START');
+
+    setupModule.uninstall({ client: 'omp' });
+    expect(fs.existsSync(skillPath)).toBe(false);
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(config.mcpServers['open-zk-kb']).toBeUndefined();
+    // Agent docs block should be removed (file deleted since it was only the managed block)
+    if (fs.existsSync(agentDocsPath)) {
+      const content = fs.readFileSync(agentDocsPath, 'utf-8');
+      expect(content).not.toContain('OPEN-ZK-KB:START');
+    }
+  });
+
+  it('doctor reports healthy skill and agent docs for omp', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    const output = setupModule.doctor({ client: 'omp' });
+    expect(output).toContain('OK OMP: skill is healthy');
+    expect(output).toContain('OK OMP: managed instructions are healthy');
+    expect(output).toContain('- ERROR: 0');
   });
 });

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -1434,4 +1434,139 @@ describe('setup.ts', () => {
       expect(fs.readFileSync(agentDocsPath, 'utf-8')).not.toContain('OPEN-ZK-KB:START');
     }
   });
+
+  // --- Stale location cleanup tests ---
+
+  it('omp install cleans up stale managed block from AGENTS.md when using RULES.md', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    // Simulate a leftover managed block in the old AGENTS.md location
+    const staleAgentsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(staleAgentsPath), { recursive: true });
+    fs.writeFileSync(staleAgentsPath,
+      '# My Rules\n\n<!-- OPEN-ZK-KB:START -- managed by open-zk-kb, do not edit -->\nOld instructions\n<!-- OPEN-ZK-KB:END -->\n',
+      'utf-8',
+    );
+
+    const output = setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    // New location should have the compact instructions
+    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    expect(fs.readFileSync(rulesPath, 'utf-8')).toContain('OPEN-ZK-KB:START');
+
+    // Old location should be cleaned up
+    const staleContent = fs.readFileSync(staleAgentsPath, 'utf-8');
+    expect(staleContent).toContain('# My Rules');
+    expect(staleContent).not.toContain('OPEN-ZK-KB:START');
+
+    // Output should mention the cleanup
+    expect(output).toContain('Cleanup:');
+    expect(output).toContain('AGENTS.md');
+  });
+
+  it('omp install does not touch stale AGENTS.md if it is a symlink', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    // Simulate a symlinked AGENTS.md with a managed block in the shared target
+    const sharedFile = path.join(env.homeDir, '.agents', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+    fs.writeFileSync(sharedFile,
+      '# Shared\n\n<!-- OPEN-ZK-KB:START -- managed by open-zk-kb, do not edit -->\nOld\n<!-- OPEN-ZK-KB:END -->\n',
+      'utf-8',
+    );
+    const staleAgentsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(staleAgentsPath), { recursive: true });
+    fs.symlinkSync(sharedFile, staleAgentsPath);
+
+    setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    // Shared file must NOT be touched — stale cleanup uses removeAgentDocs
+    // which follows the symlink. The managed block should still be there.
+    // This is acceptable: we only clean non-symlinked stale locations.
+    // (removeAgentDocs writes to the resolved path, which is the shared file)
+    // So we verify RULES.md was created correctly:
+    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    expect(fs.readFileSync(rulesPath, 'utf-8')).toContain('OPEN-ZK-KB:START');
+  });
+
+  it('doctor detects stale managed block in old OMP AGENTS.md location', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    // Install normally (goes to RULES.md)
+    setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    // Manually add a stale block to the old AGENTS.md location
+    const staleAgentsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
+    fs.writeFileSync(staleAgentsPath,
+      '<!-- OPEN-ZK-KB:START -- managed by open-zk-kb, do not edit -->\nStale\n<!-- OPEN-ZK-KB:END -->\n',
+      'utf-8',
+    );
+
+    const output = setupModule.doctor({ client: 'omp' });
+    expect(output).toContain('WARN OMP: stale managed block in');
+    expect(output).toContain('AGENTS.md');
+  });
+
+  it('doctor --fix removes stale managed block from old OMP AGENTS.md location', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    const staleAgentsPath = path.join(env.homeDir, '.omp', 'agent', 'AGENTS.md');
+    fs.writeFileSync(staleAgentsPath,
+      '# Rules\n\n<!-- OPEN-ZK-KB:START -- managed by open-zk-kb, do not edit -->\nStale\n<!-- OPEN-ZK-KB:END -->\n',
+      'utf-8',
+    );
+
+    const output = setupModule.doctor({ client: 'omp', fix: true });
+    expect(output).toContain('FIXED OMP: removed stale managed block');
+
+    const cleaned = fs.readFileSync(staleAgentsPath, 'utf-8');
+    expect(cleaned).toContain('# Rules');
+    expect(cleaned).not.toContain('OPEN-ZK-KB:START');
+  });
+
+  it('omp install uses compact instructions for RULES.md (not full)', async () => {
+    const env = createIsolatedInstallEnv();
+    const setupModule = await loadFreshSetupModule();
+
+    setupModule.install({
+      client: 'omp',
+      serverPath: env.fakeServerPath,
+      force: true,
+    });
+
+    const rulesPath = path.join(env.homeDir, '.omp', 'agent', 'RULES.md');
+    const content = fs.readFileSync(rulesPath, 'utf-8');
+
+    // Compact template does NOT have these sections (they're full-only)
+    expect(content).not.toContain('### Pre-Flight');
+    expect(content).not.toContain('### Storing Knowledge');
+    expect(content).not.toContain('### Capture Checkpoints');
+
+    // Compact template DOES have the essentials
+    expect(content).toContain('knowledge-search');
+    expect(content).toContain('knowledge-store');
+    expect(content).toContain('client: "omp"');
+  });
 });


### PR DESCRIPTION
## Summary

Add Pi and OMP as supported clients (bringing the total to 7), and introduce `knowledge-get` as the 9th MCP tool.

### Pi Integration

Pi does not include native MCP support, so open-zk-kb ships as a **Pi package extension** that bridges the existing MCP server into Pi-native `knowledge-*` tools. The extension:

- Spawns the MCP server as a subprocess and proxies tool calls via `@modelcontextprotocol/sdk` client
- Registers all 9 tools with Pi-native schemas matching the server exactly
- Uses lazy connection (no subprocess until first tool call)
- Injects prompt guidelines via `before_agent_start` hook
- Cleans up via `session_shutdown` handler

**Install paths:**
- `pi install npm:open-zk-kb` (native Pi package install)
- `bunx open-zk-kb@latest install --client pi` (writes settings + managed AGENTS.md instructions)

### OMP Integration

OMP supports MCP natively, so integration follows the standard pattern:

- MCP config at `~/.omp/agent/mcp.json`
- Skill installed at `~/.omp/agent/skills/open-zk-kb/`
- Managed instructions injected into `~/.omp/agent/RULES.md` (compact size)
- Stale location cleanup migrates from old `AGENTS.md` path

### New: `knowledge-get` MCP Tool

Retrieves a single note by exact ID — faster and more precise than `knowledge-search`. Use when you already know the note ID from search results, context hints, or wikilink references.

The `renderNoteForAgent` hint now says "Use knowledge-get with this note's id to retrieve full content" instead of directing to search.

### Bug Fixes

- **CLAUDE.md migration guard**: `migrateFromAgentDocs` now only fires for `claude-code`, not all skill-based clients. Previously, installing OMP would delete Claude Code's managed block from `~/.claude/CLAUDE.md`.
- **Pi extension schema mismatches** (all fixed):
  - `knowledge-open`: replaced phantom `noteId`/`path` with `project`
  - `knowledge-maintain`: fixed `dry_run` → `dryRun` (was causing live mutations on dry-run intent)
  - `knowledge-store`: removed phantom `existingId`, added `client`/`status`/`related`
  - `knowledge-search`: removed phantom `mode`, added `status`/`lifecycle`
  - `knowledge-maintain`: expanded from 7 to all 19 actions, added `filter`/`days`/`telemetry`
  - All tools: added `model` parameter where server supports it
- **Symlink safety**: Install skips agent docs injection when the target is a symlink (avoids modifying shared files). Interactive prompt offers override.

### Files Changed (22 files)

| Area | Files | What |
|------|-------|------|
| Feature | `src/pi/extension.ts` | New Pi package extension (MCP bridge) |
| Feature | `src/mcp-server.ts`, `src/tool-handlers.ts` | `knowledge-get` tool |
| Setup | `src/setup.ts` | Pi + OMP client configs, symlink safety, CLAUDE.md guard |
| Heuristics | `src/agent-docs-targets.ts`, `src/client-heuristics.ts` | OMP support |
| Rendering | `src/prompts.ts` | Hint references knowledge-get |
| Config | `package.json`, `plugin/.mcp.json`, `.gitignore` | Pi export, MCP format fix, agent dirs |
| Tests | `tests/pi-extension.test.ts`, `tests/setup.test.ts`, `tests/docker/mcp-protocol-test.ts` | +630 test lines |
| Docs | 9 files | 9 tools / 7 clients consistency across all docs |
| Plan | `.agents/plans/discovery-rollout.md` | OMP Marketplace tracking item |

### Verification

- ✅ Clean rebuild (`rm -rf dist/ && bun run build`)
- ✅ 935 unit tests pass
- ✅ ESLint clean
- ✅ TypeScript clean (`tsc --noEmit`)
- ✅ MCP protocol smoke test: 19/19 pass (all 9 tools verified)