### PR TITLE
Validate Pi new-session reason

### DIFF
--- a/scripts/pi-demo/openrouter-provider.ts
+++ b/scripts/pi-demo/openrouter-provider.ts
@@ -79,9 +79,9 @@ export default function openRouterReleaseProvider(pi: ExtensionAPI): void {
     };
   });
 
-  pi.on('session_start', () => {
+  pi.on('session_start', (event) => {
     sessionOrdinal += 1;
-    trace({ event: 'session_start', ordinal: sessionOrdinal });
+    trace({ event: 'session_start', ordinal: sessionOrdinal, reason: event.reason });
   });
 
   pi.on('input', (event) => {

--- a/scripts/pi-demo/validate.ts
+++ b/scripts/pi-demo/validate.ts
@@ -14,6 +14,7 @@ interface TraceEvent {
   isError?: boolean;
   text?: string;
   ordinal?: number;
+  reason?: string;
 }
 
 async function probe(file: string): Promise<Probe> {
@@ -99,7 +100,7 @@ if (mode === 'release') {
   const healthIndex = trace.findIndex((event, index) => index > rustIndex && event.event === 'input' && event.text === healthPrompt);
   const storeIndex = trace.findIndex((event, index) => index > rememberIndex && index < rustIndex && event.event === 'tool-result' && event.tool === 'knowledge-store' && event.isError === false);
   const storeCompletion = trace.findIndex((event, index) => index > storeIndex && index < rustIndex && event.event === 'assistant-text' && event.text?.includes('Cooking preference saved.'));
-  const newSession = trace.findIndex((event, index) => index > storeCompletion && index < rustIndex && event.event === 'session_start' && event.ordinal === 2);
+  const newSession = trace.findIndex((event, index) => index > storeCompletion && index < rustIndex && event.event === 'session_start' && event.reason === 'new');
   const searchIndex = trace.findIndex((event, index) => index > rustIndex && index < healthIndex && event.event === 'tool-result' && event.tool === 'knowledge-search' && event.isError === false);
   const healthToolIndex = trace.findIndex((event, index) => index > healthIndex && event.event === 'tool-result' && event.tool === 'knowledge-health' && event.isError === false);
   const healthCompletion = trace.findIndex((event, index) => index > healthToolIndex && event.event === 'assistant-text' && event.text?.includes('Knowledge base status loaded.'));


### PR DESCRIPTION
## Summary

- record Pi's authoritative `session_start.reason` in the release trace
- prove the `/new` boundary with `reason === "new"` instead of a process-local ordinal
- retain the ordinal as diagnostic trace metadata and the static VHS `/new` assertion

## Failure addressed

Release runs 29709667793 and 29710054709 recorded through the real-model flow but failed final validation after the hard-coded ordinal assertion was introduced. Pi's event contract explicitly identifies new sessions by reason; ordinal 2 is not an API guarantee.

## Validation

- synthetic release trace passes with a non-2 ordinal and `reason: "new"`
- `bun run build`
- `bun run typecheck`
- `bun run lint` (22 existing warnings, 0 errors)
- workflow audit, actionlint, VHS validation, and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

