### PR TITLE
Default Obsidian vault to dark mode with sidebar open

### DIFF
--- a/src/obsidian-scaffold.ts
+++ b/src/obsidian-scaffold.ts
@@ -614,7 +614,7 @@ function defaultAppearanceConfig(config: ObsidianConfig): Record<string, unknown
   if (config.readOnly) enabledCssSnippets.push('readonly-kb');
 
   return {
-    theme: 'system',
+    theme: 'obsidian',
     cssTheme: THEME_REGISTRY.name,
     enabledCssSnippets,
   };
@@ -1268,7 +1268,7 @@ function scaffoldWorkspaceDefaults(vaultPath: string): void {
   if (!existing) {
     writeJsonFile(filePath, {
       main: { id: crypto.randomUUID().replace(/-/g, '').slice(0, 16), type: 'split', children: [], direction: 'vertical' },
-      left: { id: crypto.randomUUID().replace(/-/g, '').slice(0, 16), type: 'split', children: [], direction: 'horizontal', width: 200, collapsed: true },
+      left: { id: crypto.randomUUID().replace(/-/g, '').slice(0, 16), type: 'split', children: [], direction: 'horizontal', width: 200, collapsed: false },
       right: { id: crypto.randomUUID().replace(/-/g, '').slice(0, 16), type: 'split', children: [], direction: 'horizontal', width: 300, collapsed: true },
     });
     return;


### PR DESCRIPTION
Set vault-specific Obsidian defaults for a better out-of-box experience:

- **Dark mode**: theme set to `obsidian` instead of `system`
- **Sidebar open**: left sidebar `collapsed: false` so the file tree is visible on first open

These are vault-specific settings in `.obsidian/` — they don't affect the user's other Obsidian vaults. Applies to new vaults; existing vaults with `theme` already set are not overwritten (`mergeAddOnly` behavior).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

