### PR TITLE
Add shared HTTP server mode with stdio-to-HTTP bridge

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,14 +14,22 @@ Obsidian plays a separate role: it is the primary human browsing and interaction
 ┌─────────────────────────────────────────────────────┐
 │                   Client Layer                       │
 │  MCP Clients (OpenCode, Claude Code,                 │
-│  Cursor, Windsurf, Zed)                              │
+│  Cursor, Windsurf, Zed, OMP, Pi)                     │
 └──────────┬──────────────────────────────────────────┘
+           │
+      ┌────┴────┐
+      │         │
+┌─────▼─────┐ ┌─▼──────────────┐
+│  stdio     │ │  HTTP (shared)  │
+│  (default) │ │  Bun.serve()    │
+└─────┬─────┘ └─┬──────────────┘
+      │         │
+      └────┬────┘
            │
 ┌──────────▼──────────┐
 │   MCP Server        │
 │   (mcp-server.ts)   │
 │   - 9 MCP tools     │
-│   - stdio transport │
 └──────────┬──────────┘
            │
 ┌──────────▼──────────┐
@@ -74,7 +82,10 @@ This distinction is intentional. Core knowledge notes (`decision`, `procedure`, 
 
 The MCP server provides a reactive interface to the knowledge base:
 
-* **Transport**: Uses `@modelcontextprotocol/sdk` with stdio transport.
+* **Transport**: Supports two modes:
+    * **Stdio** (default): One process per client connection. Used by all MCP clients.
+    * **Streamable HTTP** (`open-zk-kb serve`): Single shared process for all clients. Uses `Bun.serve()` with `WebStandardStreamableHTTPServerTransport` in stateless mode. Recommended for multi-session environments (OMP, multiple terminals).
+* **Shared Server Discovery**: When running in stdio mode, the server first checks if a shared HTTP server is available (via `$XDG_RUNTIME_DIR/open-zk-kb/server.json`). If found and healthy, it transparently bridges stdio→HTTP, avoiding resource duplication.
 * **Tools**: Registers [nine core tools](tools-reference.md): `knowledge-store`, `knowledge-search`, `knowledge-get`, `knowledge-template`, `knowledge-mine`, `knowledge-maintain`, `knowledge-ingest`, `knowledge-overview`, and `knowledge-open`.
 * **Initialization**: Uses a lazy singleton pattern where the `NoteRepository` is initialized only upon the first tool call.
 * **Embeddings**: Generated locally by default via `@huggingface/transformers` (WASM backend, no native deps).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ open-zk-kb uses a single YAML configuration file:
 
 **Location**: `~/.config/open-zk-kb/config.yaml`
 
-The file contains core settings for the MCP server, including vault location, log level, note lifecycle, the Obsidian vault scaffold, and vector embeddings.
+The file contains core settings for the MCP server, including vault location, log level, note lifecycle, the Obsidian vault scaffold, vector embeddings, and shared HTTP server configuration.
 
 For a detailed explanation of note statuses, kinds, and the review system, see [Note Lifecycle](note-lifecycle.md).
 
@@ -151,6 +151,25 @@ telemetry:
 obsidian:
   readOnly: false
 ```
+
+## Server
+
+Settings for the shared HTTP server mode (`open-zk-kb serve`).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `server.port` | integer | `17244` | Port for the HTTP server |
+| `server.host` | string | `127.0.0.1` | Bind address (localhost recommended for security) |
+
+Example:
+
+```yaml
+server:
+  port: 18000
+  host: 127.0.0.1
+```
+
+See [Setup Guide: Shared Server Mode](setup-guide.md#shared-server-mode-multi-session) for usage instructions.
 
 ## Environment & Paths
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -85,6 +85,61 @@ See the [Development Guide](development.md#development-setup) for the full contr
 | Pi | `~/.pi/agent/settings.json` |
 | OMP | `~/.omp/agent/mcp.json` |
 
+
+## Shared Server Mode (Multi-Session)
+
+By default, each MCP client session spawns its own server process. For environments with multiple concurrent sessions (OMP, multiple terminals), you can run a single shared HTTP server instead:
+
+### Quick Start
+
+```bash
+# Start the shared server (runs in foreground)
+open-zk-kb serve
+
+# Or with custom port/host
+open-zk-kb serve --port 18000 --host 0.0.0.0
+```
+
+### Configure OMP for HTTP
+
+```bash
+# Install with HTTP transport (use --force to convert from existing stdio config)
+bun run src/setup.ts install --client omp --transport http --force
+```
+
+This writes to `~/.omp/agent/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "open-zk-kb": {
+      "type": "http",
+      "url": "http://127.0.0.1:17244/mcp"
+    }
+  }
+}
+```
+
+### Transparent Proxy
+
+Existing stdio configurations automatically benefit from a running HTTP server. When `open-zk-kb server` (stdio mode) starts, it checks for a running HTTP server and bridges to it transparently — no config changes needed.
+
+### Configuration
+
+Optional `config.yaml` settings:
+
+```yaml
+server:
+  port: 17244      # Default port
+  host: 127.0.0.1  # Localhost only (recommended)
+```
+
+### Benefits
+
+- **Memory**: One ONNX embedding model (~23MB) instead of one per session
+- **SQLite**: Single database connection eliminates SQLITE_BUSY contention
+- **Startup**: Sessions connect instantly instead of loading the model
+
 ## Verify Installation
 1. Restart your editor/client.
 2. Optionally run `bunx open-zk-kb@latest doctor --client <name>` to verify the local install. Add `--fix` to repair safe issues automatically.

--- a/skills/open-zk-kb/SKILL.md
+++ b/skills/open-zk-kb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-zk-kb
-version: 1.0.13
+version: 1.1.0
 description: >
   Persistent knowledge base for cross-session memory. BEFORE responding to any
   user message: (1) knowledge-search for relevant context, (2) scan for storage

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -34,7 +34,7 @@ src/
 ```
 Client request → mcp-server.ts
                         ↓
-               tool-handlers.ts (handleStore/Search/Get/Mine/Maintain/Ingest/Overview/Open)
+               tool-handlers.ts (handleStore/Search/Get/Template/Mine/Maintain/Ingest/Overview/Open)
                         ↓
                NoteRepository.store/search/getStats/...
                     ↓              ↓

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,20 +2,55 @@
 
 export interface CliDependencies {
   startServer?: () => Promise<void>;
+  startHttpServer?: (options?: { port?: number; host?: string }) => Promise<void>;
+  tryStdioBridge?: () => Promise<boolean>;
   runSetupCli?: (rawArgs: string[]) => Promise<void>;
+}
+
+function parseFlag(args: string[], flag: string): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === flag && i + 1 < args.length) return args[i + 1];
+    if (args[i].startsWith(flag + '=')) return args[i].slice(flag.length + 1);
+  }
+  return undefined;
 }
 
 export async function runCli(rawArgs: string[] = process.argv.slice(2), deps: CliDependencies = {}): Promise<void> {
   const command = rawArgs[0];
 
   if (command === 'server') {
+    try {
+      const tryBridge = deps.tryStdioBridge ?? (await import('./mcp-stdio-proxy.js')).tryStdioBridge;
+      const bridged = await tryBridge();
+      if (bridged) return;  // Bridge established, stdio proxy running
+    } catch {
+      // Bridge unavailable — fall through to in-process server
+    }
+
+    // No HTTP server available — run full server in-process
     if (deps.startServer) {
       await deps.startServer();
       return;
     }
-
     const { startServer } = await import('./mcp-server.js');
     await startServer();
+    return;
+  }
+
+  if (command === 'serve') {
+    const portStr = parseFlag(rawArgs, '--port');
+    const host = parseFlag(rawArgs, '--host');
+    const port = portStr ? parseInt(portStr, 10) : undefined;
+    if (port !== undefined && (!Number.isInteger(port) || port < 1 || port > 65535)) {
+      throw new Error(`Invalid --port value: ${portStr}. Must be an integer between 1 and 65535.`);
+    }
+
+    if (deps.startHttpServer) {
+      await deps.startHttpServer({ port, host });
+      return;
+    }
+    const { startHttpServer } = await import('./mcp-http-server.js');
+    await startHttpServer({ port, host });
     return;
   }
 
@@ -23,7 +58,6 @@ export async function runCli(rawArgs: string[] = process.argv.slice(2), deps: Cl
     await deps.runSetupCli(rawArgs);
     return;
   }
-
   const { runSetupCli } = await import('./setup.js');
   await runSetupCli(rawArgs);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,8 +40,8 @@ export async function runCli(rawArgs: string[] = process.argv.slice(2), deps: Cl
   if (command === 'serve') {
     const portStr = parseFlag(rawArgs, '--port');
     const host = parseFlag(rawArgs, '--host');
-    const port = portStr ? parseInt(portStr, 10) : undefined;
-    if (port !== undefined && (!Number.isInteger(port) || port < 1 || port > 65535)) {
+    const port = portStr === undefined ? undefined : Number(portStr);
+    if (portStr !== undefined && (!/^\d+$/.test(portStr) || !Number.isInteger(port) || port! < 1 || port! > 65535)) {
       throw new Error(`Invalid --port value: ${portStr}. Must be an integer between 1 and 65535.`);
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,10 @@ interface RawConfig {
     enabled?: boolean;
     debounceMs?: number;
   };
+  server?: {
+    port?: number;
+    host?: string;
+  };
   embeddings?: EmbeddingsConfig;
 }
 
@@ -122,6 +126,10 @@ export const DEFAULT_CONFIG: AppConfig = {
     enabled: true,
     debounceMs: 30000,
   },
+  server: {
+    port: 17244,
+    host: '127.0.0.1',
+  },
 };
 
 // ── Loader ──
@@ -151,6 +159,12 @@ function loadYamlConfig(): RawConfig | null {
 
 function positiveInt(value: unknown, fallback: number): number {
   return Number.isInteger(value) && (value as number) > 0 ? (value as number) : fallback;
+}
+
+function validPort(value: unknown, fallback: number): number {
+  return Number.isInteger(value) && (value as number) >= 1 && (value as number) <= 65535
+    ? (value as number)
+    : fallback;
 }
 
 export function getConfig(): AppConfig {
@@ -242,6 +256,12 @@ export function getConfig(): AppConfig {
         ? raw.versioning.enabled
         : DEFAULT_CONFIG.versioning.enabled,
       debounceMs: positiveInt(raw?.versioning?.debounceMs, DEFAULT_CONFIG.versioning.debounceMs),
+    },
+    server: {
+      port: validPort(raw?.server?.port, DEFAULT_CONFIG.server.port),
+      host: typeof raw?.server?.host === 'string' && raw.server.host.length > 0
+        ? raw.server.host
+        : DEFAULT_CONFIG.server.host,
     },
   };
 }

--- a/src/mcp-http-server.ts
+++ b/src/mcp-http-server.ts
@@ -142,13 +142,16 @@ async function handleMcpRequest(req: Request): Promise<Response> {
   };
 
   await server.connect(transport);
-  const response = await transport.handleRequest(req);
 
-  // Clean up: close transport and server for this request
-  await transport.close().catch(() => {});
-  await server.close();
-
-  return response;
+  try {
+    const response = await transport.handleRequest(req);
+    return response;
+  } finally {
+    // Clean up: close transport and server for this request.
+    // Must run even if handleRequest throws to avoid resource leaks.
+    await transport.close().catch(() => {});
+    await server.close();
+  }
 }
 
 export interface StartHttpServerOptions {

--- a/src/mcp-http-server.ts
+++ b/src/mcp-http-server.ts
@@ -172,7 +172,7 @@ export async function startHttpServer(options: StartHttpServerOptions = {}): Pro
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 2000);
       const response = await fetch(
-        `http://${existingState.host}:${existingState.port}/health`,
+        `http://${existingState.host.includes(':') ? `[${existingState.host}]` : existingState.host}:${existingState.port}/health`,
         { signal: controller.signal },
       );
       clearTimeout(timeout);

--- a/src/mcp-http-server.ts
+++ b/src/mcp-http-server.ts
@@ -52,17 +52,24 @@ export function readServerState(): ServerState | null {
     const content = fs.readFileSync(SERVER_STATE_FILE, 'utf-8');
     const state = JSON.parse(content) as ServerState;
 
-    // Validate the host is a loopback address — reject state files
-    // pointing to non-local hosts to prevent traffic redirection attacks
-    // when the state file lives in a world-writable directory like /tmp.
+    // Validate the host is loopback or a wildcard bind address — reject
+    // state files pointing to non-local hosts to prevent traffic redirection
+    // attacks when the state file lives in a world-writable directory like /tmp.
     const loopback = new Set(['127.0.0.1', '::1', 'localhost']);
-    if (!loopback.has(state.host)) {
-      logToFile('WARN', 'Server state file has non-loopback host, ignoring', {
+    const wildcardBind = new Set(['0.0.0.0', '::']);
+    if (!loopback.has(state.host) && !wildcardBind.has(state.host)) {
+      logToFile('WARN', 'Server state file has non-local host, ignoring', {
         host: state.host,
         stateFile: SERVER_STATE_FILE,
       }, config);
       removeServerState();
       return null;
+    }
+
+    // Wildcard bind addresses (0.0.0.0, ::) listen on all interfaces but
+    // must be reached via loopback for local probing.
+    if (wildcardBind.has(state.host)) {
+      state.host = '127.0.0.1';
     }
 
     // On Unix, verify the state file is owned by the current user
@@ -155,14 +162,39 @@ export async function startHttpServer(options: StartHttpServerOptions = {}): Pro
 
   ensureShutdownHandlers();
 
-  // Check if another instance is already running
+  // Check if another instance is already running.
+  // PID-alive alone is not sufficient — after an unclean shutdown, PID reuse
+  // can make a stale state file block startup. Probe the health endpoint to
+  // verify the process is actually serving before rejecting.
   const existingState = readServerState();
   if (existingState) {
-    logToFile('ERROR', 'Another HTTP server is already running', {
-      pid: existingState.pid,
-      port: existingState.port,
-    }, config);
-    throw new Error(`Another open-zk-kb HTTP server is already running (pid: ${existingState.pid}, port: ${existingState.port})`);
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 2000);
+      const response = await fetch(
+        `http://${existingState.host}:${existingState.port}/health`,
+        { signal: controller.signal },
+      );
+      clearTimeout(timeout);
+      if (response.ok) {
+        logToFile('ERROR', 'Another HTTP server is already running', {
+          pid: existingState.pid,
+          port: existingState.port,
+        }, config);
+        throw new Error(`Another open-zk-kb HTTP server is already running (pid: ${existingState.pid}, port: ${existingState.port})`);
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('already running')) {
+        throw err; // Re-throw the "already running" error from above
+      }
+      // Health probe failed — the PID-alive process is not our server.
+      // Remove the stale state file and proceed with startup.
+      logToFile('INFO', 'Stale server state file detected (PID alive but not responding), removing', {
+        pid: existingState.pid,
+        port: existingState.port,
+      }, config);
+      removeServerState();
+    }
   }
 
   const httpServer = Bun.serve({

--- a/src/mcp-http-server.ts
+++ b/src/mcp-http-server.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env bun
+// mcp-http-server.ts - Shared HTTP server for multi-session MCP access
+// Runs a single process serving Streamable HTTP so multiple clients share one server.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { getConfig } from './config.js';
+import { logToFile } from './logger.js';
+import { createMcpServer, shutdownServer, ensureShutdownHandlers } from './mcp-server.js';
+import { PKG_VERSION } from './version.js';
+
+const config = getConfig();
+
+// ── Runtime directory for PID/port discovery ──
+
+const xdgRuntimeDir = process.env.XDG_RUNTIME_DIR || process.env.TMPDIR || '/tmp';
+const SERVER_STATE_DIR = path.join(xdgRuntimeDir, 'open-zk-kb');
+const SERVER_STATE_FILE = path.join(SERVER_STATE_DIR, 'server.json');
+
+export interface ServerState {
+  pid: number;
+  port: number;
+  host: string;
+  version: string;
+  startedAt: string;
+}
+
+function writeServerState(port: number, host: string): void {
+  fs.mkdirSync(SERVER_STATE_DIR, { recursive: true });
+  const state: ServerState = {
+    pid: process.pid,
+    port,
+    host,
+    version: PKG_VERSION,
+    startedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(SERVER_STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+function removeServerState(): void {
+  try {
+    fs.unlinkSync(SERVER_STATE_FILE);
+  } catch {
+    // Already gone
+  }
+}
+
+export function readServerState(): ServerState | null {
+  try {
+    const content = fs.readFileSync(SERVER_STATE_FILE, 'utf-8');
+    const state = JSON.parse(content) as ServerState;
+    // Validate the process is still alive
+    try {
+      process.kill(state.pid, 0);
+      return state;
+    } catch {
+      // Process is dead — stale state file
+      removeServerState();
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+// ── HTTP Server ──
+
+// Track active transports for cleanup
+const activeTransports = new Set<Transport>();
+
+async function handleMcpRequest(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+
+  // Health check endpoint
+  if (url.pathname === '/health') {
+    return new Response(JSON.stringify({ status: 'ok', version: PKG_VERSION }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Only handle /mcp endpoint
+  if (url.pathname !== '/mcp') {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  // Create a fresh McpServer per request — the MCP SDK's Protocol rejects
+  // connecting a second transport to the same instance, so stateless HTTP
+  // mode needs one per request. Shared state (NoteRepository, embeddings)
+  // lives in module-level singletons, not in the McpServer.
+  const server = createMcpServer();
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+  });
+
+  activeTransports.add(transport);
+  transport.onclose = () => {
+    activeTransports.delete(transport);
+  };
+
+  await server.connect(transport);
+  const response = await transport.handleRequest(req);
+
+  // Clean up: close transport and server for this request
+  await transport.close().catch(() => {});
+  await server.close();
+
+  return response;
+}
+
+export interface StartHttpServerOptions {
+  port?: number;
+  host?: string;
+}
+
+export async function startHttpServer(options: StartHttpServerOptions = {}): Promise<void> {
+  const port = options.port ?? config.server.port;
+  const host = options.host ?? config.server.host;
+
+  ensureShutdownHandlers();
+
+  // Check if another instance is already running
+  const existingState = readServerState();
+  if (existingState) {
+    logToFile('ERROR', 'Another HTTP server is already running', {
+      pid: existingState.pid,
+      port: existingState.port,
+    }, config);
+    throw new Error(`Another open-zk-kb HTTP server is already running (pid: ${existingState.pid}, port: ${existingState.port})`);
+  }
+
+  const httpServer = Bun.serve({
+    port,
+    hostname: host,
+    fetch: handleMcpRequest,
+  });
+  const actualPort = httpServer.port as number;
+
+  writeServerState(actualPort, host);
+  logToFile('INFO', 'MCP HTTP server: started', {
+    port: actualPort,
+    host,
+    version: PKG_VERSION,
+  }, config);
+
+  // Override shutdown to also clean up HTTP resources
+  const originalShutdown = () => shutdownServer();
+  const httpShutdown = () => {
+    logToFile('INFO', 'MCP HTTP server: shutting down', {}, config);
+    removeServerState();
+    for (const transport of activeTransports) {
+      transport.close().catch(() => {});
+    }
+    activeTransports.clear();
+    httpServer.stop(true);
+    originalShutdown();
+  };
+
+  process.removeAllListeners('SIGINT');
+  process.removeAllListeners('SIGTERM');
+  process.on('SIGINT', httpShutdown);
+  process.on('SIGTERM', httpShutdown);
+
+  // Log the address for the user
+  logToFile('INFO', `MCP HTTP server: listening on http://${host}:${httpServer.port}/mcp`, {}, config);
+}

--- a/src/mcp-http-server.ts
+++ b/src/mcp-http-server.ts
@@ -51,6 +51,40 @@ export function readServerState(): ServerState | null {
   try {
     const content = fs.readFileSync(SERVER_STATE_FILE, 'utf-8');
     const state = JSON.parse(content) as ServerState;
+
+    // Validate the host is a loopback address — reject state files
+    // pointing to non-local hosts to prevent traffic redirection attacks
+    // when the state file lives in a world-writable directory like /tmp.
+    const loopback = new Set(['127.0.0.1', '::1', 'localhost']);
+    if (!loopback.has(state.host)) {
+      logToFile('WARN', 'Server state file has non-loopback host, ignoring', {
+        host: state.host,
+        stateFile: SERVER_STATE_FILE,
+      }, config);
+      removeServerState();
+      return null;
+    }
+
+    // On Unix, verify the state file is owned by the current user
+    // to prevent other local users from planting a fake state file.
+    if (process.platform !== 'win32') {
+      try {
+        const stat = fs.statSync(SERVER_STATE_FILE);
+        if (stat.uid !== process.getuid!()) {
+          logToFile('WARN', 'Server state file owned by different user, ignoring', {
+            fileUid: stat.uid,
+            processUid: process.getuid!(),
+            stateFile: SERVER_STATE_FILE,
+          }, config);
+          removeServerState();
+          return null;
+        }
+      } catch {
+        // statSync failed — treat as missing
+        return null;
+      }
+    }
+
     // Validate the process is still alive
     try {
       process.kill(state.pid, 0);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -37,7 +37,7 @@ let repo: NoteRepositoryType | null = null;
 let repoInitPromise: Promise<NoteRepositoryType> | null = null;
 let gitVersioning: GitVersioning | null = null;
 
-async function getOrCreateRepo(): Promise<NoteRepositoryType> {
+export async function getOrCreateRepo(): Promise<NoteRepositoryType> {
   if (repo) return repo;
   if (repoInitPromise) return repoInitPromise;
 
@@ -77,7 +77,7 @@ async function getOrCreateRepo(): Promise<NoteRepositoryType> {
 
 let cachedEmbeddingConfig: EmbeddingConfig | null | undefined;
 
-function getEmbeddingConfig(): EmbeddingConfig | null {
+export function getEmbeddingConfig(): EmbeddingConfig | null {
   if (cachedEmbeddingConfig !== undefined) return cachedEmbeddingConfig;
 
   const embCfg = getEmbeddingsConfig();
@@ -107,106 +107,10 @@ function getEmbeddingConfig(): EmbeddingConfig | null {
 }
 
 
-const server = new McpServer({
-  name: 'open-zk-kb',
-  version: PKG_VERSION,
-});
-
-// ---- knowledge-store ----
-
 const NOTE_KINDS = ['personalization', 'reference', 'decision', 'procedure', 'resource', 'observation', 'domain', 'index', 'log'] as const;
 const STORABLE_KINDS = ['personalization', 'reference', 'decision', 'procedure', 'resource', 'observation', 'domain'] as const;
 const LIFECYCLES = ['living', 'snapshot', 'append-only'] as const;
 
-const storeSchema = z.object({
-  title: z.string().describe('Note title — 3-6 word scannable label (max 10 words / 80 chars). Detail belongs in summary.'),
-  content: z.string().describe('Note content — the knowledge to store'),
-  kind: z.enum(STORABLE_KINDS).describe('Note kind: personalization, reference, decision, procedure, resource, observation, domain'),
-  status: z.enum(['fleeting', 'permanent', 'archived']).optional().describe('Override default status (defaults based on kind)'),
-  lifecycle: z.enum(LIFECYCLES).optional().describe('Note lifecycle: living (mutable), snapshot (immutable), append-only (additive only). Defaults per kind.'),
-  tags: z.array(z.string()).optional().describe('Tags for categorization'),
-  summary: z.string().describe('One-line present-tense key takeaway'),
-  guidance: z.string().describe('Imperative actionable instruction for agents'),
-  project: z.string().optional().describe('Project scope — auto-adds project:<name> tag'),
-  client: z.string().optional().describe('Client identifier (e.g. claude-code, opencode). Auto-detected from content when omitted.'),
-  related: z.array(z.string()).optional().describe('IDs of related notes to link via wikilinks'),
-  model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
-});
-
-server.registerTool(
-  'knowledge-store',
-  {
-    description: 'Store knowledge in the persistent Zettelkasten knowledge base. One concept per note.',
-    inputSchema: storeSchema as unknown as AnySchema,
-  },
-  async (args: z.infer<typeof storeSchema>) => {
-    try {
-      const result = await handleStore({
-        title: args.title,
-        content: args.content,
-        kind: args.kind as NoteKind,
-        status: args.status,
-        lifecycle: args.lifecycle,
-        tags: args.tags,
-        summary: args.summary,
-        guidance: args.guidance,
-        project: args.project,
-        client: args.client,
-        related: args.related,
-        model: args.model,
-      }, await getOrCreateRepo(), getEmbeddingConfig(), config, gitVersioning);
-      return { content: [{ type: 'text' as const, text: result }] };
-    } catch (error) {
-      logToFile('ERROR', 'knowledge-store failed', {
-        error: error instanceof Error ? error.message : String(error),
-      }, config);
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-        isError: true,
-      };
-    }
-  },
-);
-
-// ---- knowledge-ingest ----
-
-const ingestSchema = z.object({
-  url: z.string().url()
-    .refine(u => { try { const p = new URL(u); return p.protocol === 'http:' || p.protocol === 'https:'; } catch { return false; } }, { message: 'URL must use http:// or https://' })
-    .optional()
-    .describe('URL to fetch and extract. Fallback only — the built-in fetcher cannot handle JavaScript-rendered pages, bot protection, or authenticated content. If you have a web tool (Playwright, Exa, web_fetch), fetch with that and pass html instead. When passing html, also pass url for relative link resolution.'),
-  html: z.string().optional().describe('Preferred — raw HTML to extract content from. Pass HTML you already fetched via Playwright, Exa, web_fetch, or any browser/web tool for best results.'),
-  model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
-}).refine(d => d.url || d.html, { message: 'At least one of url or html must be provided' });
-
-server.registerTool(
-  'knowledge-ingest',
-  {
-    description: 'Extract article content as clean markdown. Returns title, content, word count, and metadata. PREFER passing html from your own web tools (Playwright, Exa, web_fetch) — the built-in url fetcher is a basic fallback that cannot render JavaScript or bypass bot protection. Use the extracted content to create notes via knowledge-store.',
-    inputSchema: ingestSchema as unknown as AnySchema,
-  },
-  async (args: z.infer<typeof ingestSchema>) => {
-    try {
-      const result = await handleIngest({
-        url: args.url,
-        html: args.html,
-        model: args.model,
-      }, await getOrCreateRepo());
-      return { content: [{ type: 'text' as const, text: result }] };
-    } catch (error) {
-      logToFile('ERROR', 'knowledge-ingest failed', {
-        url: args.url,
-        error: error instanceof Error ? error.message : String(error),
-      }, config);
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-        isError: true,
-      };
-    }
-  },
-);
-
-// ---- knowledge-search ----
 
 /** Race embedding generation against a timeout. Returns null if not ready in time. */
 async function tryEmbedding(text: string, embConfig: EmbeddingConfig, timeoutMs: number): Promise<number[] | null> {
@@ -225,289 +129,387 @@ async function tryEmbedding(text: string, embConfig: EmbeddingConfig, timeoutMs:
   }
 }
 
-const searchSchema = z.object({
-  query: z.string().describe('Search query — natural language or keywords. Supports semantic matching when embeddings are enabled.'),
-  kind: z.enum(NOTE_KINDS).optional().describe('Filter by note kind'),
-  status: z.enum(['fleeting', 'permanent', 'archived']).optional().describe('Filter by status'),
-  lifecycle: z.enum(LIFECYCLES).optional().describe('Filter by lifecycle: living, snapshot, append-only'),
-  project: z.string().optional().describe('Filter by project tag'),
-  client: z.string().optional().describe('Your client name — excludes notes scoped to other clients'),
-  tags: z.array(z.string()).optional().describe('Filter by tags (all must match)'),
-  limit: z.number().optional().describe('Max results (default 10)'),
-  model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
-});
+export function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: 'open-zk-kb',
+    version: PKG_VERSION,
+  });
 
-server.registerTool(
-  'knowledge-search',
-  {
-    description: 'Search the persistent knowledge base using full-text search and semantic similarity. Accepts natural language queries, keywords, or phrases. Returns matching notes with full content.',
-    inputSchema: searchSchema as unknown as AnySchema,
-  },
-  async (args: z.infer<typeof searchSchema>) => {
-    try {
-      const embConfig = getEmbeddingConfig();
-
-      // Attempt embedding with 500ms timeout — returns FTS5-only results if model not ready
-      const queryEmbedding = embConfig
-        ? await tryEmbedding(args.query, embConfig, 500)
-        : null;
-
-      const result = handleSearch({
-        query: args.query,
-        kind: args.kind as NoteKind | undefined,
-        status: args.status,
-        lifecycle: args.lifecycle,
-        project: args.project,
-        client: args.client,
-        tags: args.tags,
-        limit: args.limit,
-        model: args.model,
-      }, await getOrCreateRepo(), queryEmbedding, config);
-      return { content: [{ type: 'text' as const, text: result }] };
-    } catch (error) {
-      logToFile('ERROR', 'knowledge-search failed', {
-        error: error instanceof Error ? error.message : String(error),
-      }, config);
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-        isError: true,
-      };
-    }
-  },
-);
-
-// ---- knowledge-overview ----
-
-const overviewSchema = z.object({
-  project: z.string().describe('Project name to get overview for'),
-  logEntries: z.number().int().min(1).optional().describe('Number of recent log entries to show (default: 10)'),
-  model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
-});
-
-server.registerTool(
-  'knowledge-overview',
-  {
-    description: 'Get a project overview: auto-generated index (catalog of all project notes) and recent operations log. The project entry point for navigation.',
-    inputSchema: overviewSchema as unknown as AnySchema,
-  },
-  async (args: z.infer<typeof overviewSchema>) => {
-    try {
-      const result = handleOverview({
-        project: args.project,
-        logEntries: args.logEntries,
-        model: args.model,
-      }, await getOrCreateRepo(), config);
-      return { content: [{ type: 'text' as const, text: result }] };
-    } catch (error) {
-      logToFile('ERROR', 'knowledge-overview failed', {
-        error: error instanceof Error ? error.message : String(error),
-      }, config);
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-        isError: true,
-      };
-    }
-  },
-);
-
-// ---- knowledge-open ----
-
-const openSchema = z.object({
-  project: z.string().optional().describe('Open focused on a specific project\'s index note'),
-});
-
-server.registerTool(
-  'knowledge-open',
-  {
-    description: 'Open the knowledge base vault in Obsidian for visual browsing. Detects Obsidian installation and launches it pointed at the vault.',
-    inputSchema: openSchema as unknown as AnySchema,
-  },
-  async (args: z.infer<typeof openSchema>) => {
-    try {
-      const result = await handleOpen({
-        project: args.project,
-      }, config, args.project ? await getOrCreateRepo() : repo ?? undefined);
-      return { content: [{ type: 'text' as const, text: result }] };
-    } catch (error) {
-      logToFile('ERROR', 'knowledge-open failed', {
-        error: error instanceof Error ? error.message : String(error),
-      }, config);
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-        isError: true,
-      };
-    }
-  },
-);
-
-// ---- knowledge-get ----
-
-const getSchema = z.object({
-  noteId: z.string().describe('Exact note ID to retrieve'),
-  model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
-});
-
-server.registerTool(
-  'knowledge-get',
-  {
-    description: 'Retrieve a single note by its exact ID. Faster and more precise than knowledge-search. Use when you already know the note ID (e.g. from injected context hints).',
-    inputSchema: getSchema as unknown as AnySchema,
-  },
-  async (args: z.infer<typeof getSchema>) => {
-    try {
-      const result = handleGet({
-        noteId: args.noteId,
-        model: args.model,
-      }, await getOrCreateRepo());
-      return { content: [{ type: 'text' as const, text: result }] };
-    } catch (error) {
-      logToFile('ERROR', 'knowledge-get failed', {
-        error: error instanceof Error ? error.message : String(error),
-      }, config);
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-        isError: true,
-      };
-    }
-  },
-);
-
-// ---- knowledge-maintain ----
-
-const maintainSchema = z.object({
-  action: z.enum(['stats', 'promote', 'archive', 'delete', 'rebuild', 'format', 'upgrade', 'upgrade-read', 'upgrade-apply', 'review', 'dedupe', 'embed', 'agent-docs', 'scope-audit', 'orphans', 'broken-links', 'migrate-layout', 'upgrade-vault', 'full'])
-      .describe('Maintenance action: stats, review (pending notes), dedupe (duplicates), promote, archive, delete, rebuild, format (re-serialize all note files with canonical frontmatter and navigation), upgrade, embed (backfill embeddings), agent-docs (audit/repair managed agent instruction files), scope-audit (detect mis-scoped client tags), orphans (notes with no links), broken-links (wikilinks to non-existent notes), migrate-layout (move flat vault to kind-based directory structure), upgrade-vault (refresh Obsidian scaffold assets), or full (composite: rebuild → migrate-layout → format → dedupe → embed → broken-links → stats, in dependency order).'),
-  noteId: z.string().optional().describe('Note ID (required for promote/archive/delete; migration ID for upgrade-read)'),
-  filter: z.enum(['fleeting', 'permanent']).optional().describe('Filter for review action: fleeting or permanent notes'),
-  days: z.number().optional().describe('Days threshold for review (default: from lifecycle.reviewAfterDays config)'),
-  limit: z.number().optional().describe('Max notes to show (default: 3 for review)'),
-  telemetry: z.boolean().optional().describe('Include 30-day local-only tool invocation aggregates in stats output'),
-  dryRun: z.boolean().optional().describe('Preview changes without applying'),
-  model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
-});
-
-server.registerTool(
-  'knowledge-maintain',
-  {
-    description: 'Maintain the knowledge base: stats, review (pending notes), dedupe (duplicates), promote, archive, delete, rebuild, upgrade, and managed agent docs repair.',
-    inputSchema: maintainSchema as unknown as AnySchema,
-  },
-  async (args: z.infer<typeof maintainSchema>) => {
-    try {
-      const result = await handleMaintain({
-        action: args.action,
-        noteId: args.noteId,
-        filter: args.filter as 'fleeting' | 'permanent' | undefined,
-        days: args.days,
-        limit: args.limit,
-        telemetry: args.telemetry,
-        dryRun: args.dryRun,
-        model: args.model,
-      }, await getOrCreateRepo(), config, getEmbeddingConfig(), PKG_VERSION, gitVersioning);
-      return { content: [{ type: 'text' as const, text: result }] };
-    } catch (error) {
-      logToFile('ERROR', 'knowledge-maintain failed', {
-        error: error instanceof Error ? error.message : String(error),
-      }, config);
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-        isError: true,
-      };
-    }
-  },
-);
-
-// ---- knowledge-mine ----
-
-const mineSchema = z.object({
-  candidates: z.array(z.object({
+  const storeSchema = z.object({
     title: z.string().describe('Note title — 3-6 word scannable label (max 10 words / 80 chars). Detail belongs in summary.'),
-    content: z.string().describe('Note content — the extracted knowledge'),
-    kind: z.enum(STORABLE_KINDS).describe('Note kind'),
+    content: z.string().describe('Note content — the knowledge to store'),
+    kind: z.enum(STORABLE_KINDS).describe('Note kind: personalization, reference, decision, procedure, resource, observation, domain'),
+    status: z.enum(['fleeting', 'permanent', 'archived']).optional().describe('Override default status (defaults based on kind)'),
+    lifecycle: z.enum(LIFECYCLES).optional().describe('Note lifecycle: living (mutable), snapshot (immutable), append-only (additive only). Defaults per kind.'),
+    tags: z.array(z.string()).optional().describe('Tags for categorization'),
     summary: z.string().describe('One-line present-tense key takeaway'),
     guidance: z.string().describe('Imperative actionable instruction for agents'),
-    tags: z.array(z.string()).optional().describe('Tags for categorization'),
-    source: z.string().optional().describe('Provenance — e.g. session ID where this was found'),
-  })).describe('Array of candidate notes extracted from session history'),
-  project: z.string().optional().describe('Project scope — auto-adds project:<name> tag to all candidates'),
-  dry_run: z.boolean().optional().describe('Preview dedup results without storing (default: true)'),
-  model: z.string().optional().describe('Your model identifier for richer responses'),
-});
+    project: z.string().optional().describe('Project scope — auto-adds project:<name> tag'),
+    client: z.string().optional().describe('Client identifier (e.g. claude-code, opencode). Auto-detected from content when omitted.'),
+    related: z.array(z.string()).optional().describe('IDs of related notes to link via wikilinks'),
+    model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
+  });
 
-server.registerTool(
-  'knowledge-mine',
-  {
-    description: 'Bulk-screen candidate notes for duplicates and optionally store. Accepts candidates extracted by the agent from session history or other sources. Returns each candidate annotated with STORE/SKIP/REVIEW based on similarity to existing KB notes. Default is dry-run (preview only).',
-    inputSchema: mineSchema as unknown as AnySchema,
-  },
-  async (args: z.infer<typeof mineSchema>) => {
-    try {
-      const result = await handleMine({
-        candidates: args.candidates.map(candidate => ({
-          title: candidate.title,
-          content: candidate.content,
-          kind: candidate.kind as NoteKind,
-          summary: candidate.summary,
-          guidance: candidate.guidance,
-          tags: candidate.tags,
-          source: candidate.source,
-        })),
-        project: args.project,
-        dry_run: args.dry_run,
-        model: args.model,
-      }, await getOrCreateRepo(), getEmbeddingConfig(), config);
-      return { content: [{ type: 'text' as const, text: result }] };
-    } catch (error) {
-      logToFile('ERROR', 'knowledge-mine failed', {
-        error: error instanceof Error ? error.message : String(error),
-      }, config);
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-        isError: true,
-      };
-    }
-  },
-);
+  server.registerTool(
+    'knowledge-store',
+    {
+      description: 'Store knowledge in the persistent Zettelkasten knowledge base. One concept per note.',
+      inputSchema: storeSchema as unknown as AnySchema,
+    },
+    async (args: z.infer<typeof storeSchema>) => {
+      try {
+        const result = await handleStore({
+          title: args.title,
+          content: args.content,
+          kind: args.kind as NoteKind,
+          status: args.status,
+          lifecycle: args.lifecycle,
+          tags: args.tags,
+          summary: args.summary,
+          guidance: args.guidance,
+          project: args.project,
+          client: args.client,
+          related: args.related,
+          model: args.model,
+        }, await getOrCreateRepo(), getEmbeddingConfig(), config, gitVersioning);
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        logToFile('ERROR', 'knowledge-store failed', {
+          error: error instanceof Error ? error.message : String(error),
+        }, config);
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
 
-// ---- knowledge-template ----
+  // ---- knowledge-ingest ----
 
-const templateSchema = z.object({
-  kind: z.enum(NOTE_KINDS).describe('Note kind to get the canonical template for'),
-  project: z.string().optional().describe('Project name — checks for project-specific template overrides'),
-  model: z.string().optional().describe('Your model identifier'),
-});
+  const ingestSchema = z.object({
+    url: z.string().url()
+      .refine(u => { try { const p = new URL(u); return p.protocol === 'http:' || p.protocol === 'https:'; } catch { return false; } }, { message: 'URL must use http:// or https://' })
+      .optional()
+      .describe('URL to fetch and extract. Fallback only — the built-in fetcher cannot handle JavaScript-rendered pages, bot protection, or authenticated content. If you have a web tool (Playwright, Exa, web_fetch), fetch with that and pass html instead. When passing html, also pass url for relative link resolution.'),
+    html: z.string().optional().describe('Preferred — raw HTML to extract content from. Pass HTML you already fetched via Playwright, Exa, web_fetch, or any browser/web tool for best results.'),
+    model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
+  }).refine(d => d.url || d.html, { message: 'At least one of url or html must be provided' });
 
-server.registerTool(
-  'knowledge-template',
-  {
-    description: 'Get the canonical note template for a specific kind. Returns skeleton structure with positive and negative examples. Consult before storing structured notes (decision, procedure, domain, reference, observation).',
-    inputSchema: templateSchema as unknown as AnySchema,
-  },
-  async (args: z.infer<typeof templateSchema>) => {
-    try {
-      const r = args.project ? await getOrCreateRepo() : (repo ?? undefined);
-      const result = handleTemplate({
-        kind: args.kind,
-        project: args.project,
-        model: args.model,
-      }, r);
-      return { content: [{ type: 'text' as const, text: result }] };
-    } catch (error) {
-      logToFile('ERROR', 'knowledge-template failed', {
-        error: error instanceof Error ? error.message : String(error),
-      }, config);
-      return {
-        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-        isError: true,
-      };
-    }
-  },
-);
+  server.registerTool(
+    'knowledge-ingest',
+    {
+      description: 'Extract article content as clean markdown. Returns title, content, word count, and metadata. PREFER passing html from your own web tools (Playwright, Exa, web_fetch) — the built-in url fetcher is a basic fallback that cannot render JavaScript or bypass bot protection. Use the extracted content to create notes via knowledge-store.',
+      inputSchema: ingestSchema as unknown as AnySchema,
+    },
+    async (args: z.infer<typeof ingestSchema>) => {
+      try {
+        const result = await handleIngest({
+          url: args.url,
+          html: args.html,
+          model: args.model,
+        }, await getOrCreateRepo());
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        logToFile('ERROR', 'knowledge-ingest failed', {
+          url: args.url,
+          error: error instanceof Error ? error.message : String(error),
+        }, config);
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  const searchSchema = z.object({
+    query: z.string().describe('Search query — natural language or keywords. Supports semantic matching when embeddings are enabled.'),
+    kind: z.enum(NOTE_KINDS).optional().describe('Filter by note kind'),
+    status: z.enum(['fleeting', 'permanent', 'archived']).optional().describe('Filter by status'),
+    lifecycle: z.enum(LIFECYCLES).optional().describe('Filter by lifecycle: living, snapshot, append-only'),
+    project: z.string().optional().describe('Filter by project tag'),
+    client: z.string().optional().describe('Your client name — excludes notes scoped to other clients'),
+    tags: z.array(z.string()).optional().describe('Filter by tags (all must match)'),
+    limit: z.number().optional().describe('Max results (default 10)'),
+    model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
+  });
+
+  server.registerTool(
+    'knowledge-search',
+    {
+      description: 'Search the persistent knowledge base using full-text search and semantic similarity. Accepts natural language queries, keywords, or phrases. Returns matching notes with full content.',
+      inputSchema: searchSchema as unknown as AnySchema,
+    },
+    async (args: z.infer<typeof searchSchema>) => {
+      try {
+        const embConfig = getEmbeddingConfig();
+
+        // Attempt embedding with 500ms timeout — returns FTS5-only results if model not ready
+        const queryEmbedding = embConfig
+          ? await tryEmbedding(args.query, embConfig, 500)
+          : null;
+
+        const result = handleSearch({
+          query: args.query,
+          kind: args.kind as NoteKind | undefined,
+          status: args.status,
+          lifecycle: args.lifecycle,
+          project: args.project,
+          client: args.client,
+          tags: args.tags,
+          limit: args.limit,
+          model: args.model,
+        }, await getOrCreateRepo(), queryEmbedding, config);
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        logToFile('ERROR', 'knowledge-search failed', {
+          error: error instanceof Error ? error.message : String(error),
+        }, config);
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ---- knowledge-overview ----
+
+  const overviewSchema = z.object({
+    project: z.string().describe('Project name to get overview for'),
+    logEntries: z.number().int().min(1).optional().describe('Number of recent log entries to show (default: 10)'),
+    model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
+  });
+
+  server.registerTool(
+    'knowledge-overview',
+    {
+      description: 'Get a project overview: auto-generated index (catalog of all project notes) and recent operations log. The project entry point for navigation.',
+      inputSchema: overviewSchema as unknown as AnySchema,
+    },
+    async (args: z.infer<typeof overviewSchema>) => {
+      try {
+        const result = handleOverview({
+          project: args.project,
+          logEntries: args.logEntries,
+          model: args.model,
+        }, await getOrCreateRepo(), config);
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        logToFile('ERROR', 'knowledge-overview failed', {
+          error: error instanceof Error ? error.message : String(error),
+        }, config);
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ---- knowledge-open ----
+
+  const openSchema = z.object({
+    project: z.string().optional().describe('Open focused on a specific project\'s index note'),
+  });
+
+  server.registerTool(
+    'knowledge-open',
+    {
+      description: 'Open the knowledge base vault in Obsidian for visual browsing. Detects Obsidian installation and launches it pointed at the vault.',
+      inputSchema: openSchema as unknown as AnySchema,
+    },
+    async (args: z.infer<typeof openSchema>) => {
+      try {
+        const result = await handleOpen({
+          project: args.project,
+        }, config, args.project ? await getOrCreateRepo() : repo ?? undefined);
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        logToFile('ERROR', 'knowledge-open failed', {
+          error: error instanceof Error ? error.message : String(error),
+        }, config);
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ---- knowledge-get ----
+
+  const getSchema = z.object({
+    noteId: z.string().describe('Exact note ID to retrieve'),
+    model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
+  });
+
+  server.registerTool(
+    'knowledge-get',
+    {
+      description: 'Retrieve a single note by its exact ID. Faster and more precise than knowledge-search. Use when you already know the note ID (e.g. from injected context hints).',
+      inputSchema: getSchema as unknown as AnySchema,
+    },
+    async (args: z.infer<typeof getSchema>) => {
+      try {
+        const result = handleGet({
+          noteId: args.noteId,
+          model: args.model,
+        }, await getOrCreateRepo());
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        logToFile('ERROR', 'knowledge-get failed', {
+          error: error instanceof Error ? error.message : String(error),
+        }, config);
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ---- knowledge-maintain ----
+
+  const maintainSchema = z.object({
+    action: z.enum(['stats', 'promote', 'archive', 'delete', 'rebuild', 'format', 'upgrade', 'upgrade-read', 'upgrade-apply', 'review', 'dedupe', 'embed', 'agent-docs', 'scope-audit', 'orphans', 'broken-links', 'migrate-layout', 'upgrade-vault', 'full'])
+        .describe('Maintenance action: stats, review (pending notes), dedupe (duplicates), promote, archive, delete, rebuild, format (re-serialize all note files with canonical frontmatter and navigation), upgrade, embed (backfill embeddings), agent-docs (audit/repair managed agent instruction files), scope-audit (detect mis-scoped client tags), orphans (notes with no links), broken-links (wikilinks to non-existent notes), migrate-layout (move flat vault to kind-based directory structure), upgrade-vault (refresh Obsidian scaffold assets), or full (composite: rebuild → migrate-layout → format → dedupe → embed → broken-links → stats, in dependency order).'),
+    noteId: z.string().optional().describe('Note ID (required for promote/archive/delete; migration ID for upgrade-read)'),
+    filter: z.enum(['fleeting', 'permanent']).optional().describe('Filter for review action: fleeting or permanent notes'),
+    days: z.number().optional().describe('Days threshold for review (default: from lifecycle.reviewAfterDays config)'),
+    limit: z.number().optional().describe('Max notes to show (default: 3 for review)'),
+    telemetry: z.boolean().optional().describe('Include 30-day local-only tool invocation aggregates in stats output'),
+    dryRun: z.boolean().optional().describe('Preview changes without applying'),
+    model: z.string().optional().describe('Your model identifier (e.g. claude-opus-4, gpt-4o). Enables richer responses for capable models.'),
+  });
+
+  server.registerTool(
+    'knowledge-maintain',
+    {
+      description: 'Maintain the knowledge base: stats, review (pending notes), dedupe (duplicates), promote, archive, delete, rebuild, upgrade, and managed agent docs repair.',
+      inputSchema: maintainSchema as unknown as AnySchema,
+    },
+    async (args: z.infer<typeof maintainSchema>) => {
+      try {
+        const result = await handleMaintain({
+          action: args.action,
+          noteId: args.noteId,
+          filter: args.filter as 'fleeting' | 'permanent' | undefined,
+          days: args.days,
+          limit: args.limit,
+          telemetry: args.telemetry,
+          dryRun: args.dryRun,
+          model: args.model,
+        }, await getOrCreateRepo(), config, getEmbeddingConfig(), PKG_VERSION, gitVersioning);
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        logToFile('ERROR', 'knowledge-maintain failed', {
+          error: error instanceof Error ? error.message : String(error),
+        }, config);
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ---- knowledge-mine ----
+
+  const mineSchema = z.object({
+    candidates: z.array(z.object({
+      title: z.string().describe('Note title — 3-6 word scannable label (max 10 words / 80 chars). Detail belongs in summary.'),
+      content: z.string().describe('Note content — the extracted knowledge'),
+      kind: z.enum(STORABLE_KINDS).describe('Note kind'),
+      summary: z.string().describe('One-line present-tense key takeaway'),
+      guidance: z.string().describe('Imperative actionable instruction for agents'),
+      tags: z.array(z.string()).optional().describe('Tags for categorization'),
+      source: z.string().optional().describe('Provenance — e.g. session ID where this was found'),
+    })).describe('Array of candidate notes extracted from session history'),
+    project: z.string().optional().describe('Project scope — auto-adds project:<name> tag to all candidates'),
+    dry_run: z.boolean().optional().describe('Preview dedup results without storing (default: true)'),
+    model: z.string().optional().describe('Your model identifier for richer responses'),
+  });
+
+  server.registerTool(
+    'knowledge-mine',
+    {
+      description: 'Bulk-screen candidate notes for duplicates and optionally store. Accepts candidates extracted by the agent from session history or other sources. Returns each candidate annotated with STORE/SKIP/REVIEW based on similarity to existing KB notes. Default is dry-run (preview only).',
+      inputSchema: mineSchema as unknown as AnySchema,
+    },
+    async (args: z.infer<typeof mineSchema>) => {
+      try {
+        const result = await handleMine({
+          candidates: args.candidates.map(candidate => ({
+            title: candidate.title,
+            content: candidate.content,
+            kind: candidate.kind as NoteKind,
+            summary: candidate.summary,
+            guidance: candidate.guidance,
+            tags: candidate.tags,
+            source: candidate.source,
+          })),
+          project: args.project,
+          dry_run: args.dry_run,
+          model: args.model,
+        }, await getOrCreateRepo(), getEmbeddingConfig(), config);
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        logToFile('ERROR', 'knowledge-mine failed', {
+          error: error instanceof Error ? error.message : String(error),
+        }, config);
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ---- knowledge-template ----
+
+  const templateSchema = z.object({
+    kind: z.enum(NOTE_KINDS).describe('Note kind to get the canonical template for'),
+    project: z.string().optional().describe('Project name — checks for project-specific template overrides'),
+    model: z.string().optional().describe('Your model identifier'),
+  });
+
+  server.registerTool(
+    'knowledge-template',
+    {
+      description: 'Get the canonical note template for a specific kind. Returns skeleton structure with positive and negative examples. Consult before storing structured notes (decision, procedure, domain, reference, observation).',
+      inputSchema: templateSchema as unknown as AnySchema,
+    },
+    async (args: z.infer<typeof templateSchema>) => {
+      try {
+        const r = args.project ? await getOrCreateRepo() : (repo ?? undefined);
+        const result = handleTemplate({
+          kind: args.kind,
+          project: args.project,
+          model: args.model,
+        }, r);
+        return { content: [{ type: 'text' as const, text: result }] };
+      } catch (error) {
+        logToFile('ERROR', 'knowledge-template failed', {
+          error: error instanceof Error ? error.message : String(error),
+        }, config);
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  return server;
+}
 
 // ---- Startup ----
 
 export async function startServer() {
   ensureShutdownHandlers();
+  const server = createMcpServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
   logToFile('INFO', 'MCP server: connected via stdio', {}, config);
@@ -521,7 +523,8 @@ export async function startServer() {
   }
 }
 
-function shutdown() {
+
+export function shutdownServer() {
   logToFile('INFO', 'MCP server: shutting down', {}, config);
   if (gitVersioning) {
     try {
@@ -546,10 +549,10 @@ function shutdown() {
 
 let shutdownHandlersRegistered = false;
 
-function ensureShutdownHandlers() {
+export function ensureShutdownHandlers() {
   if (shutdownHandlersRegistered) return;
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdownServer);
+  process.on('SIGTERM', shutdownServer);
   shutdownHandlersRegistered = true;
 }
 

--- a/src/mcp-stdio-proxy.ts
+++ b/src/mcp-stdio-proxy.ts
@@ -1,0 +1,147 @@
+// mcp-stdio-proxy.ts - Stdio proxy that delegates to a shared HTTP server when available
+// Falls back to running the full server in-process when no HTTP server is detected.
+// When bridging, this process has a tiny memory footprint — no SQLite, no ONNX model.
+
+import { logToFile } from './logger.js';
+import { getConfig } from './config.js';
+import { readServerState } from './mcp-http-server.js';
+import type { ServerState } from './mcp-http-server.js';
+
+const config = getConfig();
+
+/**
+ * Probe whether the HTTP server is actually responding.
+ * Returns the server state if healthy, null otherwise.
+ */
+async function probeHttpServer(state: ServerState): Promise<ServerState | null> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2000);
+    const response = await fetch(`http://${state.host}:${state.port}/health`, {
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    if (response.ok) {
+      return state;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read a complete JSON-RPC message from stdin.
+ * MCP stdio uses newline-delimited JSON.
+ */
+async function* readStdinMessages(): AsyncGenerator<unknown> {
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  for await (const chunk of Bun.stdin.stream()) {
+    buffer += decoder.decode(chunk as Uint8Array, { stream: true });
+
+    // Process complete lines
+    let newlineIdx: number;
+    while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, newlineIdx).trim();
+      buffer = buffer.slice(newlineIdx + 1);
+
+      if (line.length === 0) continue;
+
+      try {
+        yield JSON.parse(line);
+      } catch {
+        logToFile('WARN', 'Stdio proxy: failed to parse stdin line', { line: line.slice(0, 200) }, config);
+      }
+    }
+  }
+}
+
+/**
+ * Forward a JSON-RPC message to the HTTP server and return the response.
+ */
+async function forwardToHttp(
+  state: ServerState,
+  message: unknown,
+): Promise<unknown | null> {
+  try {
+    const response = await fetch(`http://${state.host}:${state.port}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify(message),
+    });
+
+    if (!response.ok) {
+      logToFile('ERROR', 'Stdio proxy: HTTP server returned error', {
+        status: response.status,
+        statusText: response.statusText,
+      }, config);
+      return null;
+    }
+
+    // Response may be empty (for notifications)
+    const text = await response.text();
+    if (text.length === 0) return null;
+
+    return JSON.parse(text);
+  } catch (error) {
+    logToFile('ERROR', 'Stdio proxy: failed to forward to HTTP', {
+      error: error instanceof Error ? error.message : String(error),
+    }, config);
+    return null;
+  }
+}
+
+/**
+ * Write a JSON-RPC response to stdout (newline-delimited).
+ */
+function writeToStdout(message: unknown): void {
+  const data = JSON.stringify(message) + '\n';
+  Bun.write(Bun.stdout, data);
+}
+
+/**
+ * Attempt to start as a stdio→HTTP bridge.
+ * Returns true if the bridge was established, false if fallback is needed.
+ */
+export async function tryStdioBridge(): Promise<boolean> {
+  const state = readServerState();
+  if (!state) {
+    return false;
+  }
+
+  const healthy = await probeHttpServer(state);
+  if (!healthy) {
+    logToFile('DEBUG', 'HTTP server state file exists but server not healthy, falling back to in-process', {}, config);
+    return false;
+  }
+
+  logToFile('INFO', 'MCP stdio proxy: bridging to HTTP server', {
+    pid: state.pid,
+    port: state.port,
+  }, config);
+
+  try {
+    // Run the message forwarding loop
+    for await (const message of readStdinMessages()) {
+      const response = await forwardToHttp(state, message);
+      if (response !== null) {
+        writeToStdout(response);
+      }
+    }
+
+    // stdin closed — exit cleanly
+    process.exit(0);
+  } catch (error) {
+    logToFile('WARN', 'MCP stdio proxy: bridge failed, falling back to in-process', {
+      error: error instanceof Error ? error.message : String(error),
+    }, config);
+    return false;
+  }
+
+  return true;
+}

--- a/src/mcp-stdio-proxy.ts
+++ b/src/mcp-stdio-proxy.ts
@@ -131,7 +131,24 @@ export async function tryStdioBridge(): Promise<boolean> {
       const response = await forwardToHttp(state, message);
       if (response !== null) {
         writeToStdout(response);
+      } else if (
+        message !== null &&
+        typeof message === 'object' &&
+        'id' in (message as Record<string, unknown>)
+      ) {
+        // JSON-RPC requests (with an `id`) must always receive a response.
+        // Dropping them leaves the client waiting indefinitely.
+        const id = (message as Record<string, unknown>).id;
+        writeToStdout({
+          jsonrpc: '2.0',
+          id,
+          error: {
+            code: -32603, // Internal error
+            message: 'HTTP bridge failed to forward request to server',
+          },
+        });
       }
+      // Notifications (no `id`) — suppressing output is correct per JSON-RPC spec
     }
 
     // stdin closed — exit cleanly

--- a/src/mcp-stdio-proxy.ts
+++ b/src/mcp-stdio-proxy.ts
@@ -133,19 +133,35 @@ export async function tryStdioBridge(): Promise<boolean> {
       const response = await forwardToHttp(state, message);
       if (response !== null) {
         writeToStdout(response);
+      } else if (Array.isArray(message)) {
+        // Batch JSON-RPC: emit error responses for each request in the batch.
+        // Notifications (no `id`) are omitted per spec.
+        const errors = message
+          .filter((m): m is Record<string, unknown> =>
+            m !== null && typeof m === 'object' && 'id' in m)
+          .map(m => ({
+            jsonrpc: '2.0' as const,
+            id: m.id,
+            error: {
+              code: -32603,
+              message: 'HTTP bridge failed to forward request to server',
+            },
+          }));
+        if (errors.length > 0) {
+          writeToStdout(errors);
+        }
       } else if (
         message !== null &&
         typeof message === 'object' &&
         'id' in (message as Record<string, unknown>)
       ) {
-        // JSON-RPC requests (with an `id`) must always receive a response.
-        // Dropping them leaves the client waiting indefinitely.
+        // Single JSON-RPC request: emit error response.
         const id = (message as Record<string, unknown>).id;
         writeToStdout({
           jsonrpc: '2.0',
           id,
           error: {
-            code: -32603, // Internal error
+            code: -32603,
             message: 'HTTP bridge failed to forward request to server',
           },
         });

--- a/src/mcp-stdio-proxy.ts
+++ b/src/mcp-stdio-proxy.ts
@@ -17,7 +17,8 @@ async function probeHttpServer(state: ServerState): Promise<ServerState | null> 
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 2000);
-    const response = await fetch(`http://${state.host}:${state.port}/health`, {
+    const hostForUrl = state.host.includes(':') ? `[${state.host}]` : state.host;
+    const response = await fetch(`http://${hostForUrl}:${state.port}/health`, {
       signal: controller.signal,
     });
     clearTimeout(timeout);
@@ -66,7 +67,8 @@ async function forwardToHttp(
   message: unknown,
 ): Promise<unknown | null> {
   try {
-    const response = await fetch(`http://${state.host}:${state.port}/mcp`, {
+    const hostForUrl = state.host.includes(':') ? `[${state.host}]` : state.host;
+    const response = await fetch(`http://${hostForUrl}:${state.port}/mcp`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -1,8 +1,10 @@
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import type { StdioServerParameters } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { CompatibilityCallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 
 interface JsonSchema {
@@ -50,6 +52,7 @@ interface BeforeAgentStartResult {
 interface BridgeOptions {
   server: StdioServerParameters;
   clientName: string;
+  httpUrl?: string;
 }
 
 type ToolName = typeof TOOL_DEFINITIONS[number]['name'];
@@ -261,9 +264,10 @@ function textFromMcpContent(content: unknown[]): string {
 
 class OpenZkKbMcpBridge {
   private client: Client | undefined;
-  private transport: StdioClientTransport | undefined;
+  private transport: (StdioClientTransport | StreamableHTTPClientTransport) | undefined;
   private connecting: Promise<Client> | undefined;
   private stderrTail = '';
+  private httpDisabled = false;
 
   constructor(private readonly options: BridgeOptions) {}
 
@@ -320,6 +324,24 @@ class OpenZkKbMcpBridge {
 
   private async connect(): Promise<Client> {
     const client = new Client({ name: this.options.clientName, version: '1.0.0' });
+
+    if (this.options.httpUrl && !this.httpDisabled) {
+      try {
+        const transport = new StreamableHTTPClientTransport(
+          new URL(this.options.httpUrl),
+        );
+        this.transport = transport;
+        await client.connect(transport);
+        this.client = client;
+        this.connecting = undefined;
+        return client;
+      } catch {
+        // HTTP connection failed — fall back to stdio for this and future calls
+        this.httpDisabled = true;
+        this.transport = undefined;
+      }
+    }
+
     const transport = new StdioClientTransport(this.options.server);
     this.transport = transport;
     this.captureStderr(transport);
@@ -350,11 +372,44 @@ class OpenZkKbMcpBridge {
   }
 }
 
+function isLoopbackHost(host: string): boolean {
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1';
+}
+
+function detectHttpServer(): string | undefined {
+  try {
+    // Prefer XDG_RUNTIME_DIR (per-user, secure permissions on Linux).
+    // Fall back to TMPDIR (macOS sets this to a per-user private temp dir).
+    // Never fall back to /tmp — it's world-writable and allows state-file injection.
+    const runtimeDir = process.env.XDG_RUNTIME_DIR || process.env.TMPDIR;
+    if (!runtimeDir) return undefined;
+
+    const stateFile = path.join(runtimeDir, 'open-zk-kb', 'server.json');
+    const content = fs.readFileSync(stateFile, 'utf-8');
+    const state = JSON.parse(content) as { pid: number; host: string; port: number };
+
+    // Validate shape
+    if (typeof state.pid !== 'number' || typeof state.host !== 'string' || typeof state.port !== 'number') {
+      return undefined;
+    }
+
+    // Only trust loopback addresses for auto-discovery
+    if (!isLoopbackHost(state.host)) return undefined;
+
+    // Verify process is alive
+    process.kill(state.pid, 0);
+    return `http://${state.host}:${state.port}/mcp`;
+  } catch {
+    return undefined;
+  }
+}
+
 export function createOpenZkKbPiExtension(options?: Partial<BridgeOptions>) {
   return (pi: PiExtensionApi): void => {
     const bridge = new OpenZkKbMcpBridge({
       server: options?.server ?? defaultServerParameters(),
       clientName: options?.clientName ?? 'open-zk-kb-pi',
+      httpUrl: options?.httpUrl ?? detectHttpServer(),
     });
 
     for (const definition of TOOL_DEFINITIONS) {

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -376,6 +376,10 @@ function isLoopbackHost(host: string): boolean {
   return host === '127.0.0.1' || host === 'localhost' || host === '::1';
 }
 
+function isLocalHost(host: string): boolean {
+  return isLoopbackHost(host) || host === '0.0.0.0' || host === '::';
+}
+
 function detectHttpServer(): string | undefined {
   try {
     // Prefer XDG_RUNTIME_DIR (per-user, secure permissions on Linux).
@@ -393,12 +397,20 @@ function detectHttpServer(): string | undefined {
       return undefined;
     }
 
-    // Only trust loopback addresses for auto-discovery
-    if (!isLoopbackHost(state.host)) return undefined;
+    // Only trust loopback and wildcard bind addresses for auto-discovery
+    if (!isLocalHost(state.host)) return undefined;
+
+    // Normalize wildcard bind addresses to loopback for probing
+    const probeHost = (state.host === '0.0.0.0' || state.host === '::')
+      ? '127.0.0.1'
+      : state.host;
 
     // Verify process is alive
     process.kill(state.pid, 0);
-    return `http://${state.host}:${state.port}/mcp`;
+
+    // Bracket IPv6 hosts per RFC 3986
+    const hostForUrl = probeHost.includes(':') ? `[${probeHost}]` : probeHost;
+    return `http://${hostForUrl}:${state.port}/mcp`;
   } catch {
     return undefined;
   }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -170,7 +170,7 @@ function buildMcpEntry(clientConfig: ClientConfig, serverPath?: string, transpor
       : config.server.host;
     return {
       type: 'http',
-      url: `http://${clientHost}:${config.server.port}/mcp`,
+      url: `http://${clientHost.includes(':') ? `[${clientHost}]` : clientHost}:${config.server.port}/mcp`,
     };
   }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -645,7 +645,18 @@ function validateMcpEntry(clientConfig: ClientConfig, entry: unknown): string[] 
 
   // HTTP transport entries are valid if they have a url
   if (record.type === 'http') {
-    if (typeof record.url !== 'string' || record.url.length === 0) issues.push('missing url for http entry');
+    if (typeof record.url !== 'string' || record.url.length === 0) {
+      issues.push('missing url for http entry');
+    } else {
+      try {
+        const url = new URL(record.url);
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+          issues.push('http entry url must use http or https');
+        }
+      } catch {
+        issues.push('invalid url for http entry');
+      }
+    }
     return issues;
   }
   if (clientConfig.mcpFormat === 'opencode') {
@@ -689,8 +700,14 @@ function repairClientConfig(clientConfig: ClientConfig, config: Record<string, u
   if (!clientConfig.mcpPath) {
     throw new Error(`${clientConfig.name} does not use MCP config entries`);
   }
-  // Don't repair HTTP entries — they are intentional transport overrides
-  if (existingEntry && typeof existingEntry === 'object' && (existingEntry as Record<string, unknown>).type === 'http') {
+  // Don't repair valid HTTP entries — they are intentional transport overrides.
+  // Invalid HTTP entries should still be repaired (e.g. malformed URL).
+  if (
+    existingEntry &&
+    typeof existingEntry === 'object' &&
+    (existingEntry as Record<string, unknown>).type === 'http' &&
+    validateMcpEntry(clientConfig, existingEntry).length === 0
+  ) {
     return;
   }
   const inferredServerPath = inferServerPathFromEntry(clientConfig, existingEntry);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -11,6 +11,7 @@ import { expandPath } from './utils/path.js';
 import { injectAgentDocs, inspectAgentDocs, removeAgentDocs } from './agent-docs.js';
 import type { InstructionSize } from './agent-docs.js';
 import { PKG_VERSION } from './version.js';
+import { getConfig } from './config.js';
 
 function detectNpmTag(): 'dev' | 'latest' {
   return PKG_VERSION.includes('-dev.') ? 'dev' : 'latest';
@@ -21,9 +22,12 @@ const xdgDataHome = process.env.XDG_DATA_HOME || expandPath('~/.local/share');
 
 export type McpClient = 'opencode' | 'claude-code' | 'cursor' | 'windsurf' | 'zed' | 'pi' | 'omp';
 
+export type McpTransport = 'stdio' | 'http';
+
 export interface InstallArgs {
   client: McpClient;
   serverPath?: string;
+  transport?: McpTransport;
   force?: boolean;
   dryRun?: boolean;
   instructionSize?: InstructionSize;
@@ -148,11 +152,26 @@ type McpEntry =
   | {
       command: 'bun' | 'bunx';
       args: [string, ...string[]];
+    }
+  | {
+      type: 'http';
+      url: string;
     };
 
-function buildMcpEntry(clientConfig: ClientConfig, serverPath?: string): McpEntry {
+function buildMcpEntry(clientConfig: ClientConfig, serverPath?: string, transport?: McpTransport): McpEntry {
   if (!clientConfig.mcpFormat) {
     throw new Error(`${clientConfig.name} does not use MCP config entries`);
+  }
+
+  if (transport === 'http') {
+    const config = getConfig();
+    const clientHost = config.server.host === '0.0.0.0' || config.server.host === '::'
+      ? '127.0.0.1'
+      : config.server.host;
+    return {
+      type: 'http',
+      url: `http://${clientHost}:${config.server.port}/mcp`,
+    };
   }
 
   if (!serverPath) {
@@ -624,6 +643,11 @@ function validateMcpEntry(clientConfig: ClientConfig, entry: unknown): string[] 
   const record = entry as Record<string, unknown>;
   const issues: string[] = [];
 
+  // HTTP transport entries are valid if they have a url
+  if (record.type === 'http') {
+    if (typeof record.url !== 'string' || record.url.length === 0) issues.push('missing url for http entry');
+    return issues;
+  }
   if (clientConfig.mcpFormat === 'opencode') {
     if (record.type !== 'local') issues.push('expected type "local"');
     if (!Array.isArray(record.command) || record.command.length === 0) issues.push('missing command array');
@@ -664,6 +688,10 @@ function inferServerPathFromEntry(clientConfig: ClientConfig, entry: unknown): s
 function repairClientConfig(clientConfig: ClientConfig, config: Record<string, unknown>, existingEntry: unknown): void {
   if (!clientConfig.mcpPath) {
     throw new Error(`${clientConfig.name} does not use MCP config entries`);
+  }
+  // Don't repair HTTP entries — they are intentional transport overrides
+  if (existingEntry && typeof existingEntry === 'object' && (existingEntry as Record<string, unknown>).type === 'http') {
+    return;
   }
   const inferredServerPath = inferServerPathFromEntry(clientConfig, existingEntry);
   const repairedEntry = buildMcpEntry(clientConfig, inferredServerPath);
@@ -905,11 +933,13 @@ export function doctor(args: DoctorArgs = {}): string {
 export function install(args: InstallArgs): string {
   const clientConfig = CLIENT_CONFIGS[args.client];
   const usesPiPackage = isPiPackageClient(clientConfig);
-  const serverPath = usesPiPackage ? args.serverPath : args.serverPath || detectServerPath();
+  const serverPath = usesPiPackage ? args.serverPath :
+    args.transport === 'http' ? args.serverPath :
+    args.serverPath || detectServerPath();
   const piPackageSource = usesPiPackage ? buildPiPackageSource() : null;
   const vaultPath = getVaultPath();
   
-  if (!usesPiPackage && serverPath && !fs.existsSync(serverPath)) {
+  if (!usesPiPackage && args.transport !== 'http' && serverPath && !fs.existsSync(serverPath)) {
     throw new Error(`Server not found at: ${serverPath}`);
   }
   
@@ -940,7 +970,7 @@ export function install(args: InstallArgs): string {
     return `Already installed for ${clientConfig.name}. Use --force to overwrite.`;
   }
   
-  const mcpEntry = usesPiPackage ? null : buildMcpEntry(clientConfig, serverPath);
+  const mcpEntry = usesPiPackage ? null : buildMcpEntry(clientConfig, serverPath, args.transport);
   
   const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const templatesDir = path.join(projectRoot, 'templates');
@@ -1222,6 +1252,7 @@ install:
   --client <name>      Install for specific client (opencode, claude-code, cursor, windsurf, zed, pi, omp)
   --server-path <path> Path to dist/mcp-server.js (auto-detected; MCP clients only)
   --instructions <size> Agent instruction size: compact (~140 tokens) or full (~420 tokens)
+  --transport <type>   Transport type: stdio (default) or http
   --force              Overwrite existing config
   --dry-run            Preview changes without applying
   --yes                Non-interactive, accept defaults
@@ -1274,6 +1305,12 @@ export async function runSetupCli(rawArgs: string[] = process.argv.slice(2)): Pr
     const serverPath = parseFlagValue(args, '--server-path');
     const clientArg = parseFlagValue(args, '--client');
     const instructionsArg = parseFlagValue(args, '--instructions');
+    const transportArg = parseFlagValue(args, '--transport');
+    const transport: McpTransport | undefined =
+      transportArg === 'stdio' || transportArg === 'http' ? transportArg : undefined;
+    if (transportArg && !transport) {
+      throw new Error(`Invalid --transport value: ${transportArg}. Use 'stdio' or 'http'.`);
+    }
     const instructionSize: InstructionSize | undefined =
       instructionsArg === 'compact' || instructionsArg === 'full' ? instructionsArg : undefined;
     if (instructionsArg && !instructionSize) {
@@ -1291,7 +1328,7 @@ export async function runSetupCli(rawArgs: string[] = process.argv.slice(2)): Pr
     /** Prompt for symlinked agent docs and install a single client. */
     async function installWithSymlinkPrompt(
       client: McpClient,
-      opts: { serverPath?: string; force?: boolean; dryRun?: boolean; instructionSize?: InstructionSize; yes?: boolean },
+      opts: { serverPath?: string; transport?: McpTransport; force?: boolean; dryRun?: boolean; instructionSize?: InstructionSize; yes?: boolean },
     ): Promise<string> {
       const clientConfig = CLIENT_CONFIGS[client];
       let injectSharedAgentDocs: boolean | undefined;
@@ -1319,6 +1356,7 @@ export async function runSetupCli(rawArgs: string[] = process.argv.slice(2)): Pr
       return install({
         client,
         serverPath: opts.serverPath,
+        transport: opts.transport,
         force: opts.force,
         dryRun: opts.dryRun,
         instructionSize: opts.instructionSize,
@@ -1327,14 +1365,14 @@ export async function runSetupCli(rawArgs: string[] = process.argv.slice(2)): Pr
     }
 
     if (client) {
-      const result = await installWithSymlinkPrompt(client, { serverPath, force, dryRun, instructionSize, yes });
+      const result = await installWithSymlinkPrompt(client, { serverPath, transport, force, dryRun, instructionSize, yes });
       console.log(result);
       return;
     }
 
     if (yes) {
       for (const client of ALL_CLIENTS) {
-        const result = await installWithSymlinkPrompt(client, { serverPath, force, dryRun, instructionSize, yes: true });
+        const result = await installWithSymlinkPrompt(client, { serverPath, transport, force, dryRun, instructionSize, yes: true });
         console.log(result);
       }
       return;
@@ -1366,7 +1404,7 @@ export async function runSetupCli(rawArgs: string[] = process.argv.slice(2)): Pr
 
     for (const client of selected) {
       try {
-        await installWithSymlinkPrompt(client, { serverPath, force, dryRun, instructionSize });
+        await installWithSymlinkPrompt(client, { serverPath, transport, force, dryRun, instructionSize });
         p.log.success(`Installed for ${CLIENT_CONFIGS[client].name}`);
       } catch (e) {
         p.log.error(`${CLIENT_CONFIGS[client].name}: ${e instanceof Error ? e.message : e}`);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -710,8 +710,16 @@ function repairClientConfig(clientConfig: ClientConfig, config: Record<string, u
   ) {
     return;
   }
+  // Preserve HTTP transport when repairing a broken HTTP entry —
+  // without this, a malformed HTTP URL gets silently replaced with stdio.
+  const transport: McpTransport | undefined =
+    existingEntry &&
+    typeof existingEntry === 'object' &&
+    (existingEntry as Record<string, unknown>).type === 'http'
+      ? 'http'
+      : undefined;
   const inferredServerPath = inferServerPathFromEntry(clientConfig, existingEntry);
-  const repairedEntry = buildMcpEntry(clientConfig, inferredServerPath);
+  const repairedEntry = buildMcpEntry(clientConfig, inferredServerPath, transport);
   setNestedValue(config, clientConfig.mcpPath, repairedEntry);
   if (clientConfig.mcpFormat === 'opencode') {
     removeStaleOpenCodePluginEntries(config);

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,11 @@ export interface StoreConfig {
   relatedNotes: RelatedNotesConfig;
 }
 
+export interface ServerConfig {
+  port: number;
+  host: string;
+}
+
 export interface AppConfig {
   logLevel: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
   vault: string;
@@ -102,6 +107,7 @@ export interface AppConfig {
   telemetry: TelemetryConfig;
   obsidian: ObsidianConfig;
   versioning: VersioningConfig;
+  server: ServerConfig;
 }
 
 // NOTE: NoteMetadata and StoreResult are defined in storage/NoteRepository.ts

--- a/tests/docker/mcp-protocol-test.ts
+++ b/tests/docker/mcp-protocol-test.ts
@@ -1,10 +1,11 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
+const totalExpected = 19;
+
 async function run() {
   let passed = 0;
   let failed = 0;
-  const totalExpected = 16;
 
   const check = (name: string, ok: boolean, detail?: string) => {
     if (ok) { console.log(`  ✅ ${name}`); passed++; }

--- a/tests/http-server.test.ts
+++ b/tests/http-server.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('HTTP Server', () => {
+  let tmpDir: string;
+  let originalRuntimeDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ozkb-http-test-'));
+    originalRuntimeDir = process.env.XDG_RUNTIME_DIR;
+    process.env.XDG_RUNTIME_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    if (originalRuntimeDir !== undefined) {
+      process.env.XDG_RUNTIME_DIR = originalRuntimeDir;
+    } else {
+      delete process.env.XDG_RUNTIME_DIR;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('readServerState', () => {
+    it('should return null when no state file exists', async () => {
+      // readServerState uses module-level constants computed at import time,
+      // so we need a fresh import to pick up the new XDG_RUNTIME_DIR
+      const mod = await import('../src/mcp-http-server.js');
+      const result = mod.readServerState();
+      expect(result).toBeNull();
+    });
+
+    it('should return null for stale state file (dead PID)', async () => {
+      const stateDir = path.join(tmpDir, 'open-zk-kb');
+      fs.mkdirSync(stateDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(stateDir, 'server.json'),
+        JSON.stringify({
+          pid: 999999999,
+          port: 17244,
+          host: '127.0.0.1',
+          version: '1.0.0',
+          startedAt: new Date().toISOString(),
+        }),
+      );
+      const mod = await import('../src/mcp-http-server.js');
+      expect(mod.readServerState()).toBeNull();
+    });
+
+    it('should export ServerState interface shape', async () => {
+      const mod = await import('../src/mcp-http-server.js');
+      // Verify exports exist
+      expect(typeof mod.readServerState).toBe('function');
+      expect(typeof mod.startHttpServer).toBe('function');
+    });
+  });
+
+  describe('CLI serve command', () => {
+    it('should call startHttpServer with parsed flags', async () => {
+      let capturedOptions: unknown = null;
+      const { runCli } = await import('../src/cli.js');
+
+      await runCli(['serve', '--port', '18000', '--host', '0.0.0.0'], {
+        startHttpServer: async (opts) => {
+          capturedOptions = opts;
+        },
+      });
+
+      expect(capturedOptions).toEqual({ port: 18000, host: '0.0.0.0' });
+    });
+
+    it('should call startHttpServer with defaults when no flags', async () => {
+      let capturedOptions: unknown = null;
+      const { runCli } = await import('../src/cli.js');
+
+      await runCli(['serve'], {
+        startHttpServer: async (opts) => {
+          capturedOptions = opts;
+        },
+      });
+
+      expect(capturedOptions).toEqual({ port: undefined, host: undefined });
+    });
+
+    it('should parse --port as integer', async () => {
+      let capturedOptions: unknown = null;
+      const { runCli } = await import('../src/cli.js');
+
+      await runCli(['serve', '--port', '9999'], {
+        startHttpServer: async (opts) => {
+          capturedOptions = opts;
+        },
+      });
+
+      expect((capturedOptions as { port: number }).port).toBe(9999);
+      expect(typeof (capturedOptions as { port: number }).port).toBe('number');
+    });
+
+    it('should reject invalid port values', async () => {
+      const { runCli } = await import('../src/cli.js');
+
+      await expect(runCli(['serve', '--port', 'abc'], {
+        startHttpServer: async () => {},
+      })).rejects.toThrow('Invalid --port value');
+
+      await expect(runCli(['serve', '--port', '0'], {
+        startHttpServer: async () => {},
+      })).rejects.toThrow('Invalid --port value');
+
+      await expect(runCli(['serve', '--port', '70000'], {
+        startHttpServer: async () => {},
+      })).rejects.toThrow('Invalid --port value');
+    });
+
+    it('should support --port=VALUE syntax', async () => {
+      let capturedOptions: unknown = null;
+      const { runCli } = await import('../src/cli.js');
+
+      await runCli(['serve', '--port=18000', '--host=0.0.0.0'], {
+        startHttpServer: async (opts) => {
+          capturedOptions = opts;
+        },
+      });
+
+      expect(capturedOptions).toEqual({ port: 18000, host: '0.0.0.0' });
+    });
+  });
+
+  describe('CLI server command with proxy', () => {
+    it('should try bridge first and fall back to startServer', async () => {
+      let bridgeCalled = false;
+      let serverCalled = false;
+      const { runCli } = await import('../src/cli.js');
+
+      await runCli(['server'], {
+        tryStdioBridge: async () => {
+          bridgeCalled = true;
+          return false;
+        },
+        startServer: async () => {
+          serverCalled = true;
+        },
+      });
+
+      expect(bridgeCalled).toBe(true);
+      expect(serverCalled).toBe(true);
+    });
+
+    it('should not call startServer when bridge succeeds', async () => {
+      let serverCalled = false;
+      const { runCli } = await import('../src/cli.js');
+
+      await runCli(['server'], {
+        tryStdioBridge: async () => true,
+        startServer: async () => {
+          serverCalled = true;
+        },
+      });
+
+      expect(serverCalled).toBe(false);
+    });
+
+    it('should call tryStdioBridge before startServer', async () => {
+      const callOrder: string[] = [];
+      const { runCli } = await import('../src/cli.js');
+
+      await runCli(['server'], {
+        tryStdioBridge: async () => {
+          callOrder.push('bridge');
+          return false;
+        },
+        startServer: async () => {
+          callOrder.push('server');
+        },
+      });
+
+      expect(callOrder).toEqual(['bridge', 'server']);
+    });
+
+    it('should fall back to startServer when bridge throws', async () => {
+      let serverCalled = false;
+      const { runCli } = await import('../src/cli.js');
+
+      await runCli(['server'], {
+        tryStdioBridge: async () => {
+          throw new Error('Connection refused');
+        },
+        startServer: async () => {
+          serverCalled = true;
+        },
+      });
+
+      expect(serverCalled).toBe(true);
+    });
+  });
+
+  describe('CLI default command', () => {
+    it('should fall through to setup when command is not server/serve', async () => {
+      let setupCalled = false;
+      let setupArgs: string[] = [];
+      const { runCli } = await import('../src/cli.js');
+
+      await runCli(['install'], {
+        runSetupCli: async (args) => {
+          setupCalled = true;
+          setupArgs = args;
+        },
+      });
+
+      expect(setupCalled).toBe(true);
+      expect(setupArgs).toEqual(['install']);
+    });
+
+    it('should call setup with no args when no command given', async () => {
+      let setupArgs: string[] = [];
+      const { runCli } = await import('../src/cli.js');
+
+      await runCli([], {
+        runSetupCli: async (args) => {
+          setupArgs = args;
+        },
+      });
+
+      expect(setupArgs).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a shared HTTP server mode so multiple MCP client sessions can connect to a single open-zk-kb process instead of spawning one per session.

### Changes

- **`open-zk-kb serve`** — new CLI command starts a shared HTTP server via `Bun.serve()` with `WebStandardStreamableHTTPServerTransport` in stateless mode
- **Transparent stdio bridge** — `open-zk-kb server` (stdio) auto-detects a running HTTP server via PID file and bridges to it, reducing resource usage without config changes
- **`--transport http` installer flag** — `install --client omp --transport http` writes direct HTTP MCP config
- **`createMcpServer()` factory** — refactored from singleton to per-request factory for safe concurrent HTTP handling (MCP SDK rejects connecting a second transport to the same Protocol instance)
- **Hardened server discovery** — validates state file shape, rejects non-loopback hosts, prefers `XDG_RUNTIME_DIR`/`TMPDIR` over `/tmp`, falls back to stdio on HTTP failure
- **Port validation** — 1–65535 range in CLI (`--port`/`--port=VALUE`) and config
- **Doctor HTTP awareness** — recognizes HTTP MCP entries, skips repair of intentional HTTP configs
- **Wildcard host mapping** — maps `0.0.0.0`/`::` to `127.0.0.1` in generated client URLs

### New Files

| File | Purpose |
|------|---------|
| `src/mcp-http-server.ts` | Shared HTTP server: Bun.serve(), PID state file, request handler |
| `src/mcp-stdio-proxy.ts` | Stdio→HTTP bridge: health probe, message forwarding |
| `tests/http-server.test.ts` | Tests for CLI commands, port validation, bridge fallback |

### Benefits

- **Memory**: One ONNX embedding model (~23MB) instead of one per session
- **SQLite**: Single database connection eliminates SQLITE_BUSY contention
- **Startup**: Sessions connect instantly instead of loading the model

### Config

```yaml
server:
  port: 17244      # Default
  host: 127.0.0.1  # Localhost only (recommended)
```