### PR TITLE
Force required Pi demo tools

### DIFF
--- a/scripts/pi-demo/openrouter-provider.ts
+++ b/scripts/pi-demo/openrouter-provider.ts
@@ -10,6 +10,7 @@ const COMPLETION_NOTICES = [
 ] as const;
 
 let sessionOrdinal = 0;
+let pendingTool: string | undefined;
 
 function trace(event: Record<string, unknown>): void {
   const tracePath = process.env.OPEN_ZK_KB_PI_DEMO_TRACE;
@@ -69,14 +70,15 @@ export default function openRouterReleaseProvider(pi: ExtensionAPI): void {
       ...payload,
       temperature: 0,
       seed: SEED,
-      reasoning: {
-        effort: 'low',
-        exclude: true,
-      },
+      ...(pendingTool ? {
+        tool_choice: {
+          type: 'function',
+          function: { name: pendingTool },
+        },
+      } : {}),
       provider: {
         ...provider,
         require_parameters: true,
-        sort: 'latency',
       },
     };
   });
@@ -95,11 +97,19 @@ export default function openRouterReleaseProvider(pi: ExtensionAPI): void {
 
   pi.on('input', (event) => {
     trace({ event: 'input', text: event.text });
+    pendingTool = event.text === 'Please remember that I understand coding concepts best through cooking metaphors'
+      ? 'knowledge-store'
+      : event.text === 'Please explain how macros in rust work'
+        ? 'knowledge-search'
+        : event.text === 'Whats the status of the knowledge base?'
+          ? 'knowledge-health'
+          : undefined;
   });
 
   pi.on('tool_execution_end', (event, ctx) => {
     if (!event.toolName.startsWith('knowledge-')) return;
     trace({ event: 'tool-result', tool: event.toolName, isError: event.isError });
+    if (event.toolName === pendingTool && !event.isError) pendingTool = undefined;
     if (event.toolName === 'knowledge-health' && !event.isError) {
       ctx.ui.notify('Health result complete.', 'info');
     }

--- a/scripts/pi-demo/preflight-openrouter.ts
+++ b/scripts/pi-demo/preflight-openrouter.ts
@@ -29,7 +29,7 @@ interface Endpoint {
   supported_parameters?: string[];
 }
 const payload = await routes.json() as { data?: { endpoints?: Endpoint[] } };
-const requiredParameters = ['max_tokens', 'reasoning', 'seed', 'temperature', 'tools'];
+const requiredParameters = ['max_tokens', 'seed', 'temperature', 'tools'];
 const compatibleRoutes = (payload.data?.endpoints ?? []).filter((endpoint) => (
   endpoint.status === 0
   && requiredParameters.every((parameter) => endpoint.supported_parameters?.includes(parameter))

--- a/scripts/pi-demo/preflight-openrouter.ts
+++ b/scripts/pi-demo/preflight-openrouter.ts
@@ -29,7 +29,7 @@ interface Endpoint {
   supported_parameters?: string[];
 }
 const payload = await routes.json() as { data?: { endpoints?: Endpoint[] } };
-const requiredParameters = ['max_tokens', 'seed', 'temperature', 'tools'];
+const requiredParameters = ['max_tokens', 'seed', 'temperature', 'tool_choice', 'tools'];
 const compatibleRoutes = (payload.data?.endpoints ?? []).filter((endpoint) => (
   endpoint.status === 0
   && requiredParameters.every((parameter) => endpoint.supported_parameters?.includes(parameter))


### PR DESCRIPTION
## Summary

- deterministically select the required first knowledge tool for each exact release prompt using OpenAI-compatible `tool_choice`
- clear the forced choice after that tool succeeds so the model can produce the generated Rust answer
- revert the low-reasoning and latency-route experiment that reduced instruction adherence
- keep final synchronization on the successful health renderer rather than redundant prose

## Failure addressed

Run 29711539535 used the low-reasoning route and answered Rust directly without calling `knowledge-search`, applying the stored cooking preference, or emitting the required marker. Previous default-reasoning runs reliably followed the first two tool flows; their only stall was post-health prose, which is no longer awaited.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run lint` (22 existing warnings, 0 errors)
- workflow audit, actionlint, VHS validation, and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

