### PR TITLE
Revert auto-start HTTP server on first stdio session

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,47 +19,16 @@ export async function runCli(rawArgs: string[] = process.argv.slice(2), deps: Cl
   const command = rawArgs[0];
 
   if (command === 'server') {
-    // Try to bridge to an existing shared HTTP server
+    // Try to bridge to an existing shared HTTP server (started via `open-zk-kb serve`)
     try {
       const tryBridge = deps.tryStdioBridge ?? (await import('./mcp-stdio-proxy.js')).tryStdioBridge;
       const bridged = await tryBridge();
       if (bridged) return;  // Bridge established, stdio proxy running
     } catch {
-      // Bridge unavailable — fall through
+      // Bridge unavailable — fall through to in-process server
     }
 
-    // No shared HTTP server found — start one alongside the stdio server
-    // so subsequent clients can discover it and bridge to it (lightweight).
-    let httpStarted = false;
-    try {
-      if (deps.startHttpServer) {
-        await deps.startHttpServer();
-      } else {
-        const { startHttpServer } = await import('./mcp-http-server.js');
-        await startHttpServer();
-      }
-      httpStarted = true;
-    } catch {
-      // HTTP server failed to start — could be port in use, permissions,
-      // or another instance won the race ("already running"). Retry the
-      // bridge in case a concurrent process just started the HTTP server.
-      try {
-        const tryBridge = deps.tryStdioBridge ?? (await import('./mcp-stdio-proxy.js')).tryStdioBridge;
-        const bridged = await tryBridge();
-        if (bridged) return;
-      } catch {
-        // Still no bridge — fall through to full in-process server
-      }
-    }
-
-    // In combined mode (HTTP + stdio), exit when stdin closes so the
-    // HTTP server doesn't keep the process alive after the client disconnects.
-    // Note: StdioServerTransport already reads stdin (which resumes it);
-    // we just need the exit handler, not an explicit resume().
-    if (httpStarted) {
-      process.stdin.on('end', () => process.exit(0));
-    }
-
+    // No shared HTTP server available — run full server in-process
     if (deps.startServer) {
       await deps.startServer();
       return;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -16,7 +16,6 @@ describe('cli.ts', () => {
       startServer: async () => {
         startCalls += 1;
       },
-      startHttpServer: async () => {},
       tryStdioBridge: async () => false,
       runSetupCli: async () => {
         setupCalls += 1;

--- a/tests/http-server.test.ts
+++ b/tests/http-server.test.ts
@@ -128,9 +128,8 @@ describe('HTTP Server', () => {
   });
 
   describe('CLI server command with proxy', () => {
-    it('should try bridge first, start HTTP server, then fall back to startServer', async () => {
+    it('should try bridge first and fall back to startServer', async () => {
       let bridgeCalled = false;
-      let httpStarted = false;
       let serverCalled = false;
       const { runCli } = await import('../src/cli.js');
 
@@ -139,16 +138,12 @@ describe('HTTP Server', () => {
           bridgeCalled = true;
           return false;
         },
-        startHttpServer: async () => {
-          httpStarted = true;
-        },
         startServer: async () => {
           serverCalled = true;
         },
       });
 
       expect(bridgeCalled).toBe(true);
-      expect(httpStarted).toBe(true);
       expect(serverCalled).toBe(true);
     });
 
@@ -158,7 +153,6 @@ describe('HTTP Server', () => {
 
       await runCli(['server'], {
         tryStdioBridge: async () => true,
-        startHttpServer: async () => {},
         startServer: async () => {
           serverCalled = true;
         },
@@ -176,15 +170,12 @@ describe('HTTP Server', () => {
           callOrder.push('bridge');
           return false;
         },
-        startHttpServer: async () => {
-          callOrder.push('http');
-        },
         startServer: async () => {
           callOrder.push('server');
         },
       });
 
-      expect(callOrder).toEqual(['bridge', 'http', 'server']);
+      expect(callOrder).toEqual(['bridge', 'server']);
     });
 
     it('should fall back to startServer when bridge throws', async () => {
@@ -195,32 +186,12 @@ describe('HTTP Server', () => {
         tryStdioBridge: async () => {
           throw new Error('Connection refused');
         },
-        startHttpServer: async () => {},
         startServer: async () => {
           serverCalled = true;
         },
       });
 
       expect(serverCalled).toBe(true);
-    });
-
-    it('should retry bridge when HTTP startup fails (race condition)', async () => {
-      let bridgeAttempts = 0;
-      const { runCli } = await import('../src/cli.js');
-
-      await runCli(['server'], {
-        tryStdioBridge: async () => {
-          bridgeAttempts++;
-          // First call: no server yet. Second call (retry): server found.
-          return bridgeAttempts > 1;
-        },
-        startHttpServer: async () => {
-          throw new Error('Another open-zk-kb HTTP server is already running');
-        },
-        startServer: async () => {},
-      });
-
-      expect(bridgeAttempts).toBe(2);
     });
   });
 


### PR DESCRIPTION
## Why

The auto-start from PR #156 costs more memory than it saves in the common case (2-3 sessions):

| Model | 2 sessions | 3 sessions |
|---|---|---|
| Old (independent) | ~110 MB | ~165 MB |
| Auto-start (leader + bridges) | ~314 MB | ~364 MB |

The leader process loads the full ONNX embedding model (~264 MB) regardless, and bridges still cost ~50 MB each. The savings only break even at 6-7+ concurrent sessions. Additionally, the auto-start added significant operational complexity: race condition handling, stdin close detection, leader election, stale state cleanup.

## What stays

- `open-zk-kb serve` — explicit shared HTTP server for users who need it
- `server` command still tries to bridge to an existing HTTP server if one is running
- `server-state.ts` extraction (PR #158) — keeps the bridge import chain lightweight

## What's removed

- Auto-start of HTTP server on first `server` call
- Race condition retry logic
- Stdin close handler for combined mode
- Associated tests