### PR TITLE
Wait for completed Pi demo turns

### DIFF
--- a/scripts/pi-demo/openrouter-provider.ts
+++ b/scripts/pi-demo/openrouter-provider.ts
@@ -4,6 +4,11 @@ import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 const PROVIDER = 'open-zk-release';
 const MODEL = 'openai/gpt-oss-120b';
 const SEED = 42_019;
+const COMPLETION_NOTICES = [
+  ['Cooking preference saved.', 'Preference response complete.'],
+  ['That is the recipe.', 'Rust response complete.'],
+  ['Knowledge base status loaded.', 'Health response complete.'],
+] as const;
 
 let sessionOrdinal = 0;
 
@@ -93,9 +98,12 @@ export default function openRouterReleaseProvider(pi: ExtensionAPI): void {
     trace({ event: 'tool-result', tool: event.toolName, isError: event.isError });
   });
 
-  pi.on('message_end', (event) => {
+  pi.on('message_end', (event, ctx) => {
     if (event.message.role !== 'assistant') return;
     const text = assistantText(event.message);
-    if (text) trace({ event: 'assistant-text', text });
+    if (!text) return;
+    trace({ event: 'assistant-text', text });
+    const notice = COMPLETION_NOTICES.find(([marker]) => text.endsWith(marker));
+    if (notice) ctx.ui.notify(notice[1], 'info');
   });
 }

--- a/scripts/pi-demo/prepare.ts
+++ b/scripts/pi-demo/prepare.ts
@@ -106,6 +106,7 @@ async function main(): Promise<void> {
   fs.mkdirSync(piAgentDir, { recursive: true });
   fs.writeFileSync(path.join(piAgentDir, 'settings.json'), `${JSON.stringify({
     quietStartup: true,
+    hideThinkingBlock: true,
     enableInstallTelemetry: false,
     defaultProjectTrust: 'always',
   }, null, 2)}\n`);

--- a/scripts/pi-demo/release.tape
+++ b/scripts/pi-demo/release.tape
@@ -17,7 +17,7 @@ Show
 
 Type "Please remember that I understand coding concepts best through cooking metaphors"
 Enter
-Wait+Screen /Cooking preference saved\./
+Wait+Screen /Preference response complete\./
 Sleep 2s
 
 Type "/new"
@@ -26,12 +26,12 @@ Sleep 2s
 
 Type "Please explain how macros in rust work"
 Enter
-Wait+Screen /That is the recipe\./
+Wait+Screen /Rust response complete\./
 Sleep 3s
 
 Type "Whats the status of the knowledge base?"
 Enter
-Wait+Screen /Knowledge base status loaded\./
+Wait+Screen /Health response complete\./
 Sleep 4s
 
 Type "/quit"


### PR DESCRIPTION
## Summary

- emit unique Pi UI notices only from `message_end` after final assistant text ends with the required completion marker
- make VHS wait for those notices instead of model-authored text that can appear prematurely in reasoning
- hide thinking blocks in the isolated recording settings

## Failure addressed

Run 29710553086 showed the Rust completion marker inside gpt-oss-120b reasoning before the final answer completed. VHS advanced early, submitted the health prompt during the active Rust turn, and timed out. The same race can interrupt storage before `/new`, producing an empty cross-session search.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run lint` (22 existing warnings, 0 errors)
- workflow audit, actionlint, VHS validation, and `git diff --check`

The trace validator still independently requires all model-authored completion markers and successful tool results.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

