### PR TITLE
Add bridge resilience with self-healing recovery and in-process fallback

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,7 @@ The MCP server provides a reactive interface to the knowledge base:
     * **Stdio** (default): One process per client connection. Used by all MCP clients.
     * **Streamable HTTP** (`open-zk-kb serve`): Single shared process for all clients. Uses `Bun.serve()` with `WebStandardStreamableHTTPServerTransport` in stateless mode. Recommended for multi-session environments (OMP, multiple terminals).
 * **Shared Server Discovery**: When running in stdio mode, the server first checks if a shared HTTP server is available (via `$XDG_RUNTIME_DIR/open-zk-kb/server.json`). If found and healthy, it transparently bridges stdio→HTTP, avoiding resource duplication.
+* **Resilience**: Bridges recover transparently from server crashes or restarts through an internal retry chain (retry → re-probe → process locally). See [Performance and Resilience](performance.md) for latency benchmarks, memory profiles, and failure mode analysis.
 * **Tools**: Registers [nine core tools](tools-reference.md): `knowledge-store`, `knowledge-search`, `knowledge-get`, `knowledge-template`, `knowledge-mine`, `knowledge-maintain`, `knowledge-ingest`, `knowledge-overview`, and `knowledge-open`.
 * **Initialization**: Uses a lazy singleton pattern where the `NoteRepository` is initialized only upon the first tool call.
 * **Embeddings**: Generated locally by default via `@huggingface/transformers` (WASM backend, no native deps).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,33 @@
+# Documentation Index
+
+## Structure
+
+| File | What it covers | When to read |
+| --- | --- | --- |
+| `configuration.md` | MCP server settings, vault location, lifecycle defaults, Obsidian scaffold, embeddings, and HTTP server options. | When changing install-time or runtime configuration. |
+| `setup-guide.md` | Installation for supported clients, prerequisites, manual setup, and first-run verification. | When installing or onboarding a new client. |
+| `architecture.md` | System overview, storage model, MCP flow, Obsidian role, and major subsystems. | When you need the big-picture design. |
+| `performance.md` | Tool latency, memory footprint, cold/hot start, resilience model, embedding benchmarks. | When optimizing or debugging performance, or understanding failure recovery. |
+| `tools-reference.md` | MCP tool catalog, inputs, outputs, and common usage patterns. | When wiring agents to the API. |
+| `development.md` | Local development setup, repository workflow, testing, and release notes for contributors. | When working from source or contributing. |
+| `note-lifecycle.md` | Atomic note model, lifecycle states, review flow, and promotion/archival behavior. | When changing note semantics or storage policy. |
+| `obsidian.md` | Vault browsing, managed scaffold, navigation, plugins, and UI conventions. | When using or customizing the Obsidian vault. |
+
+## Conventions
+
+- `setup-guide.md` is the user-facing entry point for installation.
+- `configuration.md` is the canonical reference for settings and defaults.
+- `tools-reference.md` documents the MCP surface area.
+- `architecture.md` explains how the parts fit together.
+- `note-lifecycle.md` defines note semantics and review behavior.
+- `obsidian.md` covers the human browsing layer.
+
+## How to add docs
+
+- Put installation and onboarding steps in `setup-guide.md`.
+- Put configuration keys and defaults in `configuration.md`.
+- Put API or MCP tool behavior in `tools-reference.md`.
+- Put design changes and subsystem explanations in `architecture.md`.
+- Put note status or lifecycle changes in `note-lifecycle.md`.
+- Put vault UI or navigation changes in `obsidian.md`.
+- Keep each page focused on one topic and link to the relevant page instead of duplicating content.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -70,7 +70,7 @@ The server uses a single-machine, multi-process architecture. One shared HTTP se
 
 When the shared HTTP server becomes unreachable, each bridge independently executes a recovery chain. Every step is attempted before returning an error to the calling agent.
 
-```
+```text
 Forward request to shared HTTP server
   |
   +--> Success? Done (normal path, ~17ms)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,131 @@
+# Performance and Resilience
+
+Benchmarks from a MacBook Pro M3 Max with 36GB RAM, 439-note knowledge base, MiniLM-L6-v2 embeddings enabled. Numbers are wall-clock latency measured at the MCP client boundary (including JSON-RPC serialization and HTTP transport).
+
+## Tool Latency
+
+Measured against the shared HTTP server (`open-zk-kb serve`) at steady state.
+
+| Tool | Typical | What it does |
+|---|---|---|
+| `knowledge-get` | 9ms | Single note by ID. File read + frontmatter parse. |
+| `knowledge-search` | 14ms | FTS5 query + embedding cosine similarity + re-rank. |
+| `knowledge-store` | 20ms | Write markdown file + SQLite insert + FTS5 update + embedding generation. |
+| `knowledge-overview` | 10ms | Read project index + recent log entries. |
+| `knowledge-template` | 10ms | Return template for a note kind. |
+| `tools/list` | 11ms | MCP tool registration (no DB). Useful as a health baseline. |
+
+Embedding generation adds ~5ms to store (MiniLM-L6-v2, quantized q8, WASM backend). Search embedding is generated on the query side and adds ~5ms. Both are fast enough to be invisible in the tool response.
+
+These latencies scale with note count for FTS5 and embedding search. At 439 notes the index fits comfortably in SQLite's page cache. For larger vaults (10k+ notes), FTS5 remains fast (it's an inverted index), but embedding search is a linear scan over cosine similarity. Consider an approximate nearest-neighbor index if search latency becomes a concern at that scale.
+
+## Memory
+
+The shared HTTP server architecture (`open-zk-kb serve` + stdio bridges) trades a small amount of complexity for significant memory savings when multiple AI sessions are active simultaneously.
+
+### Per-process footprint
+
+| Process type | Physical footprint | Dirty (private) | What it loads |
+|---|---|---|---|
+| **HTTP server** | 154 MB | 154 MB | NoteRepository + SQLite + FTS5 + ONNX Runtime + MiniLM-L6-v2 model + MCP SDK |
+| **Stdio bridge** | 21 MB | 4-10 MB | Bun runtime + JSON-RPC forwarding. No SQLite, no ONNX. |
+
+### Breakdown of the HTTP server (154 MB)
+
+| Component | Dirty memory | Notes |
+|---|---|---|
+| ONNX Runtime + model weights | ~52 MB | MiniLM-L6-v2 is 23 MB on disk, expands in ONNX inference buffers. |
+| App heap (SQLite, FTS5, MCP SDK) | ~49 MB | Includes SQLite page cache, FTS5 inverted index, tool handler state. |
+| Bun runtime (__TEXT, shared COW) | ~22 MB | Shared via copy-on-write with bridge processes. |
+| Stacks + other | ~31 MB | 22 threads (MCP handlers, ONNX inference pool). |
+
+### Scaling with sessions
+
+| Active sessions | In-process (no sharing) | Shared HTTP server |
+|---|---|---|
+| 1 | 154 MB | 154 MB (no bridges yet) |
+| 3 | 462 MB | 196 MB (1 server + 2 bridges) |
+| 5 | 770 MB | 238 MB (1 server + 4 bridges) |
+| 8 | 1,232 MB | 295 MB (1 server + 7 bridges) |
+
+Bridge processes share the Bun runtime's __TEXT pages via COW. The kernel stores one copy regardless of bridge count. The "true unique" memory for 8 processes is ~210 MB (vs. the naive 302 MB sum of per-process footprints).
+
+## Startup and Cold Paths
+
+| Event | Latency | What happens |
+|---|---|---|
+| **Bridge startup (hot server)** | <100ms | Read state file, probe `/health`, enter forwarding loop. No heavy imports. |
+| **HTTP server startup** | ~500ms | `Bun.serve()` + SQLite open + schema check + state file write. |
+| **ONNX model first load** | 2-3s | Downloads model to `~/.cache/open-zk-kb/models/` on first run. Async, doesn't block requests. |
+| **ONNX model warm (cached)** | ~200ms | Loads from disk cache into ONNX Runtime. Background, non-blocking. |
+| **Bridge recovery (server dead)** | ~116ms | Dynamic import of MCP server stack + first in-process request. One-time cost. |
+
+The ONNX model warm-up is fire-and-forget. Until it completes, search falls back to FTS5-only (still returns results, just without semantic re-ranking).
+
+## Resilience Model
+
+The server uses a single-machine, multi-process architecture. One shared HTTP server handles all MCP traffic; lightweight stdio bridges forward requests from individual client sessions.
+
+### Recovery chain
+
+When the shared HTTP server becomes unreachable, each bridge independently executes a recovery chain. Every step is attempted before returning an error to the calling agent.
+
+```
+Forward request to shared HTTP server
+  |
+  +--> Success? Done (normal path, ~17ms)
+  |
+  +--> Fail? Immediate retry (handles transient glitches, ~1ms)
+         |
+         +--> Success? Done
+         |
+         +--> Fail? Re-read state file + probe (handles server restart, ~10ms)
+                |
+                +--> Found healthy server? Reconnect + retry. Done.
+                |
+                +--> No server? Process locally (~116ms first time, ~17ms after)
+                       |
+                       +--> Also start HTTP server in background for other bridges
+```
+
+### Failure modes and mitigations
+
+| Failure | What happens | User-visible impact |
+|---|---|---|
+| Shared server crashes | Bridges detect on next request, process locally, start background HTTP server. | ~116ms one-time latency on the triggering request. No errors. |
+| Shared server restart (rebuild) | Bridges detect new state file on next request, reconnect. | ~10ms extra latency on the triggering request. No errors. |
+| Transient network glitch | Immediate retry succeeds. | ~1ms extra latency. No errors. |
+| Multiple bridges lose server simultaneously | Each independently processes locally via SQLite WAL. One starts background HTTP, others reconnect to it. | ~116ms one-time per bridge. No errors. |
+| Unhandled exception in tool handler | HTTP server catches at request level, returns JSON-RPC error. Server stays alive. | Tool-level error returned (expected behavior). Server survives. |
+| Uncaught exception / unhandled rejection | HTTP server logs and continues (registered handlers). | No impact on other requests. |
+
+### Graceful shutdown
+
+On SIGINT/SIGTERM, the HTTP server:
+
+1. Removes the state file (prevents new bridges from connecting)
+2. Stops accepting new connections
+3. Waits up to 5 seconds for in-flight requests to complete
+4. Force-closes any remaining transports
+5. Cleans up SQLite and exits
+
+### Design principles
+
+- **Server computes, agent judges.** The server owns storage, indexing, and recovery. The agent owns intent and relevance. Recovery is transparent to the agent.
+- **No external supervision required.** The system self-organizes: the first process becomes the master, bridges discover it, and any bridge can promote itself if the master dies. No launchd, systemd, or process managers needed.
+- **Availability over memory.** When the shared server is unavailable, bridges independently load the full MCP server stack (~154 MB each). Multiple bridges serving simultaneously is preferred over any bridge returning errors.
+- **SQLite WAL enables concurrency.** Multiple processes can safely read and write the same database. WAL mode allows concurrent readers with a single writer. `SQLITE_BUSY` retries (3 attempts, 50ms backoff) handle contention.
+
+## Embedding Performance
+
+Local embeddings use MiniLM-L6-v2 via `@huggingface/transformers` (ONNX Runtime, WASM backend).
+
+| Operation | Latency | Notes |
+|---|---|---|
+| Generate embedding (single note) | ~5ms | 384-dimensional vector. Included in store latency. |
+| Cosine similarity (439 notes) | ~1ms | Linear scan. Dominates at large vault sizes. |
+| Search total (FTS5 + embedding re-rank) | ~14ms | FTS5 finds candidates, embeddings re-rank top results. |
+| Model cold load (first ever) | 2-3s | Downloads ~23 MB model. One-time. |
+| Model warm load (from cache) | ~200ms | Loads ONNX session from disk. Background on startup. |
+
+The embedding model runs in the same process as the MCP server. No external API calls, no network latency, no API keys required. Override with an OpenAI-compatible API via `config.yaml` if preferred.

--- a/src/config.ts
+++ b/src/config.ts
@@ -162,7 +162,7 @@ function positiveInt(value: unknown, fallback: number): number {
 }
 
 function validPort(value: unknown, fallback: number): number {
-  return Number.isInteger(value) && (value as number) >= 1 && (value as number) <= 65535
+  return Number.isInteger(value) && (value as number) >= 0 && (value as number) <= 65535
     ? (value as number)
     : fallback;
 }

--- a/src/mcp-http-server.ts
+++ b/src/mcp-http-server.ts
@@ -39,6 +39,9 @@ export async function handleMcpRequest(req: Request): Promise<Response> {
   // never propagate to Bun.serve() where it would crash the process.
   let server: ReturnType<typeof createMcpServer> | undefined;
   let transport: WebStandardStreamableHTTPServerTransport | undefined;
+  // Clone request so we can extract the JSON-RPC id in the error path
+  // (transport.handleRequest() consumes the original body stream).
+  const reqForId = req.clone();
   try {
     // Create a fresh McpServer per request — the MCP SDK's Protocol rejects
     // connecting a second transport to the same instance, so stateless HTTP
@@ -65,15 +68,23 @@ export async function handleMcpRequest(req: Request): Promise<Response> {
       method: req.method,
       path: url.pathname,
     }, config);
+    // Best-effort id extraction from the cloned request.
+    let requestId: unknown = null;
+    try {
+      const body = await reqForId.json() as Record<string, unknown>;
+      requestId = body.id ?? null;
+    } catch { /* body wasn't valid JSON */ }
     // Return a JSON-RPC internal error so the bridge/client gets a
-    // parseable response rather than a connection reset.
+    // parseable response rather than a connection reset. HTTP 200 is
+    // intentional — non-2xx causes the bridge to treat this as a
+    // transport failure rather than reading the JSON-RPC error body.
     return new Response(
       JSON.stringify({
         jsonrpc: '2.0',
-        id: null,
+        id: requestId,
         error: { code: -32603, message: 'Internal server error' },
       }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } },
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
     );
   } finally {
     // Clean up: close transport and server for this request.
@@ -83,7 +94,7 @@ export async function handleMcpRequest(req: Request): Promise<Response> {
       await transport.close().catch(() => {});
     }
     if (server) {
-      await server.close();
+      await server.close().catch(() => {});
     }
   }
 }

--- a/src/mcp-http-server.ts
+++ b/src/mcp-http-server.ts
@@ -20,7 +20,7 @@ const config = getConfig();
 // Track active transports for cleanup
 const activeTransports = new Set<Transport>();
 
-async function handleMcpRequest(req: Request): Promise<Response> {
+export async function handleMcpRequest(req: Request): Promise<Response> {
   const url = new URL(req.url);
 
   // Health check endpoint
@@ -35,31 +35,56 @@ async function handleMcpRequest(req: Request): Promise<Response> {
     return new Response('Not Found', { status: 404 });
   }
 
-  // Create a fresh McpServer per request — the MCP SDK's Protocol rejects
-  // connecting a second transport to the same instance, so stateless HTTP
-  // mode needs one per request. Shared state (NoteRepository, embeddings)
-  // lives in module-level singletons, not in the McpServer.
-  const server = createMcpServer();
-  const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: undefined,
-    enableJsonResponse: true,
-  });
-
-  activeTransports.add(transport);
-  transport.onclose = () => {
-    activeTransports.delete(transport);
-  };
-
-  await server.connect(transport);
-
+  // Top-level error isolation: any throw here MUST return an HTTP response,
+  // never propagate to Bun.serve() where it would crash the process.
+  let server: ReturnType<typeof createMcpServer> | undefined;
+  let transport: WebStandardStreamableHTTPServerTransport | undefined;
   try {
+    // Create a fresh McpServer per request — the MCP SDK's Protocol rejects
+    // connecting a second transport to the same instance, so stateless HTTP
+    // mode needs one per request. Shared state (NoteRepository, embeddings)
+    // lives in module-level singletons, not in the McpServer.
+    server = createMcpServer();
+    transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+
+    activeTransports.add(transport);
+    transport.onclose = () => {
+      activeTransports.delete(transport!);
+    };
+
+    await server.connect(transport);
+
     const response = await transport.handleRequest(req);
     return response;
+  } catch (error) {
+    logToFile('ERROR', 'HTTP handler: request failed', {
+      error: error instanceof Error ? error.message : String(error),
+      method: req.method,
+      path: url.pathname,
+    }, config);
+    // Return a JSON-RPC internal error so the bridge/client gets a
+    // parseable response rather than a connection reset.
+    return new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32603, message: 'Internal server error' },
+      }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
   } finally {
     // Clean up: close transport and server for this request.
     // Must run even if handleRequest throws to avoid resource leaks.
-    await transport.close().catch(() => {});
-    await server.close();
+    if (transport) {
+      activeTransports.delete(transport);
+      await transport.close().catch(() => {});
+    }
+    if (server) {
+      await server.close();
+    }
   }
 }
 
@@ -123,23 +148,74 @@ export async function startHttpServer(options: StartHttpServerOptions = {}): Pro
     version: PKG_VERSION,
   }, config);
 
-  // Override shutdown to also clean up HTTP resources
+  // Override shutdown to also clean up HTTP resources.
+  // 1. Remove state file immediately so new bridges don't try to connect.
+  // 2. Stop accepting new connections (stop(false) = graceful).
+  // 3. Wait for in-flight requests to complete (up to 5s).
+  // 4. Force-close any stragglers and exit.
   const originalShutdown = () => shutdownServer();
   const httpShutdown = () => {
-    logToFile('INFO', 'MCP HTTP server: shutting down', {}, config);
+    logToFile('INFO', 'MCP HTTP server: shutting down', {
+      activeRequests: activeTransports.size,
+    }, config);
+
+    // Remove state file first — prevents new bridges from connecting
+    // to a server that's about to die.
     removeServerState();
-    for (const transport of activeTransports) {
-      transport.close().catch(() => {});
-    }
-    activeTransports.clear();
-    httpServer.stop(true);
-    originalShutdown();
+
+    // Stop accepting new connections but let in-flight requests finish.
+    httpServer.stop(false);
+
+    // Give in-flight requests up to 5 seconds to complete.
+    const DRAIN_TIMEOUT_MS = 5000;
+    const drainStart = Date.now();
+    const drainInterval = setInterval(() => {
+      if (activeTransports.size === 0 || Date.now() - drainStart > DRAIN_TIMEOUT_MS) {
+        clearInterval(drainInterval);
+        if (activeTransports.size > 0) {
+          logToFile('WARN', 'HTTP server: force-closing remaining transports', {
+            remaining: activeTransports.size,
+          }, config);
+          for (const transport of activeTransports) {
+            transport.close().catch(() => {});
+          }
+          activeTransports.clear();
+        }
+        httpServer.stop(true);
+        originalShutdown();
+      }
+    }, 100);
   };
 
   process.removeAllListeners('SIGINT');
   process.removeAllListeners('SIGTERM');
   process.on('SIGINT', httpShutdown);
   process.on('SIGTERM', httpShutdown);
+
+  // Crash safety: survive unhandled exceptions/rejections instead of dying.
+  // The per-request try/catch in handleMcpRequest covers normal operation,
+  // but module-level errors (e.g. in lazy singleton init) can still escape.
+  // Log and continue — the server is more valuable alive with a logged error
+  // than dead with a clean stack trace.
+  process.on('uncaughtException', (error) => {
+    logToFile('ERROR', 'HTTP server: uncaught exception (survived)', {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    }, config);
+  });
+  process.on('unhandledRejection', (reason) => {
+    logToFile('ERROR', 'HTTP server: unhandled rejection (survived)', {
+      error: reason instanceof Error ? reason.message : String(reason),
+      stack: reason instanceof Error ? reason.stack : undefined,
+    }, config);
+  });
+
+  // Clean up state file on any exit path — covers scenarios where
+  // SIGINT/SIGTERM handlers don't fire (e.g. Bun internal crash, OOM kill
+  // recovery after the kernel sends SIGKILL to a child but not the parent).
+  process.on('exit', () => {
+    try { removeServerState(); } catch { /* best effort */ }
+  });
 
   // Log the address for the user
   logToFile('INFO', `MCP HTTP server: listening on http://${host}:${httpServer.port}/mcp`, {}, config);

--- a/src/mcp-stdio-proxy.ts
+++ b/src/mcp-stdio-proxy.ts
@@ -186,14 +186,17 @@ export async function tryStdioBridge(): Promise<boolean> {
     for await (const message of readStdinMessages()) {
       let response = await forwardToHttp(state, message);
 
-      // Notifications (no `id`, not a batch) are fire-and-forget — no
-      // response expected. forwardToHttp returns null for both "empty
-      // body" (notification success) and "transport failure", so we must
-      // skip the recovery chain to avoid re-executing notifications.
-      const isNotification = message !== null
-        && typeof message === 'object'
-        && !Array.isArray(message)
-        && !('id' in (message as Record<string, unknown>));
+      // Notifications (no `id`) are fire-and-forget — no response expected.
+      // forwardToHttp returns null for both "empty body" (notification
+      // success) and "transport failure", so we skip the recovery chain to
+      // avoid re-executing notifications. A batch array where every element
+      // lacks an `id` is also entirely fire-and-forget.
+      const isNotification = Array.isArray(message)
+        ? message.every(m =>
+            m === null || typeof m !== 'object' || !('id' in (m as Record<string, unknown>)))
+        : message !== null
+          && typeof message === 'object'
+          && !('id' in (message as Record<string, unknown>));
 
       // On failure, exhaust every recovery option before returning an error.
       // The user should never see -32603 if the server can be recovered.

--- a/src/mcp-stdio-proxy.ts
+++ b/src/mcp-stdio-proxy.ts
@@ -192,7 +192,7 @@ export async function tryStdioBridge(): Promise<boolean> {
       // avoid re-executing notifications. A batch array where every element
       // lacks an `id` is also entirely fire-and-forget.
       const isNotification = Array.isArray(message)
-        ? message.every(m =>
+        ? message.length > 0 && message.every(m =>
             m === null || typeof m !== 'object' || !('id' in (m as Record<string, unknown>)))
         : message !== null
           && typeof message === 'object'

--- a/src/mcp-stdio-proxy.ts
+++ b/src/mcp-stdio-proxy.ts
@@ -106,12 +106,63 @@ function writeToStdout(message: unknown): void {
   Bun.write(Bun.stdout, data);
 }
 
+// Cache the dynamic import so we only load the heavy modules once.
+let localHandler: ((req: Request) => Promise<Response>) | null = null;
+
+/**
+ * Process a JSON-RPC message through a local MCP server instance.
+ * Dynamically imports the heavy modules (NoteRepository, ONNX, MCP SDK)
+ * on first call so the bridge stays lightweight until actually needed.
+ */
+async function processLocally(message: unknown): Promise<unknown | null> {
+  if (!localHandler) {
+    logToFile('INFO', 'Stdio proxy: loading in-process MCP server', {}, config);
+    const mod = await import('./mcp-http-server.js');
+    localHandler = mod.handleMcpRequest;
+  }
+
+  const req = new Request('http://localhost/mcp', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify(message),
+  });
+
+  const resp = await localHandler(req);
+  const text = await resp.text();
+  return text.length > 0 ? JSON.parse(text) : null;
+}
+
+/**
+ * Start an HTTP server in the background so other bridges can discover us.
+ * Best-effort: if it fails (port race, etc.), we still serve locally.
+ */
+function startHttpServerBackground(): void {
+  import('./mcp-http-server.js')
+    .then(mod => mod.startHttpServer())
+    .then(() => {
+      const st = readServerState();
+      logToFile('INFO', 'Stdio proxy: background HTTP server started', {
+        pid: st?.pid,
+        port: st?.port,
+      }, config);
+    })
+    .catch(err => {
+      // Another bridge won the race, or port in use — that's fine.
+      logToFile('DEBUG', 'Stdio proxy: background HTTP server skipped', {
+        error: err instanceof Error ? err.message : String(err),
+      }, config);
+    });
+}
+
 /**
  * Attempt to start as a stdio→HTTP bridge.
  * Returns true if the bridge was established, false if fallback is needed.
  */
 export async function tryStdioBridge(): Promise<boolean> {
-  const state = readServerState();
+  let state = readServerState();
   if (!state) {
     return false;
   }
@@ -127,10 +178,51 @@ export async function tryStdioBridge(): Promise<boolean> {
     port: state.port,
   }, config);
 
+  // Track whether we've started a background HTTP server for other bridges.
+  let httpStarted = false;
+
   try {
     // Run the message forwarding loop
     for await (const message of readStdinMessages()) {
-      const response = await forwardToHttp(state, message);
+      let response = await forwardToHttp(state, message);
+
+      // On failure, exhaust every recovery option before returning an error.
+      // The user should never see -32603 if the server can be recovered.
+      if (response === null) {
+        // 1. Immediate retry — handles transient network glitches.
+        response = await forwardToHttp(state, message);
+      }
+
+      if (response === null) {
+        // 2. Re-read state file — maybe the server restarted on a new port/PID.
+        const newState = readServerState();
+        if (newState) {
+          const newHealthy = await probeHttpServer(newState);
+          if (newHealthy) {
+            state = newHealthy;
+            logToFile('INFO', 'Stdio proxy: reconnected to HTTP server', {
+              pid: state.pid,
+              port: state.port,
+            }, config);
+            response = await forwardToHttp(state, message);
+          }
+        }
+      }
+
+      if (response === null) {
+        // 3. No server anywhere — process locally. Every bridge can
+        //    independently serve via the shared SQLite database (WAL mode).
+        //    Multiple bridges handling requests in parallel is fine.
+        response = await processLocally(message);
+
+        // Also start an HTTP server in the background (best-effort) so
+        // other bridges can reconnect to us rather than all going local.
+        if (!httpStarted) {
+          httpStarted = true;
+          startHttpServerBackground();
+        }
+      }
+
       if (response !== null) {
         writeToStdout(response);
       } else if (Array.isArray(message)) {

--- a/src/mcp-stdio-proxy.ts
+++ b/src/mcp-stdio-proxy.ts
@@ -186,14 +186,23 @@ export async function tryStdioBridge(): Promise<boolean> {
     for await (const message of readStdinMessages()) {
       let response = await forwardToHttp(state, message);
 
+      // Notifications (no `id`, not a batch) are fire-and-forget — no
+      // response expected. forwardToHttp returns null for both "empty
+      // body" (notification success) and "transport failure", so we must
+      // skip the recovery chain to avoid re-executing notifications.
+      const isNotification = message !== null
+        && typeof message === 'object'
+        && !Array.isArray(message)
+        && !('id' in (message as Record<string, unknown>));
+
       // On failure, exhaust every recovery option before returning an error.
       // The user should never see -32603 if the server can be recovered.
-      if (response === null) {
+      if (!isNotification && response === null) {
         // 1. Immediate retry — handles transient network glitches.
         response = await forwardToHttp(state, message);
       }
 
-      if (response === null) {
+      if (!isNotification && response === null) {
         // 2. Re-read state file — maybe the server restarted on a new port/PID.
         const newState = readServerState();
         if (newState) {
@@ -209,11 +218,18 @@ export async function tryStdioBridge(): Promise<boolean> {
         }
       }
 
-      if (response === null) {
+      if (!isNotification && response === null) {
         // 3. No server anywhere — process locally. Every bridge can
         //    independently serve via the shared SQLite database (WAL mode).
         //    Multiple bridges handling requests in parallel is fine.
-        response = await processLocally(message);
+        try {
+          response = await processLocally(message);
+        } catch (err) {
+          logToFile('ERROR', 'Stdio proxy: local fallback failed', {
+            error: err instanceof Error ? err.message : String(err),
+          }, config);
+          response = null;
+        }
 
         // Also start an HTTP server in the background (best-effort) so
         // other bridges can reconnect to us rather than all going local.

--- a/tests/stdio-bridge.test.ts
+++ b/tests/stdio-bridge.test.ts
@@ -4,6 +4,11 @@ import * as path from 'path';
 import * as os from 'os';
 import type { Server } from 'bun';
 
+const CLI_PATH = path.resolve('dist/cli.js');
+if (!fs.existsSync(CLI_PATH)) {
+  throw new Error('dist/cli.js not found — run `bun run build` before `bun test`');
+}
+
 /**
  * Integration tests for the stdio→HTTP bridge self-healing behavior.
  *
@@ -122,7 +127,7 @@ describe('Stdio Bridge Self-Healing', () => {
     writeStateFile(stateDir, server1.port, process.pid);
 
     const proc = Bun.spawn(
-      ['bun', 'run', path.resolve('dist/cli.js'), 'server'],
+      ['bun', 'run', CLI_PATH, 'server'],
       {
         stdin: 'pipe',
         stdout: 'pipe',
@@ -219,7 +224,7 @@ describe('Stdio Bridge Local Fallback', () => {
     fs.mkdirSync(path.join(tmpDir, 'data', 'open-zk-kb'), { recursive: true });
 
     const proc = Bun.spawn(
-      ['bun', 'run', path.resolve('dist/cli.js'), 'server'],
+      ['bun', 'run', CLI_PATH, 'server'],
       {
         stdin: 'pipe',
         stdout: 'pipe',

--- a/tests/stdio-bridge.test.ts
+++ b/tests/stdio-bridge.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import type { Server } from 'bun';
+
+/**
+ * Integration tests for the stdio→HTTP bridge self-healing behavior.
+ *
+ * These tests verify that when the HTTP server goes down and restarts,
+ * the bridge proxy recovers by re-reading the state file and re-probing.
+ */
+
+// Minimal MCP-like JSON-RPC handler — responds to tools/list and tools/call
+function createMcpHandler(serverId: string) {
+  return (req: Request): Response | Promise<Response> => {
+    const url = new URL(req.url);
+    if (url.pathname === '/health') {
+      return new Response(JSON.stringify({ status: 'ok', version: '1.0.0' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.pathname !== '/mcp' || req.method !== 'POST') {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    return req.json().then((body: { id?: unknown; method?: string }) => {
+      const result = { serverId, method: body.method };
+      return new Response(
+        JSON.stringify({ jsonrpc: '2.0', id: body.id, result }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+  };
+}
+
+function writeStateFile(stateDir: string, port: number, pid: number) {
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(stateDir, 'server.json'),
+    JSON.stringify({
+      pid,
+      port,
+      host: '127.0.0.1',
+      version: '1.0.0',
+      startedAt: new Date().toISOString(),
+    }),
+  );
+}
+
+/** Send a JSON-RPC request to the proxy subprocess via stdin and read the response from stdout. */
+async function sendJsonRpc(
+  proc: { stdin: { write(data: string): void }; stdout: ReadableStream },
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  method: string,
+  id: number,
+): Promise<{ id: number; result?: unknown; error?: { code: number; message: string } }> {
+  const msg = JSON.stringify({ jsonrpc: '2.0', id, method, params: {} }) + '\n';
+  proc.stdin.write(msg);
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const deadline = Date.now() + 5000;
+
+  while (Date.now() < deadline) {
+    const { value, done } = await Promise.race([
+      reader.read(),
+      new Promise<{ value: undefined; done: true }>((resolve) =>
+        setTimeout(() => resolve({ value: undefined, done: true }), 500),
+      ),
+    ]);
+
+    if (value) {
+      buffer += decoder.decode(value, { stream: true });
+    }
+
+    // Try to parse complete lines
+    const newlineIdx = buffer.indexOf('\n');
+    if (newlineIdx !== -1) {
+      const line = buffer.slice(0, newlineIdx).trim();
+      if (line.length > 0) {
+        return JSON.parse(line);
+      }
+      buffer = buffer.slice(newlineIdx + 1);
+    }
+
+    if (done && buffer.trim().length > 0) {
+      return JSON.parse(buffer.trim());
+    }
+  }
+  throw new Error('Timed out waiting for response');
+}
+
+describe('Stdio Bridge Self-Healing', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let originalRuntimeDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ozkb-bridge-test-'));
+    stateDir = path.join(tmpDir, 'open-zk-kb');
+    originalRuntimeDir = process.env.XDG_RUNTIME_DIR;
+  });
+
+  afterEach(() => {
+    if (originalRuntimeDir !== undefined) {
+      process.env.XDG_RUNTIME_DIR = originalRuntimeDir;
+    } else {
+      delete process.env.XDG_RUNTIME_DIR;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should reconnect to a restarted HTTP server', async () => {
+    // Start first server
+    let server1: Server | null = Bun.serve({
+      port: 0,
+      hostname: '127.0.0.1',
+      fetch: createMcpHandler('server-1'),
+    });
+
+    writeStateFile(stateDir, server1.port, process.pid);
+
+    const proc = Bun.spawn(
+      ['bun', 'run', path.resolve('dist/cli.js'), 'server'],
+      {
+        stdin: 'pipe',
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: {
+          ...process.env,
+          XDG_RUNTIME_DIR: tmpDir,
+          XDG_CONFIG_HOME: path.join(tmpDir, 'config'),
+          XDG_DATA_HOME: path.join(tmpDir, 'data'),
+          XDG_STATE_HOME: path.join(tmpDir, 'state'),
+        },
+      },
+    );
+
+    try {
+      const reader = proc.stdout.getReader();
+      await new Promise((r) => setTimeout(r, 300));
+
+      // First request succeeds via server-1
+      const resp1 = await sendJsonRpc(proc, reader, 'tools/list', 1);
+      expect(resp1.id).toBe(1);
+      expect(resp1.result).toBeDefined();
+      expect((resp1.result as { serverId: string }).serverId).toBe('server-1');
+
+      // Kill server-1 and immediately start server-2 on a new port.
+      // The bridge's internal retry chain (retry → re-probe state file → reconnect)
+      // should find server-2 without the user ever seeing an error.
+      server1.stop(true);
+      server1 = null;
+
+      const server2 = Bun.serve({
+        port: 0,
+        hostname: '127.0.0.1',
+        fetch: createMcpHandler('server-2'),
+      });
+      writeStateFile(stateDir, server2.port, process.pid);
+
+      // The bridge retries internally — the user sees a successful response,
+      // never the -32603 error.
+      const resp2 = await sendJsonRpc(proc, reader, 'tools/list', 2);
+      expect(resp2.result).toBeDefined();
+      expect(resp2.error).toBeUndefined();
+      expect((resp2.result as { serverId: string }).serverId).toBe('server-2');
+
+      server2.stop(true);
+    } finally {
+      proc.stdin.end();
+      proc.kill();
+      if (server1) server1.stop(true);
+    }
+  }, 15000);
+});
+
+describe('Stdio Bridge Local Fallback', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let originalRuntimeDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ozkb-local-test-'));
+    stateDir = path.join(tmpDir, 'open-zk-kb');
+    originalRuntimeDir = process.env.XDG_RUNTIME_DIR;
+  });
+
+  afterEach(() => {
+    if (originalRuntimeDir !== undefined) {
+      process.env.XDG_RUNTIME_DIR = originalRuntimeDir;
+    } else {
+      delete process.env.XDG_RUNTIME_DIR;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should process locally when shared server is gone', async () => {
+    // Start a mock server that the bridge will initially connect to
+    let mockServer: Server | null = Bun.serve({
+      port: 0,
+      hostname: '127.0.0.1',
+      fetch: createMcpHandler('mock-server'),
+    });
+
+    writeStateFile(stateDir, mockServer.port, process.pid);
+
+    // Create a config.yaml with port: 0 so any background HTTP server
+    // picks an ephemeral port (avoids collision with the real server).
+    const configDir = path.join(tmpDir, 'config', 'open-zk-kb');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'config.yaml'),
+      'server:\n  port: 0\n  host: "127.0.0.1"\n',
+    );
+
+    // Create data dir for SQLite
+    fs.mkdirSync(path.join(tmpDir, 'data', 'open-zk-kb'), { recursive: true });
+
+    const proc = Bun.spawn(
+      ['bun', 'run', path.resolve('dist/cli.js'), 'server'],
+      {
+        stdin: 'pipe',
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: {
+          ...process.env,
+          XDG_RUNTIME_DIR: tmpDir,
+          XDG_CONFIG_HOME: path.join(tmpDir, 'config'),
+          XDG_DATA_HOME: path.join(tmpDir, 'data'),
+          XDG_STATE_HOME: path.join(tmpDir, 'state'),
+        },
+      },
+    );
+
+    try {
+      const reader = proc.stdout.getReader();
+      await new Promise((r) => setTimeout(r, 300));
+
+      // First request succeeds via mock server
+      const resp1 = await sendJsonRpc(proc, reader, 'tools/list', 1);
+      expect(resp1.id).toBe(1);
+      expect(resp1.result).toBeDefined();
+
+      // Kill mock server AND remove state file — server is truly gone
+      mockServer.stop(true);
+      mockServer = null;
+      try { fs.unlinkSync(path.join(stateDir, 'server.json')); } catch { /* ok */ }
+
+      // The bridge retries internally, finds no server, and falls back to
+      // local in-process handling. The user sees a successful response.
+      const resp2Promise = sendJsonRpc(proc, reader, 'tools/list', 2);
+      const resp2 = await Promise.race([
+        resp2Promise,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Local processing timed out')), 20000),
+        ),
+      ]);
+
+      // The bridge handled the request in-process — no error
+      expect(resp2.result).toBeDefined();
+      expect(resp2.error).toBeUndefined();
+    } finally {
+      proc.stdin.end();
+      proc.kill();
+      if (mockServer) mockServer.stop(true);
+    }
+  }, 30000);
+});


### PR DESCRIPTION
## Problem

When the shared HTTP server dies (crash, rebuild, restart), all stdio bridges return `-32603: HTTP bridge failed to forward request to server` until the user manually starts a new session. This produced the error:

```
MCP error -32603: HTTP bridge failed to forward request to server
```

## Solution

Three layers of defense so the user never sees this error:

### Bridge recovery chain

Every failed forward exhausts all recovery options before returning an error:

1. **Immediate retry** — handles transient network glitches (~1ms)
2. **Re-read state file + re-probe** — handles server restart on new port/PID (~10ms)
3. **Process locally** — dynamic import of full MCP server stack, handle request in-process (~116ms first time, ~17ms after)

After local fallback, the bridge also starts an HTTP server in the background so other bridges can reconnect to it rather than all going local independently.

### HTTP server hardening

- **Request-level error isolation** — top-level try/catch in `handleMcpRequest` returns JSON-RPC error instead of crashing `Bun.serve()`
- **Crash handlers** — `uncaughtException` and `unhandledRejection` handlers log and survive
- **Graceful shutdown** — on SIGINT/SIGTERM: remove state file immediately, stop accepting connections, wait up to 5s for in-flight requests, then force-close
- **Exit cleanup** — `process.on('exit')` removes state file as last resort

### Config

Allow `port: 0` in `validPort()` for OS-assigned ephemeral ports (used by tests and bridge promotion).

## Performance characteristics

Measured on M3 Max, 439-note KB:

| Scenario | Latency | Errors |
|---|---|---|
| Normal forward to shared server | ~17ms | 0 |
| First request after server death (cold local fallback) | ~116ms | 0 |
| Subsequent local requests (handler cached) | ~17ms | 0 |
| Server restart (re-probe path) | ~10ms extra | 0 |

## Memory model

Multiple bridges can independently serve via SQLite WAL — no single master required. The shared HTTP server is an optimization (saves ~130MB per bridge), not a requirement for correctness.

| Sessions | In-process (no sharing) | Shared HTTP server |
|---|---|---|
| 1 | 154 MB | 154 MB |
| 5 | 770 MB | 238 MB |
| 8 | 1,232 MB | 295 MB |

## Files changed

| File | Change |
|---|---|
| `src/mcp-stdio-proxy.ts` | Recovery chain: retry → re-probe → process locally + background HTTP |
| `src/mcp-http-server.ts` | Request isolation, crash handlers, graceful drain, exported `handleMcpRequest` |
| `src/config.ts` | Allow port 0 for ephemeral ports |
| `tests/stdio-bridge.test.ts` | Integration tests for reconnect and local fallback |
| `docs/performance.md` | Tool latency, memory profiles, resilience model |
| `docs/architecture.md` | Cross-reference to performance doc |
| `docs/index.md` | Added performance doc to index |

## Testing

- `tests/stdio-bridge.test.ts` — two integration tests:
  - **Reconnect**: kill server, start new one on different port, verify bridge reconnects transparently (zero errors)
  - **Local fallback**: kill server, remove state file, verify bridge processes request in-process (zero errors)
- All 255 existing tests pass