### PR TITLE
Default telemetry install prompt to yes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ For any new feature, ask in order:
 - **Server surfaces, agent acts**: Every computed insight (similarity, dedup, staleness) appears in the tool response. The agent decides what to do with it.
 - **Hints, not directives**: Server responses include computed metrics (word count, similarity score, staleness days). Never phrased as recommendations.
 - **Behavioral guidance is advisory**: Instructions are "a request, not a guarantee" ([Anthropic](https://docs.anthropic.com/en/docs/claude-code/features-overview)). Deterministic enforcement requires hooks/plugins.
-- **Telemetry is local-only and opt-in**: Tool invocation counters are disabled by default; set `telemetry.enabled: true` to enable. Counters stay in SQLite, never include content or query strings. When disabled, both counter rows and access timestamp updates are skipped.
+- **Telemetry runtime defaults remain disabled**: Interactive setup preselects Yes for anonymous analytics but writes `telemetry.enabled: true` and `telemetry.share: true` only after confirmation. Non-interactive installs remain disabled unless already configured. Local counters stay in SQLite and never include content or query strings.
 - **Anonymous analytics sharing**: When both `telemetry.enabled: true` and `telemetry.share: true` are set, anonymous session metadata (client, version, platform, vault size, duration, tool usage counts, model IDs) is persisted to SQLite and sent to PostHog (EU Cloud) on the next server startup. No PII, no note content, no queries, no network calls at shutdown. Set `telemetry.share: false` to opt out. All sharing logic lives in `src/analytics.ts`. See `docs/telemetry.md`.
 
 ## Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Telemetry consent prompt** — interactive installations now preselect Yes when asking to share anonymous usage analytics. Sharing is still enabled only after confirmation; No, cancellation, `--no-telemetry`, and non-interactive installs remain disabled
+
 ## 1.4.1
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Search combines SQLite FTS5 full-text indexing with local vector embeddings (Min
 
 ## Telemetry
 
-When opted in (`telemetry.enabled: true` and `telemetry.share: true`), open-zk-kb sends anonymous session analytics to [PostHog](https://posthog.com) (EU Cloud) — which client and models you use, vault size, and tool usage counts. No note content, search queries, or personal data is ever collected. Both flags are disabled by default. Set `DO_NOT_TRACK=1` to unconditionally block sharing (local SQLite counters are unaffected). Set both flags to `false` to disable all telemetry entirely. See [Telemetry](docs/telemetry.md) for the full event schema and details.
+When enabled (`telemetry.enabled: true` and `telemetry.share: true`), open-zk-kb sends anonymous session analytics to [PostHog](https://posthog.com) (EU Cloud) — which client and models you use, vault size, and tool usage counts. No note content, search queries, file paths, names, or email addresses are collected. Runtime configuration defaults remain disabled; the interactive installer asks for consent with **Yes** preselected and enables sharing only after confirmation. Non-interactive and direct package installs remain disabled unless configured separately. Set `DO_NOT_TRACK=1` to unconditionally block sharing (local SQLite counters are unaffected), or set both flags to `false`. See [Telemetry](docs/telemetry.md) for the full event schema and details.
 
 ## Documentation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,8 @@ embeddings:
 | lifecycle.reviewAfterDays | number | 14 | Days until a note is surfaced for review |
 | lifecycle.promotionThreshold | number | 2 | Accesses needed to recommend promotion to permanent |
 | lifecycle.exemptKinds | string[] | ["personalization", "decision"] | Note kinds exempt from the review queue |
-| telemetry.enabled | boolean | false | Enable local-only tool invocation counters and access timestamps (opt-in) |
+| telemetry.enabled | boolean | false | Enable local-only tool invocation counters and access timestamps |
+| telemetry.share | boolean | false | Share anonymous session analytics when local telemetry is also enabled |
 | obsidian.scaffold | boolean | true | Create and maintain the opinionated `.obsidian/` scaffold used by `knowledge-open` |
 | obsidian.autoUpgrade | boolean | true | Refresh pinned theme/plugin/snippet assets when the server starts |
 | obsidian.readOnly | boolean | true | Default Obsidian to Reading View and enable read-only helpers |
@@ -55,11 +56,11 @@ Embeddings work **out of the box** with zero configuration using a local model (
 
 ## Telemetry
 
-Telemetry has two layers, both **disabled by default**:
+Telemetry has two layers. Both runtime configuration defaults are `false`; during interactive installation, the consent prompt has **Yes** preselected and writes both settings as `true` only after confirmation. Choosing No, cancelling, using `--no-telemetry`, or installing non-interactively leaves the runtime defaults unchanged.
 
 **Local counters** (`telemetry.enabled`) — Records tool invocation counters and note access timestamps to the local SQLite database. Never leaves your machine. Used by `knowledge-health` for usage breakdowns.
 
-**Anonymous sharing** (`telemetry.share`) — When also enabled, anonymous session metadata (client, models, version, platform, vault size, tool usage counts) is sent to PostHog (EU Cloud) on the next server startup. No note content, search queries, or personal data is ever shared. See [Telemetry](telemetry.md) for the full event schema.
+**Anonymous sharing** (`telemetry.share`) — When also enabled, anonymous session metadata (client, models, version, platform, vault size, tool usage counts) is sent to PostHog (EU Cloud) on the next server startup. No note content, search queries, file paths, names, or email addresses are shared. See [Telemetry](telemetry.md) for the full event schema.
 
 ```yaml
 telemetry:
@@ -67,7 +68,7 @@ telemetry:
   share: true      # also send anonymous session data to PostHog
 ```
 
-When disabled (the default), open-zk-kb records no telemetry rows, skips note access tracking (`last_accessed_at` and `access_count`), and sends nothing externally.
+When disabled, open-zk-kb records no telemetry rows, skips note access tracking (`last_accessed_at` and `access_count`), and sends nothing externally.
 
 ## Obsidian Vault Scaffold
 

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -8,7 +8,7 @@ open-zk-kb ships as a native [Pi package](https://github.com/badlogic/pi-mono). 
 pi install npm:open-zk-kb
 ```
 
-Bun remains required for the local MCP server and SQLite storage. Restart Pi after installation.
+Bun remains required for the local MCP server and SQLite storage. Restart Pi after installation. The direct `pi install` command does not run open-zk-kb's interactive telemetry consent prompt, so sharing remains disabled unless it was configured separately or Pi was installed through `bunx open-zk-kb@latest`.
 
 ## Automatic Project Preferences
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -17,6 +17,16 @@ This presents a multi-select prompt — use Space to select clients, Enter to co
 
 > **Note**: The installer automatically copies `config.example.yaml` to `~/.config/open-zk-kb/config.yaml` if no config file exists yet. Local embeddings (MiniLM, 23MB) are enabled by default and require no API key.
 
+### Telemetry choice
+
+Interactive installation asks whether to share anonymous session analytics, with **Yes** preselected. Sharing is enabled only after the user confirms; choosing No or cancelling leaves the disabled runtime defaults unchanged. Use `--no-telemetry` to skip the prompt and keep telemetry disabled:
+
+```bash
+bunx open-zk-kb@latest --no-telemetry
+```
+
+Non-interactive installs, including `--yes`, do not assume consent and remain disabled unless telemetry was already configured. Direct package-manager installs that bypass this installer also do not enable telemetry.
+
 ### Pi Installation
 
 Pi does not include native MCP support, so open-zk-kb ships as a Pi package extension that bridges the existing MCP server into Pi-native `knowledge-*` tools:
@@ -31,7 +41,7 @@ The open-zk-kb installer can also wire Pi settings and managed `AGENTS.md` instr
 bunx open-zk-kb@latest install --client pi
 ```
 
-Restart Pi after either install path so it can load the package extension.
+Restart Pi after either install path so it can load the package extension. The direct `pi install` path does not run open-zk-kb's telemetry consent prompt; use the `bunx` installer or configure telemetry explicitly if you want to share anonymous analytics.
 
 Pi loads ten native `knowledge-*` tools. Search, store, context, and health results use compact Pi TUI summaries with expandable details; the remaining tools use concise status renderers. Pi's native tool shell remains visible around each result.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,6 +1,8 @@
 # Telemetry
 
-open-zk-kb can collect anonymous usage analytics to understand adoption and guide development. **Sharing is disabled by default** — both `telemetry.enabled` and `telemetry.share` must be set to `true` to send any data. This page documents what is collected, why, and how to opt out.
+open-zk-kb can collect anonymous usage analytics to understand adoption and guide development. Runtime configuration defaults remain disabled, and both `telemetry.enabled` and `telemetry.share` must be `true` to send any data. During an interactive installation, open-zk-kb asks for consent with **Yes** preselected and writes those settings only after confirmation. Choosing No, cancelling the prompt, using `--no-telemetry`, or installing non-interactively leaves sharing disabled. Direct package installs that do not run the installer, such as `pi install npm:open-zk-kb`, also remain disabled unless configured separately.
+
+This page documents what is collected, why, and how to opt out.
 
 ## What we collect
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -119,6 +119,7 @@ export interface ClientConfig {
 }
 
 const PI_PACKAGE_NAME = 'open-zk-kb';
+export const TELEMETRY_PROMPT_INITIAL_VALUE = true;
 export const CLIENT_CONFIGS: Record<McpClient, ClientConfig> = {
   'opencode': {
     name: 'OpenCode',
@@ -2231,10 +2232,10 @@ export async function runSetupCli(rawArgs: string[] = process.argv.slice(2)): Pr
 
       const answer = await p.confirm({
         message: 'Help improve open-zk-kb with anonymous usage analytics?\n' +
-          color.dim('    Session metadata: client, models, version, platform, vault size, tool usage counts.\n') +
-          color.dim('    Never any note contents, search queries, or personal data.\n') +
+          color.dim('    Sends session metadata and a random installation ID to PostHog EU Cloud.\n') +
+          color.dim('    Never note contents, search queries, names, email addresses, or file paths.\n') +
           color.dim('    Open source and auditable: https://github.com/mrosnerr/open-zk-kb/blob/main/docs/telemetry.md'),
-        initialValue: false,
+        initialValue: TELEMETRY_PROMPT_INITIAL_VALUE,
       });
       if (p.isCancel(answer)) return null; // Don't block install on cancel
       // Only write config when opting in — the defaults are already disabled,

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { installTtsrRule, removeTtsrRule } from '../src/setup.js';
+import { installTtsrRule, removeTtsrRule, TELEMETRY_PROMPT_INITIAL_VALUE } from '../src/setup.js';
 import { OMP_AGENT_DOCS_PREAMBLE } from '../src/agent-docs-targets.js';
 import { createTestHarness, cleanupTestHarness } from './harness.js';
 import type { TestContext } from './harness.js';
@@ -155,6 +155,10 @@ function expectSlimAgentDocsBlock(content: string, usesOmpSkill = false): void {
 
 
 describe('setup.ts', () => {
+  it('preselects Yes for interactive telemetry consent', () => {
+    expect(TELEMETRY_PROMPT_INITIAL_VALUE).toBe(true);
+  });
+
   let ctx: TestContext;
   let envSnapshot: EnvSnapshot;
   const tempDirs: string[] = [];


### PR DESCRIPTION
## Summary

- preselect **Yes** in the interactive anonymous analytics consent prompt while keeping runtime config defaults disabled
- disclose the random installation ID and PostHog EU Cloud directly in the prompt
- document behavior for No, cancellation, `--no-telemetry`, non-interactive installs, and direct Pi package installs
- add a regression test that pins the interactive prompt default

## Verification

- `bun run build`
- `bun run typecheck`
- `bun run lint` — 0 errors; 22 pre-existing warnings in `src/mcp-server.ts`
- sanitized PTY render — verified selected `● Yes` and unselected `○ No` through the real installer path
- `DO_NOT_TRACK=1 bun test` — 1180 pass, 56 skip; 2 existing Pi package-source tests fail only because the Worktrunk checkout basename is not `open-zk-kb`. Both tests pass from the canonical checkout, matching CI's checkout layout.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

