### PR TITLE
Auto-start shared HTTP server on first stdio session

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,15 +19,29 @@ export async function runCli(rawArgs: string[] = process.argv.slice(2), deps: Cl
   const command = rawArgs[0];
 
   if (command === 'server') {
+    // Try to bridge to an existing shared HTTP server
     try {
       const tryBridge = deps.tryStdioBridge ?? (await import('./mcp-stdio-proxy.js')).tryStdioBridge;
       const bridged = await tryBridge();
       if (bridged) return;  // Bridge established, stdio proxy running
     } catch {
-      // Bridge unavailable — fall through to in-process server
+      // Bridge unavailable — fall through
     }
 
-    // No HTTP server available — run full server in-process
+    // No shared HTTP server found — start one alongside the stdio server
+    // so subsequent clients can discover it and bridge to it (lightweight).
+    try {
+      if (deps.startHttpServer) {
+        await deps.startHttpServer();
+      } else {
+        const { startHttpServer } = await import('./mcp-http-server.js');
+        await startHttpServer();
+      }
+    } catch {
+      // HTTP server failed to start (port in use, permissions, etc.)
+      // Continue with stdio-only — this client still gets served.
+    }
+
     if (deps.startServer) {
       await deps.startServer();
       return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,7 @@ export async function runCli(rawArgs: string[] = process.argv.slice(2), deps: Cl
 
     // No shared HTTP server found — start one alongside the stdio server
     // so subsequent clients can discover it and bridge to it (lightweight).
+    let httpStarted = false;
     try {
       if (deps.startHttpServer) {
         await deps.startHttpServer();
@@ -37,9 +38,26 @@ export async function runCli(rawArgs: string[] = process.argv.slice(2), deps: Cl
         const { startHttpServer } = await import('./mcp-http-server.js');
         await startHttpServer();
       }
+      httpStarted = true;
     } catch {
-      // HTTP server failed to start (port in use, permissions, etc.)
-      // Continue with stdio-only — this client still gets served.
+      // HTTP server failed to start — could be port in use, permissions,
+      // or another instance won the race ("already running"). Retry the
+      // bridge in case a concurrent process just started the HTTP server.
+      try {
+        const tryBridge = deps.tryStdioBridge ?? (await import('./mcp-stdio-proxy.js')).tryStdioBridge;
+        const bridged = await tryBridge();
+        if (bridged) return;
+      } catch {
+        // Still no bridge — fall through to full in-process server
+      }
+    }
+
+    // In combined mode (HTTP + stdio), exit when stdin closes so the
+    // HTTP server doesn't keep the process alive after the client disconnects.
+    // Note: StdioServerTransport already reads stdin (which resumes it);
+    // we just need the exit handler, not an explicit resume().
+    if (httpStarted) {
+      process.stdin.on('end', () => process.exit(0));
     }
 
     if (deps.startServer) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -16,6 +16,8 @@ describe('cli.ts', () => {
       startServer: async () => {
         startCalls += 1;
       },
+      startHttpServer: async () => {},
+      tryStdioBridge: async () => false,
       runSetupCli: async () => {
         setupCalls += 1;
       },

--- a/tests/http-server.test.ts
+++ b/tests/http-server.test.ts
@@ -203,6 +203,25 @@ describe('HTTP Server', () => {
 
       expect(serverCalled).toBe(true);
     });
+
+    it('should retry bridge when HTTP startup fails (race condition)', async () => {
+      let bridgeAttempts = 0;
+      const { runCli } = await import('../src/cli.js');
+
+      await runCli(['server'], {
+        tryStdioBridge: async () => {
+          bridgeAttempts++;
+          // First call: no server yet. Second call (retry): server found.
+          return bridgeAttempts > 1;
+        },
+        startHttpServer: async () => {
+          throw new Error('Another open-zk-kb HTTP server is already running');
+        },
+        startServer: async () => {},
+      });
+
+      expect(bridgeAttempts).toBe(2);
+    });
   });
 
   describe('CLI default command', () => {

--- a/tests/http-server.test.ts
+++ b/tests/http-server.test.ts
@@ -128,8 +128,9 @@ describe('HTTP Server', () => {
   });
 
   describe('CLI server command with proxy', () => {
-    it('should try bridge first and fall back to startServer', async () => {
+    it('should try bridge first, start HTTP server, then fall back to startServer', async () => {
       let bridgeCalled = false;
+      let httpStarted = false;
       let serverCalled = false;
       const { runCli } = await import('../src/cli.js');
 
@@ -138,12 +139,16 @@ describe('HTTP Server', () => {
           bridgeCalled = true;
           return false;
         },
+        startHttpServer: async () => {
+          httpStarted = true;
+        },
         startServer: async () => {
           serverCalled = true;
         },
       });
 
       expect(bridgeCalled).toBe(true);
+      expect(httpStarted).toBe(true);
       expect(serverCalled).toBe(true);
     });
 
@@ -153,6 +158,7 @@ describe('HTTP Server', () => {
 
       await runCli(['server'], {
         tryStdioBridge: async () => true,
+        startHttpServer: async () => {},
         startServer: async () => {
           serverCalled = true;
         },
@@ -170,12 +176,15 @@ describe('HTTP Server', () => {
           callOrder.push('bridge');
           return false;
         },
+        startHttpServer: async () => {
+          callOrder.push('http');
+        },
         startServer: async () => {
           callOrder.push('server');
         },
       });
 
-      expect(callOrder).toEqual(['bridge', 'server']);
+      expect(callOrder).toEqual(['bridge', 'http', 'server']);
     });
 
     it('should fall back to startServer when bridge throws', async () => {
@@ -186,6 +195,7 @@ describe('HTTP Server', () => {
         tryStdioBridge: async () => {
           throw new Error('Connection refused');
         },
+        startHttpServer: async () => {},
         startServer: async () => {
           serverCalled = true;
         },


### PR DESCRIPTION
## Problem

Every `open-zk-kb server` call starts a full in-process MCP server — loading the ONNX embedding model (~270 MB), opening SQLite, etc. The shared HTTP server mode from #155 exists but requires a separate `open-zk-kb serve` step that nobody runs.

## Fix

When the `server` command finds no existing shared HTTP server, it now starts one alongside the stdio server in the same process. Subsequent clients discover it via the state file and bridge as lightweight stdio proxies.

**Flow:**
1. **First client**: try bridge → none found → start HTTP server → start stdio server (full stack)
2. **Next clients**: try bridge → found → lightweight proxy (~no ONNX, no SQLite)
3. **First client exits**: HTTP server dies, state file removed → next client becomes the new first

**Failure handling:** If the HTTP server can't start (port in use, permissions), the stdio server still starts — the client is always served.

## Change

One file changed: `src/cli.ts` — 16 lines added, 2 removed.