### PR TITLE
Limit Pi demo reasoning latency

### DIFF
--- a/scripts/pi-demo/openrouter-provider.ts
+++ b/scripts/pi-demo/openrouter-provider.ts
@@ -70,9 +70,14 @@ export default function openRouterReleaseProvider(pi: ExtensionAPI): void {
       ...payload,
       temperature: 0,
       seed: SEED,
+      reasoning: {
+        effort: 'low',
+        exclude: true,
+      },
       provider: {
         ...provider,
         require_parameters: true,
+        sort: 'latency',
       },
     };
   });

--- a/scripts/pi-demo/preflight-openrouter.ts
+++ b/scripts/pi-demo/preflight-openrouter.ts
@@ -29,7 +29,7 @@ interface Endpoint {
   supported_parameters?: string[];
 }
 const payload = await routes.json() as { data?: { endpoints?: Endpoint[] } };
-const requiredParameters = ['max_tokens', 'seed', 'temperature', 'tools'];
+const requiredParameters = ['max_tokens', 'reasoning', 'seed', 'temperature', 'tools'];
 const compatibleRoutes = (payload.data?.endpoints ?? []).filter((endpoint) => (
   endpoint.status === 0
   && requiredParameters.every((parameter) => endpoint.supported_parameters?.includes(parameter))


### PR DESCRIPTION
## Summary

- request low reasoning effort from OpenRouter and exclude reasoning content from the response
- prefer the lowest-latency compatible route while retaining exact-model routing and `require_parameters`
- require active routes to advertise the reasoning parameter during preflight

## Failure addressed

Both attempts of run 29710953104 reached a successful `knowledge-health` result, but openai/gpt-oss-120b then remained in reasoning for more than the 90-second completion timeout. The tool flow and cross-session retrieval were successful.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run lint` (22 existing warnings, 0 errors)
- workflow audit, actionlint, VHS validation, and `git diff --check`

The release still requires exact model `openai/gpt-oss-120b` and fails if no active route supports every required parameter.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

