### PR TITLE
Validate final Pi tool from trace

### DIFF
--- a/scripts/pi-demo/openrouter-provider.ts
+++ b/scripts/pi-demo/openrouter-provider.ts
@@ -106,13 +106,10 @@ export default function openRouterReleaseProvider(pi: ExtensionAPI): void {
           : undefined;
   });
 
-  pi.on('tool_execution_end', (event, ctx) => {
+  pi.on('tool_execution_end', (event) => {
     if (!event.toolName.startsWith('knowledge-')) return;
     trace({ event: 'tool-result', tool: event.toolName, isError: event.isError });
     if (event.toolName === pendingTool && !event.isError) pendingTool = undefined;
-    if (event.toolName === 'knowledge-health' && !event.isError) {
-      ctx.ui.setWidget('release-health-complete', ['Health result complete.'], { placement: 'belowEditor' });
-    }
   });
 
   pi.on('message_end', (event, ctx) => {

--- a/scripts/pi-demo/release.tape
+++ b/scripts/pi-demo/release.tape
@@ -31,8 +31,7 @@ Sleep 3s
 
 Type "Whats the status of the knowledge base?"
 Enter
-Wait+Screen /Health result complete\./
-Sleep 5s
+Sleep 8s
 Escape
 Sleep 500ms
 

--- a/scripts/pi-demo/release.tape
+++ b/scripts/pi-demo/release.tape
@@ -33,7 +33,7 @@ Type "Whats the status of the knowledge base?"
 Enter
 Sleep 8s
 Escape
-Sleep 500ms
+Sleep 3s
 
 Type "/quit"
 Enter


### PR DESCRIPTION
## Summary

- remove the health completion widget hidden by the intentionally empty demo footer
- allow a fixed eight-second window for the forced health tool, then interrupt redundant model continuation
- rely on strict post-capture trace validation to prove successful `knowledge-health`

## Failure addressed

Run 29717382233 rendered `knowledge-health`, but the below-editor completion widget was not visible because the release presentation intentionally replaces the footer with an empty component.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run lint` (22 existing warnings, 0 errors)
- workflow audit, actionlint, VHS validation, and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

