### PR TITLE
Fix embed defaults, remaining count, unlinked output

### DIFF
--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -1574,7 +1574,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         return 'Embedding not configured. Add provider + embeddings section to config.yaml to enable vector search.';
       }
 
-      const limit = args.limit || 999999;
+      const limit = args.limit ?? 999999;
       const pending = repo.getNotesWithoutEmbeddings(limit);
       if (pending.length === 0) {
         return 'All notes already have embeddings. Nothing to backfill.';

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -1574,7 +1574,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         return 'Embedding not configured. Add provider + embeddings section to config.yaml to enable vector search.';
       }
 
-      const limit = args.limit || 50;
+      const limit = args.limit || 999999;
       const pending = repo.getNotesWithoutEmbeddings(limit);
       if (pending.length === 0) {
         return 'All notes already have embeddings. Nothing to backfill.';
@@ -1586,7 +1586,9 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
 
       try {
         const embResult = await backfillEmbeddings(repo, embeddingConfig, limit);
-        return `Embedded ${embResult.stored}/${embResult.requested} notes using ${embeddingConfig.model}.`;
+        const remaining = repo.getEmbeddingStats().withoutEmbedding;
+        const suffix = remaining > 0 ? ` (${remaining} still pending)` : '';
+        return `Embedded ${embResult.stored}/${embResult.requested} notes using ${embeddingConfig.model}.${suffix}`;
       } catch (err) {
         return `Embedding failed: ${err instanceof Error ? err.message : String(err)}`;
       }
@@ -1743,13 +1745,69 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
         return 'No unlinked notes found. All non-archived notes have at least one incoming or outgoing wikilink.';
       }
 
-      let output = `## Unlinked Notes (${unlinked.length})\n\n`;
-      output += 'Notes with no incoming or outgoing wikilinks:\n\n';
+      // Group by project, then by kind
+      const byProject = new Map<string, NoteMetadata[]>();
       for (const note of unlinked) {
-        const wordCount = countWords(note.content || '');
-        output += `- "${note.title}" [${note.id}] | ${note.kind} | ${note.status} | ${wordCount} words\n`;
+        const project = extractProjectFromTags(note.tags) || '(no project)';
+        let group = byProject.get(project);
+        if (!group) {
+          group = [];
+          byProject.set(project, group);
+        }
+        group.push(note);
       }
-      output += '\n## Next Steps\n';
+
+      const projectCount = [...byProject.keys()].filter(k => k !== '(no project)').length;
+      const unscopedCount = byProject.get('(no project)')?.length ?? 0;
+      let output = `## Unlinked Notes (${unlinked.length})\n\n`;
+      const summaryParts: string[] = [];
+      if (projectCount > 0) summaryParts.push(`${unlinked.length - unscopedCount} in ${projectCount} project${projectCount > 1 ? 's' : ''}`);
+      if (unscopedCount > 0) summaryParts.push(`${unscopedCount} unscoped`);
+      output += summaryParts.join(', ') + '\n\n';
+
+      const displayCap = 20;
+      let displayed = 0;
+
+      // Sort projects alphabetically, but put (no project) last
+      const sortedProjects = [...byProject.keys()].sort((a, b) => {
+        if (a === '(no project)') return 1;
+        if (b === '(no project)') return -1;
+        return a.localeCompare(b);
+      });
+
+      for (const project of sortedProjects) {
+        if (displayed >= displayCap) break;
+        const notes = byProject.get(project)!;
+        output += `### ${project} (${notes.length})\n`;
+
+        // Group by kind within project
+        const byKind = new Map<string, NoteMetadata[]>();
+        for (const note of notes) {
+          let group = byKind.get(note.kind);
+          if (!group) {
+            group = [];
+            byKind.set(note.kind, group);
+          }
+          group.push(note);
+        }
+
+        for (const [kind, kindNotes] of byKind) {
+          if (displayed >= displayCap) break;
+          output += `**${kind}**:\n`;
+          for (const note of kindNotes) {
+            if (displayed >= displayCap) break;
+            output += `- "${note.title}" [${note.id}] | ${note.status}\n`;
+            displayed++;
+          }
+        }
+        output += '\n';
+      }
+
+      if (displayed < unlinked.length) {
+        output += `(showing ${displayed} of ${unlinked.length} — use \`knowledge-search\` to find specific notes)\n\n`;
+      }
+
+      output += '## Next Steps\n';
       output += '[A] Add wikilinks to connect unlinked notes to related notes\n';
       output += '[B] Archive notes that are no longer relevant\n';
       return output;

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -641,6 +641,113 @@ describe('MCP Tool: knowledge-maintain', () => {
     }
   });
 
+  it('should default to unlimited embed limit when no limit specified', async () => {
+    ctx.engine.clearAll();
+    // Create 60 notes — more than the old default of 50
+    for (let i = 0; i < 60; i++) {
+      ctx.engine.store(`Content ${i}`, {
+        title: `Note ${i}`,
+        kind: 'reference',
+        summary: `Summary ${i}`,
+      });
+    }
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const body = JSON.parse(String(init?.body || '{}')) as { input?: string[] | string; model?: string };
+      const inputs = Array.isArray(body.input) ? body.input : body.input ? [body.input] : [];
+      return new Response(JSON.stringify({
+        model: body.model || 'test-model',
+        data: inputs.map((_text, index) => ({ index, embedding: [index, 0, 0] })),
+      }), { status: 200 });
+    };
+
+    try {
+      const output = await handleMaintain(
+        { action: 'embed' },  // no limit — should process all 60
+        ctx.engine,
+        ctx.config,
+        { provider: 'api', baseUrl: 'https://example.invalid/v1', apiKey: 'test-key', model: 'test-model', dimensions: 3 },
+      );
+
+      expect(output).toContain('Embedded 60/60');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should include remaining count in embed response when partial', async () => {
+    ctx.engine.clearAll();
+    for (let i = 0; i < 10; i++) {
+      ctx.engine.store(`Content ${i}`, {
+        title: `Note ${i}`,
+        kind: 'reference',
+        summary: `Summary ${i}`,
+      });
+    }
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const body = JSON.parse(String(init?.body || '{}')) as { input?: string[] | string; model?: string };
+      const inputs = Array.isArray(body.input) ? body.input : body.input ? [body.input] : [];
+      return new Response(JSON.stringify({
+        model: body.model || 'test-model',
+        // Only embed the first 3 — simulate partial by failing the rest
+        data: inputs.map((_text, index) => ({ index, embedding: [index, 0, 0] })),
+      }), { status: 200 });
+    };
+
+    try {
+      // Embed only 5 of 10 via explicit limit
+      const output = await handleMaintain(
+        { action: 'embed', limit: 5 },
+        ctx.engine,
+        ctx.config,
+        { provider: 'api', baseUrl: 'https://example.invalid/v1', apiKey: 'test-key', model: 'test-model', dimensions: 3 },
+      );
+
+      expect(output).toContain('Embedded 5/5');
+      expect(output).toContain('5 still pending');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should not show remaining count when all notes are embedded', async () => {
+    ctx.engine.clearAll();
+    for (let i = 0; i < 3; i++) {
+      ctx.engine.store(`Content ${i}`, {
+        title: `Note ${i}`,
+        kind: 'reference',
+        summary: `Summary ${i}`,
+      });
+    }
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const body = JSON.parse(String(init?.body || '{}')) as { input?: string[] | string; model?: string };
+      const inputs = Array.isArray(body.input) ? body.input : body.input ? [body.input] : [];
+      return new Response(JSON.stringify({
+        model: body.model || 'test-model',
+        data: inputs.map((_text, index) => ({ index, embedding: [index, 0, 0] })),
+      }), { status: 200 });
+    };
+
+    try {
+      const output = await handleMaintain(
+        { action: 'embed' },
+        ctx.engine,
+        ctx.config,
+        { provider: 'api', baseUrl: 'https://example.invalid/v1', apiKey: 'test-key', model: 'test-model', dimensions: 3 },
+      );
+
+      expect(output).toContain('Embedded 3/3');
+      expect(output).not.toContain('still pending');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('should require noteId for promote/archive/delete', async () => {
     expect(await handleMaintain({ action: 'promote' }, ctx.engine, ctx.config)).toContain('noteId is required');
     expect(await handleMaintain({ action: 'archive' }, ctx.engine, ctx.config)).toContain('noteId is required');
@@ -2089,6 +2196,33 @@ describe('MCP Tool: knowledge-maintain unlinked', () => {
 
     const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
     expect(output).not.toContain('Linker To Archived');
+  });
+
+  it('should group unlinked notes by project and kind', async () => {
+    ctx.engine.store('Alpha content', { title: 'Alpha', kind: 'reference', tags: ['project:proj-a'] });
+    ctx.engine.store('Beta content', { title: 'Beta', kind: 'decision', tags: ['project:proj-a'] });
+    ctx.engine.store('Gamma content', { title: 'Gamma', kind: 'observation', tags: ['project:proj-b'] });
+    ctx.engine.store('Delta content', { title: 'Delta', kind: 'reference' }); // no project
+
+    const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
+    expect(output).toContain('Unlinked Notes (4)');
+    expect(output).toContain('3 in 2 projects');
+    expect(output).toContain('1 unscoped');
+    expect(output).toContain('### proj-a (2)');
+    expect(output).toContain('### proj-b (1)');
+    expect(output).toContain('### (no project) (1)');
+    expect(output).toContain('**reference**:');
+    expect(output).toContain('**decision**:');
+  });
+
+  it('should cap unlinked display at 20 with overflow message', async () => {
+    for (let i = 0; i < 25; i++) {
+      ctx.engine.store(`Content ${i}`, { title: `Note ${i}`, kind: 'reference' });
+    }
+
+    const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
+    expect(output).toContain('Unlinked Notes (25)');
+    expect(output).toContain('showing 20 of 25');
   });
 });
 


### PR DESCRIPTION
Closes #159

## Changes

**A. Embed default limit → unlimited**
Changed from `50` to `999999`, matching the behavior `full` composite already uses. Standalone `embed` calls now process all pending notes by default. Internal batching (`EMBEDDING_BACKFILL_BATCH_SIZE = 50`) is unchanged — only the outer fetch cap was artificially low.

**B. Embed remaining count in response**
After backfill, calls `repo.getEmbeddingStats().withoutEmbedding` (cheap COUNT query, no content loaded) and appends `(N still pending)` when non-zero. Prevents the "50/50 looks done" trap where agents think embedding is complete.

**E. Unlinked output redesign**
- Notes grouped by project (alphabetical, unscoped last), then by kind within each project
- Summary line: `180 in 3 projects, 117 unscoped`
- Capped at 20 displayed items with overflow message pointing to `knowledge-search`
- Dropped per-note word count (noise for this view)

## Tests

5 new tests:
- Unlimited default processes all notes (>50)
- Remaining count shown when partial embed
- No remaining count when all embedded
- Project/kind grouping with summary
- Display cap overflow at 20