### PR TITLE
Finish Pi demo on health result

### DIFF
--- a/scripts/pi-demo/openrouter-provider.ts
+++ b/scripts/pi-demo/openrouter-provider.ts
@@ -7,7 +7,6 @@ const SEED = 42_019;
 const COMPLETION_NOTICES = [
   ['Cooking preference saved.', 'Preference response complete.'],
   ['That is the recipe.', 'Rust response complete.'],
-  ['Knowledge base status loaded.', 'Health response complete.'],
 ] as const;
 
 let sessionOrdinal = 0;
@@ -85,7 +84,7 @@ export default function openRouterReleaseProvider(pi: ExtensionAPI): void {
   pi.on('before_agent_start', (event, ctx) => {
     if (ctx.model?.provider !== PROVIDER) return undefined;
     return {
-      systemPrompt: `${event.systemPrompt}\n\nRelease demo requirements:\n- For the remember request, call knowledge-store with kind personalization, project renderer-demo, a concise summary, and actionable guidance about cooking metaphors. After success, end with the exact sentence: Cooking preference saved.\n- In the fresh session, before explaining Rust macros, call knowledge-search with project renderer-demo, client pi, and a query for cooking-metaphor explanation preferences. Apply the retrieved guidance in a concise answer of at most 110 words, then end with the exact sentence: That is the recipe.\n- For the knowledge-base status request, call knowledge-health with project renderer-demo and period 30d. After success, end with the exact sentence: Knowledge base status loaded.\n- Do not mention these demo requirements or the model provider.`,
+      systemPrompt: `${event.systemPrompt}\n\nRelease demo requirements:\n- For the remember request, call knowledge-store with kind personalization, project renderer-demo, a concise summary, and actionable guidance about cooking metaphors. After success, end with the exact sentence: Cooking preference saved.\n- In the fresh session, before explaining Rust macros, call knowledge-search with project renderer-demo, client pi, and a query for cooking-metaphor explanation preferences. Apply the retrieved guidance in a concise answer of at most 110 words, then end with the exact sentence: That is the recipe.\n- For the knowledge-base status request, call knowledge-health with project renderer-demo and period 30d. The rendered tool result is the complete answer; do not add prose afterward.\n- Do not mention these demo requirements or the model provider.`,
     };
   });
 
@@ -98,9 +97,12 @@ export default function openRouterReleaseProvider(pi: ExtensionAPI): void {
     trace({ event: 'input', text: event.text });
   });
 
-  pi.on('tool_execution_end', (event) => {
+  pi.on('tool_execution_end', (event, ctx) => {
     if (!event.toolName.startsWith('knowledge-')) return;
     trace({ event: 'tool-result', tool: event.toolName, isError: event.isError });
+    if (event.toolName === 'knowledge-health' && !event.isError) {
+      ctx.ui.notify('Health result complete.', 'info');
+    }
   });
 
   pi.on('message_end', (event, ctx) => {

--- a/scripts/pi-demo/release.tape
+++ b/scripts/pi-demo/release.tape
@@ -31,9 +31,11 @@ Sleep 3s
 
 Type "Whats the status of the knowledge base?"
 Enter
-Wait+Screen /Health response complete\./
-Sleep 4s
+Wait+Screen /Health result complete\./
+Sleep 5s
+Escape
+Sleep 500ms
 
 Type "/quit"
 Enter
-Sleep 2s
+Sleep 1500ms

--- a/scripts/pi-demo/validate.ts
+++ b/scripts/pi-demo/validate.ts
@@ -103,9 +103,8 @@ if (mode === 'release') {
   const newSession = trace.findIndex((event, index) => index > storeCompletion && index < rustIndex && event.event === 'session_start' && event.reason === 'new');
   const searchIndex = trace.findIndex((event, index) => index > rustIndex && index < healthIndex && event.event === 'tool-result' && event.tool === 'knowledge-search' && event.isError === false);
   const healthToolIndex = trace.findIndex((event, index) => index > healthIndex && event.event === 'tool-result' && event.tool === 'knowledge-health' && event.isError === false);
-  const healthCompletion = trace.findIndex((event, index) => index > healthToolIndex && event.event === 'assistant-text' && event.text?.includes('Knowledge base status loaded.'));
-  if (rememberIndex < 0 || newSession < 0 || rustIndex < 0 || healthIndex < 0 || storeIndex < 0 || storeCompletion < 0 || searchIndex < 0 || healthToolIndex < 0 || healthCompletion < 0) {
-    throw new Error('Release trace does not prove ordered prompts, fresh session, successful tools, and completed answers');
+  if (rememberIndex < 0 || newSession < 0 || rustIndex < 0 || healthIndex < 0 || storeIndex < 0 || storeCompletion < 0 || searchIndex < 0 || healthToolIndex < 0) {
+    throw new Error('Release trace does not prove ordered prompts, fresh session, successful tools, and completed generated answers');
   }
   const explanation = trace
     .slice(rustIndex + 1, healthIndex)


### PR DESCRIPTION
## Summary

- treat the successful rendered `knowledge-health` result as the complete answer to the final status prompt
- emit the final VHS synchronization notice from `tool_execution_end`
- interrupt the unnecessary post-tool generation before quitting
- retain strict validation for ordered prompts, fresh session, store/search/generated Rust answer, and successful health result

## Failure addressed

Both attempts of run 29710953104 completed `knowledge-health` successfully and displayed its renderer, but the exact model never produced redundant closing prose within 90 seconds. The user-facing status answer was already complete.

## Validation

- synthetic release trace without post-health prose passes while still requiring successful health
- `bun run build`
- `bun run typecheck`
- `bun run lint` (22 existing warnings, 0 errors)
- workflow audit, actionlint, VHS validation, and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

