### PR TITLE
Fix stable release tag detection

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -5,15 +5,6 @@ on:
     branches: ['feat/plugin-*']
   pull_request:
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'plugin/**'
-      - 'skill-templates/**'
-      - 'scripts/build-plugin.ts'
-      - 'patches/**'
-      - 'package.json'
-      - 'bun.lock'
-      - 'bun.lockb'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,8 @@ jobs:
           NPM_PUBLISHED: ${{ steps.check.outputs.skip }}
         run: |
           TAG="v$VERSION"
-          TAG_SHA=$(gh api "repos/$GH_REPO/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
+          TAG_SHA=$(gh api "repos/$GH_REPO/git/matching-refs/tags/$TAG" \
+            --jq "map(select(.ref == \"refs/tags/$TAG\"))[0].object.sha // \"\"")
           if [ "$NPM_PUBLISHED" = "true" ] && [ -n "$TAG_SHA" ] && [ "$TAG_SHA" != "$COMMIT_SHA" ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "Version $VERSION was already released from $TAG_SHA; no stable release work is needed for $COMMIT_SHA."
@@ -157,7 +158,8 @@ jobs:
           PRERELEASE: ${{ steps.release.outputs.prerelease }}
         run: |
           TAG="v$VERSION"
-          TAG_SHA=$(gh api "repos/$GH_REPO/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
+          TAG_SHA=$(gh api "repos/$GH_REPO/git/matching-refs/tags/$TAG" \
+            --jq "map(select(.ref == \"refs/tags/$TAG\"))[0].object.sha // \"\"")
           if [ -z "$TAG_SHA" ]; then
             gh api --method POST "repos/$GH_REPO/git/refs" \
               -f ref="refs/tags/$TAG" \


### PR DESCRIPTION
## Summary
- query matching tag refs so an absent tag produces an empty result instead of captured 404 JSON
- preserve exact-tag filtering and existing release rerun safeguards

## Validation
- `actionlint -color`
- `git diff --check`
- verified absent `v1.4.0` and existing `v1.3.0` API results
- independent release-workflow review approved

## Release context
The v1.4.0 publish run failed before npm publication or tag creation. Merging this workflow-only fix will rerun the stable release safely.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

