### PR TITLE
Fix OpenRouter release routing

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -50,10 +50,11 @@ jobs:
           bun install --frozen-lockfile
           bun install --global @earendil-works/pi-coding-agent@0.80.10
 
-      - name: Install FFmpeg, ttyd, and VHS
+      - name: Install FFmpeg, ttyd, VHS, and Pi helpers
         run: |
           sudo apt-get update
-          sudo apt-get install -y ffmpeg ttyd
+          sudo apt-get install -y fd-find ffmpeg ripgrep ttyd
+          sudo ln -sf /usr/bin/fdfind /usr/local/bin/fd
           curl -fsSL https://github.com/charmbracelet/vhs/releases/download/v0.10.0/vhs_0.10.0_amd64.deb -o vhs.deb
           echo "$VHS_DEB_SHA256  vhs.deb" | sha256sum --check --strict
           sudo apt-get install -y ./vhs.deb
@@ -115,10 +116,11 @@ jobs:
           bun install --frozen-lockfile
           bun install --global @earendil-works/pi-coding-agent@0.80.10
 
-      - name: Install FFmpeg, ttyd, and VHS
+      - name: Install FFmpeg, ttyd, VHS, and Pi helpers
         run: |
           sudo apt-get update
-          sudo apt-get install -y ffmpeg ttyd
+          sudo apt-get install -y fd-find ffmpeg ripgrep ttyd
+          sudo ln -sf /usr/bin/fdfind /usr/local/bin/fd
           curl -fsSL https://github.com/charmbracelet/vhs/releases/download/v0.10.0/vhs_0.10.0_amd64.deb -o vhs.deb
           echo "$VHS_DEB_SHA256  vhs.deb" | sha256sum --check --strict
           sudo apt-get install -y ./vhs.deb

--- a/scripts/pi-demo/openrouter-provider.ts
+++ b/scripts/pi-demo/openrouter-provider.ts
@@ -40,6 +40,10 @@ export default function openRouterReleaseProvider(pi: ExtensionAPI): void {
       id: MODEL,
       name: 'OpenAI gpt-oss-120b',
       api: 'openai-completions',
+      compat: {
+        maxTokensField: 'max_tokens',
+        supportsUsageInStreaming: false,
+      },
       reasoning: false,
       input: ['text'],
       cost: { input: 0.037, output: 0.17, cacheRead: 0.037, cacheWrite: 0.037 },

--- a/scripts/pi-demo/preflight-openrouter.ts
+++ b/scripts/pi-demo/preflight-openrouter.ts
@@ -29,7 +29,7 @@ interface Endpoint {
   supported_parameters?: string[];
 }
 const payload = await routes.json() as { data?: { endpoints?: Endpoint[] } };
-const requiredParameters = ['seed', 'temperature', 'tools'];
+const requiredParameters = ['max_tokens', 'seed', 'temperature', 'tools'];
 const compatibleRoutes = (payload.data?.endpoints ?? []).filter((endpoint) => (
   endpoint.status === 0
   && requiredParameters.every((parameter) => endpoint.supported_parameters?.includes(parameter))


### PR DESCRIPTION
## Summary

- make Pi emit OpenRouter-advertised `max_tokens` and omit streaming usage options under strict parameter routing
- require `max_tokens` in the exact-model route preflight
- preinstall `rg` and `fd` in capture jobs so Pi startup downloads do not pollute release media

## Failure addressed

Release run 29708291586 passed key/model preflight but OpenRouter returned HTTP 404 because no endpoint advertised support for Pi's default completion payload under `require_parameters: true`.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run lint` (22 existing warnings, 0 errors)
- `bun run demo:pi:audit`
- `actionlint .github/workflows/demo.yml`
- both VHS tapes validate
- OpenRouter currently advertises 11 active routes supporting `max_tokens`, seed, temperature, and tools

No secret values are present in this change or its validation output.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

