### PR TITLE
Replace multi-byte emoji with single-width Unicode symbols

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -2140,7 +2140,7 @@ export async function runSetupCli(rawArgs: string[] = process.argv.slice(2)): Pr
         parts.push(`  ${color.dim(agentDocsPath)}\n  ${color.dim(`→ ${agentDocsSymlinkTarget}`)}`);
       }
       for (const { stalePath, target } of staleSymlinks) {
-        parts.push(`  ${color.dim(stalePath)}\n  ${color.dim(`→ ${target}`)}\n\n  ⚠️  has stale KB block`);
+        parts.push(`  ${color.dim(stalePath)}\n  ${color.dim(`→ ${target}`)}\n\n  ⚠  has stale KB block`);
       }
       const actionDesc = staleSymlinks.length > 0 && !agentDocsSymlinkTarget
         ? 'file to remove the stale block'

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -484,7 +484,7 @@ export async function handleStats(args: StatsArgs, repo: NoteRepository, config:
         if (!inst.instructionVersion) {
           statusIcon = '?';
         } else if (latest && isNewerVersion(inst.instructionVersion, latest)) {
-          statusIcon = '⚠️';
+          statusIcon = '⚠';
         } else {
           statusIcon = '✓';
         }
@@ -577,7 +577,7 @@ export async function handleIngest(args: IngestArgs, repo?: NoteRepository): Pro
     const existing = repo.findByUrl(sourceUrl);
     if (existing.length > 0) {
       output += '\n## Existing KB Coverage\n';
-      output += `⚠️ ${existing.length} note(s) already reference this URL:\n`;
+      output += `⚠ ${existing.length} note(s) already reference this URL:\n`;
       for (const note of existing) {
         output += `- ${note.title} [${note.id}]\n`;
       }
@@ -1601,7 +1601,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
           for (let i = 0; i < notes.length; i++) {
             const note = notes[i];
             const isPermanent = note.status === 'permanent';
-            const marker = isPermanent ? '🔒 (permanent - protected)' : (i === 0 ? '(keep)' : '(duplicate)');
+            const marker = isPermanent ? '⦸ (permanent - protected)' : (i === 0 ? '(keep)' : '(duplicate)');
             output += `- ${note.id} | ${note.status} | ${note.access_count || 0} accesses | ${marker}\n`;
           }
 
@@ -1633,7 +1633,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
           for (let i = 0; i < notes.length; i++) {
             const note = notes[i];
             const isPermanent = note.status === 'permanent';
-            const marker = isPermanent ? '🔒 (permanent - protected)' : (i === 0 ? '(keep)' : '(near-duplicate)');
+            const marker = isPermanent ? '⦸ (permanent - protected)' : (i === 0 ? '(keep)' : '(near-duplicate)');
             output += `- ${note.id} | "${note.title}" | ${note.status} | ${marker}\n`;
           }
 
@@ -1655,7 +1655,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       output += '## Next Steps:\n';
       output += '[A] Archive specific duplicate (requires --noteId)\n';
       output += '[B] View specific note details (use knowledge-search)\n';
-      output += '\n⚠️ Permanent notes (🔒) are never auto-archived. Promote the best version before archiving others.\n';
+      output += '\n⚠ Permanent notes (⦸) are never auto-archived. Promote the best version before archiving others.\n';
 
       return output;
     }
@@ -2122,7 +2122,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
           sections.push(result);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          sections.push(`⚠️ Failed: ${msg}`);
+          sections.push(`⚠ Failed: ${msg}`);
           logToFile('WARN', `Full maintenance step "${step.action}" failed`, { error: msg });
         }
         stepNum++;
@@ -2185,7 +2185,7 @@ function formatProjectOverview(project: string, logLimit: number, repo: NoteRepo
   if (recentNotes.length > 0) {
     output += '### Recent Notes\n';
     for (const note of recentNotes) {
-      const status = note.status === 'permanent' ? '🔒' : note.status === 'archived' ? '📦' : '📝';
+      const status = note.status === 'permanent' ? '⦸' : note.status === 'archived' ? '▪' : '▫';
       output += `- ${status} **${note.title}** (${note.kind})\n`;
     }
     if (projectNotes.length > recentNotes.length) {
@@ -2266,7 +2266,7 @@ function formatGlobalOverview(logLimit: number, repo: NoteRepository, config?: A
   if (recentNotes.length > 0) {
     output += '### Recent Notes\n';
     for (const note of recentNotes) {
-      const status = note.status === 'permanent' ? '🔒' : note.status === 'archived' ? '📦' : '📝';
+      const status = note.status === 'permanent' ? '⦸' : note.status === 'archived' ? '▪' : '▫';
       const project = extractProjectFromTags(note.tags);
       const projectSuffix = project ? ` [${project}]` : '';
       output += `- ${status} **${note.title}** (${note.kind})${projectSuffix}\n`;

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -1164,7 +1164,7 @@ describe('MCP Tool: knowledge-maintain', () => {
     const result = await handleMaintain({ action: 'dedupe' }, ctx.engine, ctx.config);
 
     expect(result).toContain('permanent - protected');
-    expect(result).toContain('⚠️ Permanent notes (🔒) are never auto-archived');
+    expect(result).toContain('⚠ Permanent notes (⦸) are never auto-archived');
     expect(result).toContain(`Archive ${duplicate.id}`);
     expect(result).not.toContain(`Archive ${permanent.id}`);
   });


### PR DESCRIPTION
Multi-byte emoji (⚠️, 🔒, 📦, 📝) cause TUI width measurement issues since they render as 2 columns but may be counted differently by `visibleWidth()`. This leads to lines exceeding terminal width and crashing Pi on window resize.

### Changes
- `⚠️` → `⚠` (warning sign, no variation selector)
- `🔒` → `⦸` (circled reverse solidus)
- `📦` → `▪` (black small square)
- `📝` → `▫` (white small square)

### Files
- `src/setup.ts` — stale KB block warning
- `src/tool-handlers.ts` — health status, ingest warnings, dedupe markers, context status icons
- `tests/mcp-tools.test.ts` — updated assertion to match new symbols

3 files, 10 lines changed. All tests pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

