### PR TITLE
Persist Pi health completion signal

### DIFF
--- a/scripts/pi-demo/openrouter-provider.ts
+++ b/scripts/pi-demo/openrouter-provider.ts
@@ -111,7 +111,7 @@ export default function openRouterReleaseProvider(pi: ExtensionAPI): void {
     trace({ event: 'tool-result', tool: event.toolName, isError: event.isError });
     if (event.toolName === pendingTool && !event.isError) pendingTool = undefined;
     if (event.toolName === 'knowledge-health' && !event.isError) {
-      ctx.ui.notify('Health result complete.', 'info');
+      ctx.ui.setWidget('release-health-complete', ['Health result complete.'], { placement: 'belowEditor' });
     }
   });
 


### PR DESCRIPTION
## Summary

- replace the transient health-result notification with a persistent below-editor demo widget
- keep the signal outside the model transcript while making VHS synchronization deterministic

## Failure addressed

Run 29716966108 completed all required tools and the personalized Rust answer, but the health `notify()` signal was not retained on screen long enough for VHS to observe it during the active agent turn.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run lint` (22 existing warnings, 0 errors)
- workflow audit, actionlint, VHS validation, and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

