### PR TITLE
Prevent destructive smoke tests from touching host data

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -120,16 +120,22 @@ PRs are reviewed by automated tools (CodeRabbit, Cubic) and maintainers. Here's 
 
 All PRs run: build, lint, unit tests, and **smoke tests** (install/uninstall for all 7 clients, MCP protocol verification, and a full KB round-trip).
 
-You can run smoke tests locally:
+Run smoke tests locally only inside a clean Docker container with no host home
+or vault mount:
+
 ```bash
-bash tests/docker/smoke-test.sh
+docker build --target smoke -t open-zk-kb-smoke -f tests/docker/Dockerfile .
 ```
 
-Or in a clean Docker container:
-```bash
-docker build -t open-zk-kb-smoke -f tests/docker/Dockerfile .
-docker run --rm open-zk-kb-smoke bash tests/docker/smoke-test.sh
-```
+The script refuses destructive execution on an unmarked host. On disposable CI
+and container runners it also creates a private temporary `HOME` and XDG
+environment before executing any test, routes recursive deletion through a
+canonical-path guard, and refuses smoke-mode vault deletion outside its
+sentinel-marked sandbox.
+
+Never weaken or bypass either the disposable-runner gate or smoke sandbox to
+debug a failing test. Inspect the sandboxed paths or reproduce the failing
+operation in a separate temporary directory instead.
 
 ## Submitting Changes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,13 +131,11 @@ jobs:
         if: steps.embedding-cache.outputs.cache-hit != 'true'
         run: bun -e "import { generateEmbedding, DEFAULT_EMBEDDING_CONFIG } from './dist/embeddings.js'; const result = await generateEmbedding('cache prime', DEFAULT_EMBEDDING_CONFIG); if (!result) process.exit(1);"
         env:
-          NODE_TLS_REJECT_UNAUTHORIZED: "0"
           XDG_CACHE_HOME: ${{ runner.temp }}/open-zk-kb-model-cache
 
       - name: Local model smoke tests
         run: LOCAL_MODELS=1 bash tests/docker/smoke-test.sh
         env:
-          NODE_TLS_REJECT_UNAUTHORIZED: "0"
           OPEN_ZK_KB_EPHEMERAL_SMOKE: "1"
           OPEN_ZK_KB_MODEL_CACHE_SEED: ${{ runner.temp }}/open-zk-kb-model-cache/open-zk-kb/models/Xenova/all-MiniLM-L6-v2
         timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Smoke tests (install, MCP protocol, KB round-trip)
         run: bash tests/docker/smoke-test.sh
+        env:
+          OPEN_ZK_KB_EPHEMERAL_SMOKE: "1"
 
       # Non-blocking: these tests spawn dist/cli.js subprocesses and are timing-sensitive on shared hosted runners; failures are surfaced in the job log but do not fail the build.
       - name: Stdio bridge integration tests
@@ -128,4 +130,5 @@ jobs:
         run: LOCAL_MODELS=1 bash tests/docker/smoke-test.sh
         env:
           NODE_TLS_REJECT_UNAUTHORIZED: "0"
+          OPEN_ZK_KB_EPHEMERAL_SMOKE: "1"
         timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,14 +121,23 @@ jobs:
         run: bun run build
 
       - name: Cache embedding model
+        id: embedding-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: ~/.cache/open-zk-kb/models/Xenova/all-MiniLM-L6-v2
+          path: ${{ runner.temp }}/open-zk-kb-model-cache/open-zk-kb/models/Xenova/all-MiniLM-L6-v2
           key: embedding-model-all-MiniLM-L6-v2-${{ runner.os }}
+
+      - name: Prime embedding model cache
+        if: steps.embedding-cache.outputs.cache-hit != 'true'
+        run: bun -e "import { generateEmbedding, DEFAULT_EMBEDDING_CONFIG } from './dist/embeddings.js'; const result = await generateEmbedding('cache prime', DEFAULT_EMBEDDING_CONFIG); if (!result) process.exit(1);"
+        env:
+          NODE_TLS_REJECT_UNAUTHORIZED: "0"
+          XDG_CACHE_HOME: ${{ runner.temp }}/open-zk-kb-model-cache
 
       - name: Local model smoke tests
         run: LOCAL_MODELS=1 bash tests/docker/smoke-test.sh
         env:
           NODE_TLS_REJECT_UNAUTHORIZED: "0"
           OPEN_ZK_KB_EPHEMERAL_SMOKE: "1"
+          OPEN_ZK_KB_MODEL_CACHE_SEED: ${{ runner.temp }}/open-zk-kb-model-cache/open-zk-kb/models/Xenova/all-MiniLM-L6-v2
         timeout-minutes: 10

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1756,6 +1756,12 @@ export function uninstall(args: UninstallArgs): UninstallResult {
   const vaultPath = getVaultPath();
   const docsLabel = clientConfig.agentDocsLabel || 'Agent docs';
 
+  // Smoke mode must reject an unexpected vault before dry-run summaries,
+  // confirmation statistics, or any other read touches that path.
+  if (args.removeVault) {
+    assertSmokeTestVaultDeletionIsSandboxed(vaultPath);
+  }
+
   const disabledServersOnUninstall = clientConfig.disabledServersOnUninstall ?? [];
   const configExists = fs.existsSync(clientConfig.configPath);
   const hasAuxiliaryArtifacts = hasAuxiliaryInstallArtifacts(clientConfig);
@@ -1902,7 +1908,6 @@ export function uninstall(args: UninstallArgs): UninstallResult {
       return { status: 'not-installed', clientName: clientConfig.name, output, details: [], agentDocsSkippedSymlink: null };
     }
 
-    assertSmokeTestVaultDeletionIsSandboxed(vaultPath);
     if (fs.existsSync(vaultPath)) {
       fs.rmSync(vaultPath, { recursive: true });
     }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -697,6 +697,42 @@ function getVaultPath(): string {
   return path.join(xdgDataHome, 'open-zk-kb');
 }
 
+/**
+ * Destructive smoke tests must only delete vaults inside their private,
+ * sentinel-marked sandbox. This is an independent backstop in case the shell
+ * harness passes an unexpected XDG path.
+ */
+function assertSmokeTestVaultDeletionIsSandboxed(vaultPath: string): void {
+  if (process.env.OPEN_ZK_KB_SMOKE_TEST !== '1') return;
+
+  const sandboxRoot = process.env.OPEN_ZK_KB_SMOKE_SANDBOX_ROOT;
+  if (!sandboxRoot) {
+    throw new Error('Refusing vault deletion: smoke-test sandbox root is not set');
+  }
+
+  const sentinelPath = path.join(sandboxRoot, '.open-zk-kb-smoke-sandbox');
+  const expectedSentinel = 'open-zk-kb destructive smoke-test sandbox';
+  if (!fs.existsSync(sentinelPath)
+    || !fs.statSync(sentinelPath).isFile()
+    || fs.readFileSync(sentinelPath, 'utf8').trim() !== expectedSentinel) {
+    throw new Error('Refusing vault deletion: smoke-test sandbox sentinel is missing or invalid');
+  }
+
+  const realSandboxRoot = fs.realpathSync(sandboxRoot);
+  const realVaultPath = fs.existsSync(vaultPath)
+    ? fs.realpathSync(vaultPath)
+    : path.resolve(vaultPath);
+  const relativeVaultPath = path.relative(realSandboxRoot, realVaultPath);
+  const isInsideSandbox = relativeVaultPath !== ''
+    && relativeVaultPath !== '..'
+    && !relativeVaultPath.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relativeVaultPath);
+
+  if (!isInsideSandbox) {
+    throw new Error(`Refusing vault deletion outside smoke-test sandbox: ${realVaultPath}`);
+  }
+}
+
 function getConfigYamlPath(): string {
   return path.join(xdgConfigHome, 'open-zk-kb', 'config.yaml');
 }
@@ -1866,6 +1902,7 @@ export function uninstall(args: UninstallArgs): UninstallResult {
       return { status: 'not-installed', clientName: clientConfig.name, output, details: [], agentDocsSkippedSymlink: null };
     }
 
+    assertSmokeTestVaultDeletionIsSandboxed(vaultPath);
     if (fs.existsSync(vaultPath)) {
       fs.rmSync(vaultPath, { recursive: true });
     }

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -84,7 +84,8 @@ docker build --target smoke -t open-zk-kb-smoke -f tests/docker/Dockerfile .
 - Keep all `HOME`, XDG, runtime cache, temporary, package staging, and generated
   output paths inside the smoke sandbox. CI may copy an explicitly restored,
   read-only model seed into that cache; model execution must never write back to
-  the seed location.
+  the seed location. Never disable TLS certificate verification when downloading
+  or caching model artifacts.
 - Keep the independent `src/setup.ts` smoke-mode deletion backstop and its
   regression tests. Shell isolation alone is not sufficient.
 - Prefer the Docker invocation when practical; do not mount a host home or vault

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -23,7 +23,7 @@ tests/
 ├── knowledge-quality-assessment.test.ts  # Content quality scoring
 ├── injection-quality-test.ts  # Agent self-search quality via MCP
 ├── docker/                # Docker-based integration tests
-│   ├── smoke-test.sh      # Full install/uninstall + MCP protocol + KB round-trip
+│   ├── smoke-test.sh      # Sandboxed install/uninstall + MCP protocol + KB round-trip
 │   ├── mcp-protocol-test.ts   # MCP protocol compliance
 │   ├── model-smoke-test.ts    # Local embedding model validation
 │   └── Dockerfile
@@ -72,4 +72,18 @@ bun test                          # All tests
 bun test tests/mcp-tools.test.ts  # Single file
 bun test --watch                  # Watch mode
 EVAL=1 bun test tests/eval/eval.test.ts --timeout 120000  # Eval suite
+docker build --target smoke -t open-zk-kb-smoke -f tests/docker/Dockerfile .
 ```
+
+## Destructive Test Safety
+
+- `tests/docker/smoke-test.sh` must refuse unmarked host execution and establish
+  its private, sentinel-marked sandbox before running any test command.
+- Route every recursive deletion in the smoke suite through its canonical-path
+  guard. Never add a direct `rm -rf` test step.
+- Keep all `HOME`, XDG, runtime, cache, temporary, package staging, and generated
+  output paths inside the smoke sandbox.
+- Keep the independent `src/setup.ts` smoke-mode deletion backstop and its
+  regression tests. Shell isolation alone is not sufficient.
+- Prefer the Docker invocation when practical; do not mount a host home or vault
+  into the container.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -81,8 +81,10 @@ docker build --target smoke -t open-zk-kb-smoke -f tests/docker/Dockerfile .
   its private, sentinel-marked sandbox before running any test command.
 - Route every recursive deletion in the smoke suite through its canonical-path
   guard. Never add a direct `rm -rf` test step.
-- Keep all `HOME`, XDG, runtime, cache, temporary, package staging, and generated
-  output paths inside the smoke sandbox.
+- Keep all `HOME`, XDG, runtime cache, temporary, package staging, and generated
+  output paths inside the smoke sandbox. CI may copy an explicitly restored,
+  read-only model seed into that cache; model execution must never write back to
+  the seed location.
 - Keep the independent `src/setup.ts` smoke-mode deletion backstop and its
   regression tests. Shell isolation alone is not sufficient.
 - Prefer the Docker invocation when practical; do not mount a host home or vault

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -10,5 +10,4 @@ FROM base AS smoke
 RUN bash tests/docker/smoke-test.sh
 
 FROM base AS model-smoke
-ENV NODE_TLS_REJECT_UNAUTHORIZED=0
 RUN timeout 300 bun run tests/docker/model-smoke-test.ts

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM oven/bun:1 AS base
+ENV OPEN_ZK_KB_EPHEMERAL_SMOKE=1
 WORKDIR /app
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile

--- a/tests/docker/model-smoke-test.ts
+++ b/tests/docker/model-smoke-test.ts
@@ -2,6 +2,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 
 const EMBEDDING_DIMENSIONS = 384;
 const _TOTAL_EXPECTED = 9;
@@ -68,7 +69,7 @@ async function testEmbeddings() {
 async function testKbRoundTripWithEmbeddings() {
   console.log('\n\u25b8 KB Round-Trip with Embeddings');
 
-  const tmpDir = fs.mkdtempSync('/tmp/model-smoke-');
+  const tmpDir = fs.mkdtempSync(path.join(process.env.TMPDIR || os.tmpdir(), 'model-smoke-'));
 
   const transport = new StdioClientTransport({
     command: 'bun',

--- a/tests/docker/smoke-test.sh
+++ b/tests/docker/smoke-test.sh
@@ -753,7 +753,7 @@ echo ""
 if [ "${LOCAL_MODELS:-}" = "1" ]; then
   echo "▸ Local Model Quality Tests"
 
-  MODEL_OUTPUT=$(NODE_TLS_REJECT_UNAUTHORIZED=0 timeout 300 bun run tests/docker/model-smoke-test.ts 2>/dev/null || true)
+  MODEL_OUTPUT=$(timeout 300 bun run tests/docker/model-smoke-test.ts 2>/dev/null || true)
   echo "$MODEL_OUTPUT" | grep -E "^  [✅❌⏱]" || true
 
   MODEL_RESULT=$(echo "$MODEL_OUTPUT" | grep "MODEL_SMOKE_RESULT" || echo "MODEL_SMOKE_RESULT:0:12")

--- a/tests/docker/smoke-test.sh
+++ b/tests/docker/smoke-test.sh
@@ -1,6 +1,164 @@
 #!/bin/bash
 set -euo pipefail
 
+# This suite intentionally exercises destructive install/uninstall paths. Isolate
+# every user-writable location before running any command so a host invocation
+# cannot touch the caller's real vault or client configuration.
+SMOKE_SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+SMOKE_REPO_ROOT=$(CDPATH= cd -- "$SMOKE_SCRIPT_DIR/../.." && pwd -P)
+SMOKE_ORIGINAL_HOME=${HOME:-}
+SMOKE_ORIGINAL_XDG_DATA_HOME=${XDG_DATA_HOME:-}
+
+# The destructive suite is supported only on an explicitly disposable runner
+# (CI or a container). Unit tests may invoke the lightweight sandbox verifier.
+if [ "${1:-}" != "--verify-sandbox" ] \
+  && [ "${OPEN_ZK_KB_EPHEMERAL_SMOKE:-}" != "1" ]; then
+  echo "REFUSING TO RUN destructive smoke tests on an unmarked host." >&2
+  echo "Run the documented Docker command instead." >&2
+  exit 1
+fi
+
+SMOKE_SANDBOX_MARKER="open-zk-kb destructive smoke-test sandbox"
+SMOKE_SANDBOX_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/open-zk-kb-smoke.XXXXXX")
+SMOKE_SANDBOX_ROOT=$(CDPATH= cd -- "$SMOKE_SANDBOX_ROOT" && pwd -P)
+
+# Refuse even temporary sandbox creation below inherited user-data roots. This
+# catches hostile or surprising TMPDIR values before the suite writes anything.
+for SMOKE_PROTECTED_ROOT in "$SMOKE_ORIGINAL_HOME" "$SMOKE_ORIGINAL_XDG_DATA_HOME"; do
+  if [ -n "$SMOKE_PROTECTED_ROOT" ] && [ -d "$SMOKE_PROTECTED_ROOT" ]; then
+    SMOKE_PROTECTED_ROOT=$(CDPATH= cd -- "$SMOKE_PROTECTED_ROOT" && pwd -P)
+    case "$SMOKE_SANDBOX_ROOT" in
+      "$SMOKE_PROTECTED_ROOT"|"$SMOKE_PROTECTED_ROOT"/*)
+        rmdir "$SMOKE_SANDBOX_ROOT"
+        echo "REFUSING TO RUN: smoke sandbox resolved inside user data: $SMOKE_PROTECTED_ROOT" >&2
+        exit 1
+        ;;
+    esac
+  fi
+done
+
+SMOKE_SANDBOX_SENTINEL="$SMOKE_SANDBOX_ROOT/.open-zk-kb-smoke-sandbox"
+chmod 700 "$SMOKE_SANDBOX_ROOT"
+printf '%s\n' "$SMOKE_SANDBOX_MARKER" > "$SMOKE_SANDBOX_SENTINEL"
+
+smoke_canonical_path() {
+  local target=$1
+  local parent base
+  if [ -d "$target" ]; then
+    (CDPATH= cd -P -- "$target" && pwd -P)
+    return
+  fi
+  parent=$(dirname -- "$target")
+  base=$(basename -- "$target")
+  parent=$(CDPATH= cd -P -- "$parent" 2>/dev/null && pwd -P) || return 1
+  printf '%s/%s\n' "$parent" "$base"
+}
+
+smoke_assert_sandbox_path() {
+  local target=$1
+  local allow_root=${2:-false}
+  local resolved
+
+  if [ ! -f "$SMOKE_SANDBOX_SENTINEL" ] \
+    || [ "$(cat "$SMOKE_SANDBOX_SENTINEL")" != "$SMOKE_SANDBOX_MARKER" ]; then
+    echo "REFUSING DELETION: smoke-test sandbox sentinel is missing or invalid" >&2
+    return 1
+  fi
+
+  resolved=$(smoke_canonical_path "$target") || {
+    echo "REFUSING DELETION: cannot resolve $target" >&2
+    return 1
+  }
+
+  if [ "$resolved" = "$SMOKE_SANDBOX_ROOT" ]; then
+    if [ "$allow_root" = "true" ]; then
+      return 0
+    fi
+    echo "REFUSING DELETION: sandbox root requires cleanup authorization" >&2
+    return 1
+  fi
+
+  case "$resolved" in
+    "$SMOKE_SANDBOX_ROOT"/*) return 0 ;;
+    *)
+      echo "REFUSING DELETION OUTSIDE SMOKE SANDBOX: $resolved" >&2
+      return 1
+      ;;
+  esac
+}
+
+smoke_rm_rf() {
+  local target
+  for target in "$@"; do
+    smoke_assert_sandbox_path "$target" || return 1
+    rm -rf -- "$target"
+  done
+}
+
+smoke_cleanup() {
+  if [ -d "$SMOKE_SANDBOX_ROOT" ]; then
+    smoke_assert_sandbox_path "$SMOKE_SANDBOX_ROOT" true || return
+    rm -rf -- "$SMOKE_SANDBOX_ROOT"
+  fi
+}
+trap smoke_cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+mkdir -p \
+  "$SMOKE_SANDBOX_ROOT/home" \
+  "$SMOKE_SANDBOX_ROOT/home/.config" \
+  "$SMOKE_SANDBOX_ROOT/home/.local/share" \
+  "$SMOKE_SANDBOX_ROOT/home/.local/state" \
+  "$SMOKE_SANDBOX_ROOT/home/.cache" \
+  "$SMOKE_SANDBOX_ROOT/runtime" \
+  "$SMOKE_SANDBOX_ROOT/tmp"
+
+export HOME="$SMOKE_SANDBOX_ROOT/home"
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_DATA_HOME="$HOME/.local/share"
+export XDG_STATE_HOME="$HOME/.local/state"
+export XDG_CACHE_HOME="$HOME/.cache"
+export XDG_RUNTIME_DIR="$SMOKE_SANDBOX_ROOT/runtime"
+export TMPDIR="$SMOKE_SANDBOX_ROOT/tmp"
+export NPM_CONFIG_CACHE="$XDG_CACHE_HOME/npm"
+export NPM_CONFIG_PREFIX="$SMOKE_SANDBOX_ROOT/npm-prefix"
+export NPM_CONFIG_USERCONFIG="$XDG_CONFIG_HOME/npm/npmrc"
+export BUN_INSTALL="$SMOKE_SANDBOX_ROOT/bun-install"
+export BUN_INSTALL_CACHE_DIR="$XDG_CACHE_HOME/bun-install"
+export GIT_CONFIG_GLOBAL="$XDG_CONFIG_HOME/git/config"
+export GIT_CONFIG_SYSTEM=/dev/null
+unset APPDATA LOCALAPPDATA
+export OPEN_ZK_KB_SMOKE_TEST=1
+export OPEN_ZK_KB_SMOKE_SANDBOX_ROOT="$SMOKE_SANDBOX_ROOT"
+
+cd "$SMOKE_REPO_ROOT"
+
+# Lightweight regression-test entry point. It proves inherited HOME/XDG values
+# are ignored and that the deletion guard rejects the original user vault.
+if [ "${1:-}" = "--verify-sandbox" ]; then
+  if [ -n "$SMOKE_ORIGINAL_HOME" ] && smoke_rm_rf "$SMOKE_ORIGINAL_HOME/.local/share/open-zk-kb" 2>/dev/null; then
+    echo "sandbox guard accepted the original vault" >&2
+    exit 1
+  fi
+  printf 'SMOKE_SANDBOX_ROOT=%s\n' "$SMOKE_SANDBOX_ROOT"
+  printf 'HOME=%s\n' "$HOME"
+  printf 'XDG_CONFIG_HOME=%s\n' "$XDG_CONFIG_HOME"
+  printf 'XDG_DATA_HOME=%s\n' "$XDG_DATA_HOME"
+  printf 'XDG_STATE_HOME=%s\n' "$XDG_STATE_HOME"
+  printf 'XDG_CACHE_HOME=%s\n' "$XDG_CACHE_HOME"
+  printf 'XDG_RUNTIME_DIR=%s\n' "$XDG_RUNTIME_DIR"
+  printf 'TMPDIR=%s\n' "$TMPDIR"
+  printf 'NPM_CONFIG_CACHE=%s\n' "$NPM_CONFIG_CACHE"
+  printf 'NPM_CONFIG_PREFIX=%s\n' "$NPM_CONFIG_PREFIX"
+  printf 'NPM_CONFIG_USERCONFIG=%s\n' "$NPM_CONFIG_USERCONFIG"
+  printf 'BUN_INSTALL=%s\n' "$BUN_INSTALL"
+  printf 'BUN_INSTALL_CACHE_DIR=%s\n' "$BUN_INSTALL_CACHE_DIR"
+  printf 'GIT_CONFIG_GLOBAL=%s\n' "$GIT_CONFIG_GLOBAL"
+  exit 0
+fi
+
 PASS=0
 FAIL=0
 TESTS=()
@@ -105,7 +263,7 @@ for CLIENT in opencode claude-code cursor windsurf; do
 done
 
 # Verify vault directory was created (shared across all clients)
-VAULT_PATH="$HOME/.local/share/open-zk-kb"
+VAULT_PATH="$XDG_DATA_HOME/open-zk-kb"
 if [ -d "$VAULT_PATH" ]; then
   pass "vault directory created"
 else
@@ -161,9 +319,9 @@ echo ""
 echo "▸ MCP Server Protocol + KB Round-Trip"
 
 # Use a clean temporary vault to avoid state pollution from previous runs
-MCP_VAULT_DIR=$(mktemp -d)
+MCP_VAULT_DIR=$(mktemp -d "$SMOKE_SANDBOX_ROOT/mcp-vault.XXXXXX")
 MCP_OUTPUT=$(XDG_DATA_HOME="$MCP_VAULT_DIR" timeout 20 bun run tests/docker/mcp-protocol-test.ts 2>/dev/null || true)
-rm -rf "$MCP_VAULT_DIR"
+smoke_rm_rf "$MCP_VAULT_DIR"
 echo "$MCP_OUTPUT" | grep -E "^  [✅❌]" || true
 
 MCP_RESULT=$(echo "$MCP_OUTPUT" | grep "MCP_RESULT" || echo "MCP_RESULT:0:4")
@@ -338,6 +496,7 @@ echo "▸ README JSON Validation"
 BLOCK_COUNT=0
 BLOCK_VALID=0
 
+JSON_CHECK_PATH="$TMPDIR/json-check.txt"
 bun -e "
   const fs = require('fs');
   const readme = fs.readFileSync('README.md', 'utf-8');
@@ -347,10 +506,10 @@ bun -e "
     try { JSON.parse(block); valid++; } catch {}
   }
   console.log(blocks.length + ':' + valid);
-" 2>/dev/null > /tmp/json-check.txt || echo "0:0" > /tmp/json-check.txt
+" 2>/dev/null > "$JSON_CHECK_PATH" || echo "0:0" > "$JSON_CHECK_PATH"
 
-BLOCK_COUNT=$(cut -d: -f1 /tmp/json-check.txt)
-BLOCK_VALID=$(cut -d: -f2 /tmp/json-check.txt)
+BLOCK_COUNT=$(cut -d: -f1 "$JSON_CHECK_PATH")
+BLOCK_VALID=$(cut -d: -f2 "$JSON_CHECK_PATH")
 
 if [ "$BLOCK_COUNT" -eq 0 ]; then
   pass "README has no JSON blocks (none to validate)"
@@ -364,7 +523,7 @@ echo ""
 # ─── 16. MCP server works without pre-existing vault ───
 echo "▸ MCP Server Fresh Start (no vault)"
 
-rm -rf "$VAULT_PATH"
+smoke_rm_rf "$VAULT_PATH"
 
 FRESH_OUTPUT=$(timeout 15 bun run tests/docker/mcp-protocol-test.ts 2>/dev/null || true)
 if echo "$FRESH_OUTPUT" | grep -q "knowledge-store creates note"; then
@@ -391,7 +550,7 @@ for CLIENT in opencode claude-code cursor windsurf; do
   bun run src/setup.ts uninstall --client "$CLIENT" >/dev/null 2>&1 || true
 done
 
-rm -rf "$VAULT_PATH"
+smoke_rm_rf "$VAULT_PATH"
 mkdir -p "$VAULT_PATH/.index"
 
 cat > "$VAULT_PATH/202501011200-existing-decision.md" << 'NOTE'
@@ -477,14 +636,24 @@ echo ""
 # ─── 18. npm pack produces valid package ───
 echo "▸ npm pack Validation"
 
-# Strip patchedDependencies before packing — it's a dev-only Bun feature
-# that breaks consumers when included in the published tarball.
-node -e "const p=JSON.parse(require('fs').readFileSync('package.json','utf8')); delete p.patchedDependencies; require('fs').writeFileSync('package.json', JSON.stringify(p,null,2)+'\n');"
-(bun pm pack || npm pack) >/dev/null 2>&1 || true
-git checkout package.json 2>/dev/null || true
+# Pack from a sandboxed staging copy. Never rewrite package.json or create
+# tarballs in the developer's working tree.
+PACK_SOURCE="$SMOKE_SANDBOX_ROOT/package-source"
+PACK_OUTPUT_DIR="$SMOKE_SANDBOX_ROOT/package-output"
+mkdir -p "$PACK_SOURCE" "$PACK_OUTPUT_DIR"
+for SOURCE in package.json README.md LICENSE CHANGELOG.md server.json llms.txt dist patches skills skill-templates templates assets docs; do
+  if [ -e "$SOURCE" ]; then
+    cp -R "$SOURCE" "$PACK_SOURCE/"
+  fi
+done
+node -e "const fs=require('fs'); const f=process.argv[1]; const p=JSON.parse(fs.readFileSync(f,'utf8')); delete p.patchedDependencies; fs.writeFileSync(f, JSON.stringify(p,null,2)+'\n');" "$PACK_SOURCE/package.json"
+(
+  cd "$PACK_SOURCE"
+  bun pm pack --destination "$PACK_OUTPUT_DIR" || npm pack --pack-destination "$PACK_OUTPUT_DIR"
+) >/dev/null 2>&1 || true
 shopt -s nullglob
 TARBALL=""
-for CANDIDATE in open-zk-kb-*.tgz; do
+for CANDIDATE in "$PACK_OUTPUT_DIR"/open-zk-kb-*.tgz; do
   if [ -z "$TARBALL" ] || [ "$CANDIDATE" -nt "$TARBALL" ]; then
     TARBALL="$CANDIDATE"
   fi
@@ -504,14 +673,15 @@ if [ -n "$TARBALL" ] && [ -f "$TARBALL" ]; then
     fi
   done
 
-  PACK_DIR=$(mktemp -d)
+  PACK_DIR=$(mktemp -d "$SMOKE_SANDBOX_ROOT/package-install.XXXXXX")
   mkdir -p "$PACK_DIR/test-install"
-  cp "$TARBALL" "$PACK_DIR/test-install/"
+  TARBALL_NAME=$(basename "$TARBALL")
+  cp "$TARBALL" "$PACK_DIR/test-install/$TARBALL_NAME"
 
   INSTALL_STATUS=0
   INSTALL_OUTPUT=$(
     cd "$PACK_DIR/test-install" &&
-    echo '{"dependencies":{"open-zk-kb":"file:./'"$TARBALL"'"}}' > package.json &&
+    echo '{"dependencies":{"open-zk-kb":"file:./'"$TARBALL_NAME"'"}}' > package.json &&
     bun install 2>&1
   ) || INSTALL_STATUS=$?
 
@@ -526,7 +696,7 @@ if [ -n "$TARBALL" ] && [ -f "$TARBALL" ]; then
     fail "package install" "$(echo "$INSTALL_OUTPUT" | head -5)"
   fi
 
-  rm -rf "$PACK_DIR"
+  smoke_rm_rf "$PACK_DIR"
   rm -f "$TARBALL"
 else
   fail "npm pack" "no tarball created"

--- a/tests/docker/smoke-test.sh
+++ b/tests/docker/smoke-test.sh
@@ -133,6 +133,32 @@ unset APPDATA LOCALAPPDATA
 export OPEN_ZK_KB_SMOKE_TEST=1
 export OPEN_ZK_KB_SMOKE_SANDBOX_ROOT="$SMOKE_SANDBOX_ROOT"
 
+# CI may restore the immutable model files outside the disposable smoke root.
+# Copy only that explicitly provided model directory into the private cache;
+# model execution continues to read and write exclusively inside the sandbox.
+SMOKE_MODEL_CACHE_TARGET="$XDG_CACHE_HOME/open-zk-kb/models/Xenova/all-MiniLM-L6-v2"
+SMOKE_MODEL_CACHE_SEEDED=false
+if [ -n "${OPEN_ZK_KB_MODEL_CACHE_SEED:-}" ]; then
+  case "$OPEN_ZK_KB_MODEL_CACHE_SEED" in
+    */all-MiniLM-L6-v2) ;;
+    *)
+      echo "REFUSING MODEL CACHE SEED: expected all-MiniLM-L6-v2 directory" >&2
+      exit 1
+      ;;
+  esac
+  if [ ! -d "$OPEN_ZK_KB_MODEL_CACHE_SEED" ] || [ -L "$OPEN_ZK_KB_MODEL_CACHE_SEED" ]; then
+    echo "REFUSING MODEL CACHE SEED: source is missing or symlinked" >&2
+    exit 1
+  fi
+  if find "$OPEN_ZK_KB_MODEL_CACHE_SEED" -type l -print -quit | grep -q .; then
+    echo "REFUSING MODEL CACHE SEED: source contains symlinks" >&2
+    exit 1
+  fi
+  mkdir -p "$SMOKE_MODEL_CACHE_TARGET"
+  cp -R "$OPEN_ZK_KB_MODEL_CACHE_SEED"/. "$SMOKE_MODEL_CACHE_TARGET"/
+  SMOKE_MODEL_CACHE_SEEDED=true
+fi
+
 cd "$SMOKE_REPO_ROOT"
 
 # Lightweight regression-test entry point. It proves inherited HOME/XDG values
@@ -156,6 +182,8 @@ if [ "${1:-}" = "--verify-sandbox" ]; then
   printf 'BUN_INSTALL=%s\n' "$BUN_INSTALL"
   printf 'BUN_INSTALL_CACHE_DIR=%s\n' "$BUN_INSTALL_CACHE_DIR"
   printf 'GIT_CONFIG_GLOBAL=%s\n' "$GIT_CONFIG_GLOBAL"
+  printf 'MODEL_CACHE_DIR=%s\n' "$SMOKE_MODEL_CACHE_TARGET"
+  printf 'MODEL_CACHE_SEEDED=%s\n' "$SMOKE_MODEL_CACHE_SEEDED"
   exit 0
 fi
 

--- a/tests/injection-quality-test.ts
+++ b/tests/injection-quality-test.ts
@@ -11,6 +11,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 
 function text(result: unknown): string {
   const r = result as { content?: Array<{ type: string; text: string }> };
@@ -18,7 +19,7 @@ function text(result: unknown): string {
 }
 
 async function run() {
-  const tmpDir = fs.mkdtempSync('/tmp/injection-test-');
+  const tmpDir = fs.mkdtempSync(path.join(process.env.TMPDIR || os.tmpdir(), 'injection-test-'));
 
   const transport = new StdioClientTransport({
     command: 'bun',

--- a/tests/smoke-safety.test.ts
+++ b/tests/smoke-safety.test.ts
@@ -85,6 +85,49 @@ describe('destructive smoke-test safety', () => {
     }
   });
 
+  it('seeds the model cache only inside the private sandbox', () => {
+    const fixtureRoot = createTempDir('kb-smoke-model-cache-');
+    const fakeRealHome = path.join(fixtureRoot, 'real-home');
+    const tempParent = path.join(fixtureRoot, 'temp-parent');
+    const seedDir = path.join(fixtureRoot, 'cache-seed', 'all-MiniLM-L6-v2');
+    const seedMarker = path.join(seedDir, 'model.json');
+    fs.mkdirSync(fakeRealHome, { recursive: true });
+    fs.mkdirSync(tempParent, { recursive: true });
+    fs.mkdirSync(seedDir, { recursive: true });
+    fs.writeFileSync(seedMarker, '{"model":"fixture"}');
+
+    const result = Bun.spawnSync(['bash', smokeScript, '--verify-sandbox'], {
+      env: {
+        ...process.env,
+        HOME: fakeRealHome,
+        TMPDIR: tempParent,
+        OPEN_ZK_KB_MODEL_CACHE_SEED: seedDir,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(fs.readFileSync(seedMarker, 'utf8')).toBe('{"model":"fixture"}');
+    const values = parseKeyValues(result.stdout.toString());
+    expect(values.MODEL_CACHE_SEEDED).toBe('true');
+    expect(values.MODEL_CACHE_DIR).toStartWith(`${values.SMOKE_SANDBOX_ROOT}${path.sep}`);
+
+    fs.symlinkSync(fakeRealHome, path.join(seedDir, 'outside-link'));
+    const unsafeResult = Bun.spawnSync(['bash', smokeScript, '--verify-sandbox'], {
+      env: {
+        ...process.env,
+        HOME: fakeRealHome,
+        TMPDIR: tempParent,
+        OPEN_ZK_KB_MODEL_CACHE_SEED: seedDir,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(unsafeResult.exitCode).toBe(1);
+    expect(unsafeResult.stderr.toString()).toContain('source contains symlinks');
+  });
+
   it('refuses to run the destructive suite on an unmarked host', () => {
     const fixtureRoot = createTempDir('kb-smoke-unmarked-host-');
     const fakeRealHome = path.join(fixtureRoot, 'real-home');
@@ -140,6 +183,16 @@ describe('destructive smoke-test safety', () => {
     expect(script).not.toContain('VAULT_PATH="$HOME/.local/share/open-zk-kb"');
   });
 
+  it('uses the isolated temporary directory for model smoke fixtures', () => {
+    const modelSmokeScript = fs.readFileSync(
+      path.resolve(import.meta.dir, 'docker/model-smoke-test.ts'),
+      'utf8',
+    );
+
+    expect(modelSmokeScript).not.toContain("mkdtempSync('/tmp/");
+    expect(modelSmokeScript).toContain('process.env.TMPDIR || os.tmpdir()');
+  });
+
   it('makes setup refuse smoke-test deletion outside the marked sandbox', async () => {
     const fixtureRoot = createTempDir('kb-smoke-setup-refusal-');
     const sandboxRoot = path.join(fixtureRoot, 'sandbox');
@@ -164,8 +217,14 @@ describe('destructive smoke-test safety', () => {
     fs.writeFileSync(cursorConfig, '{"mcpServers":{"open-zk-kb":{"command":"bun"}}}');
 
     const setup = await import(`../src/setup.js?smoke-refusal=${Date.now()}-${Math.random()}`);
-    expect(() => setup.uninstall({ client: 'cursor', removeVault: true, confirm: true }))
-      .toThrow('Refusing vault deletion outside smoke-test sandbox');
+    for (const options of [
+      { client: 'cursor' as const, removeVault: true, confirm: false },
+      { client: 'cursor' as const, removeVault: true, confirm: true, dryRun: true },
+      { client: 'cursor' as const, removeVault: true, confirm: true },
+    ]) {
+      expect(() => setup.uninstall(options))
+        .toThrow('Refusing vault deletion outside smoke-test sandbox');
+    }
     expect(fs.readFileSync(marker, 'utf8')).toBe('production knowledge');
   });
 

--- a/tests/smoke-safety.test.ts
+++ b/tests/smoke-safety.test.ts
@@ -183,14 +183,36 @@ describe('destructive smoke-test safety', () => {
     expect(script).not.toContain('VAULT_PATH="$HOME/.local/share/open-zk-kb"');
   });
 
-  it('uses the isolated temporary directory for model smoke fixtures', () => {
-    const modelSmokeScript = fs.readFileSync(
-      path.resolve(import.meta.dir, 'docker/model-smoke-test.ts'),
-      'utf8',
-    );
+  it('uses the isolated temporary directory for all smoke-suite fixtures', () => {
+    for (const relativePath of [
+      'docker/model-smoke-test.ts',
+      'injection-quality-test.ts',
+      'templates.test.ts',
+    ]) {
+      const source = fs.readFileSync(path.resolve(import.meta.dir, relativePath), 'utf8');
+      expect(source).toContain('process.env.TMPDIR || os.tmpdir()');
+    }
 
-    expect(modelSmokeScript).not.toContain("mkdtempSync('/tmp/");
-    expect(modelSmokeScript).toContain('process.env.TMPDIR || os.tmpdir()');
+    const pendingDirs = [import.meta.dir];
+    const hardcodedTempPrefix = /mkdtempSync\(\s*['"]\/tmp\//;
+    const violations: string[] = [];
+    while (pendingDirs.length > 0) {
+      const currentDir = pendingDirs.pop();
+      if (!currentDir) break;
+      for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+        const entryPath = path.join(currentDir, entry.name);
+        if (entry.isDirectory()) {
+          pendingDirs.push(entryPath);
+        } else if (entry.name.endsWith('.ts')) {
+          const source = fs.readFileSync(entryPath, 'utf8');
+          if (hardcodedTempPrefix.test(source)) {
+            violations.push(path.relative(import.meta.dir, entryPath));
+          }
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
   });
 
   it('requires TLS verification for model downloads', () => {

--- a/tests/smoke-safety.test.ts
+++ b/tests/smoke-safety.test.ts
@@ -193,6 +193,17 @@ describe('destructive smoke-test safety', () => {
     expect(modelSmokeScript).toContain('process.env.TMPDIR || os.tmpdir()');
   });
 
+  it('requires TLS verification for model downloads', () => {
+    for (const relativePath of [
+      '../.github/workflows/ci.yml',
+      'docker/Dockerfile',
+      'docker/smoke-test.sh',
+    ]) {
+      const source = fs.readFileSync(path.resolve(import.meta.dir, relativePath), 'utf8');
+      expect(source).not.toContain('NODE_TLS_REJECT_UNAUTHORIZED');
+    }
+  });
+
   it('makes setup refuse smoke-test deletion outside the marked sandbox', async () => {
     const fixtureRoot = createTempDir('kb-smoke-setup-refusal-');
     const sandboxRoot = path.join(fixtureRoot, 'sandbox');

--- a/tests/smoke-safety.test.ts
+++ b/tests/smoke-safety.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const smokeScript = path.resolve(import.meta.dir, 'docker/smoke-test.sh');
+const tempDirs: string[] = [];
+const originalEnv = {
+  HOME: process.env.HOME,
+  TMPDIR: process.env.TMPDIR,
+  XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+  XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+  XDG_STATE_HOME: process.env.XDG_STATE_HOME,
+  XDG_CACHE_HOME: process.env.XDG_CACHE_HOME,
+  XDG_RUNTIME_DIR: process.env.XDG_RUNTIME_DIR,
+  OPEN_ZK_KB_SMOKE_TEST: process.env.OPEN_ZK_KB_SMOKE_TEST,
+  OPEN_ZK_KB_SMOKE_SANDBOX_ROOT: process.env.OPEN_ZK_KB_SMOKE_SANDBOX_ROOT,
+};
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function parseKeyValues(output: string): Record<string, string> {
+  return Object.fromEntries(
+    output.trim().split('\n').map((line) => {
+      const separator = line.indexOf('=');
+      return [line.slice(0, separator), line.slice(separator + 1)];
+    }),
+  );
+}
+
+describe('destructive smoke-test safety', () => {
+  it('replaces inherited HOME and XDG paths before any destructive operation', () => {
+    const fixtureRoot = createTempDir('kb-smoke-host-');
+    const fakeRealHome = path.join(fixtureRoot, 'real-home');
+    const fakeRealVault = path.join(fakeRealHome, '.local', 'share', 'open-zk-kb');
+    const tempParent = path.join(fixtureRoot, 'temp-parent');
+    const marker = path.join(fakeRealVault, 'must-survive.md');
+    fs.mkdirSync(fakeRealVault, { recursive: true });
+    fs.mkdirSync(tempParent, { recursive: true });
+    fs.writeFileSync(marker, 'production knowledge');
+
+    const result = Bun.spawnSync(['bash', smokeScript, '--verify-sandbox'], {
+      env: {
+        ...process.env,
+        HOME: fakeRealHome,
+        TMPDIR: tempParent,
+        XDG_CONFIG_HOME: path.join(fakeRealHome, 'real-config'),
+        XDG_DATA_HOME: path.join(fakeRealHome, 'real-data'),
+        XDG_STATE_HOME: path.join(fakeRealHome, 'real-state'),
+        XDG_CACHE_HOME: path.join(fakeRealHome, 'real-cache'),
+        XDG_RUNTIME_DIR: path.join(fakeRealHome, 'real-runtime'),
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(fs.readFileSync(marker, 'utf8')).toBe('production knowledge');
+
+    const values = parseKeyValues(result.stdout.toString());
+    const sandboxRoot = values.SMOKE_SANDBOX_ROOT;
+    expect(sandboxRoot).toStartWith(`${fs.realpathSync(tempParent)}${path.sep}`);
+    for (const key of [
+      'HOME', 'XDG_CONFIG_HOME', 'XDG_DATA_HOME', 'XDG_STATE_HOME',
+      'XDG_CACHE_HOME', 'XDG_RUNTIME_DIR', 'TMPDIR', 'NPM_CONFIG_CACHE',
+      'NPM_CONFIG_PREFIX', 'NPM_CONFIG_USERCONFIG', 'BUN_INSTALL',
+      'BUN_INSTALL_CACHE_DIR', 'GIT_CONFIG_GLOBAL',
+    ]) {
+      expect(values[key]).toStartWith(`${sandboxRoot}${path.sep}`);
+      expect(values[key]).not.toStartWith(`${fs.realpathSync(fakeRealHome)}${path.sep}`);
+    }
+  });
+
+  it('refuses to run the destructive suite on an unmarked host', () => {
+    const fixtureRoot = createTempDir('kb-smoke-unmarked-host-');
+    const fakeRealHome = path.join(fixtureRoot, 'real-home');
+    const fakeRealVault = path.join(fakeRealHome, '.local', 'share', 'open-zk-kb');
+    const marker = path.join(fakeRealVault, 'must-survive.md');
+    fs.mkdirSync(fakeRealVault, { recursive: true });
+    fs.writeFileSync(marker, 'production knowledge');
+
+    const env = { ...process.env, HOME: fakeRealHome };
+    delete env.OPEN_ZK_KB_EPHEMERAL_SMOKE;
+    const result = Bun.spawnSync(['bash', smokeScript], {
+      env,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain('REFUSING TO RUN destructive smoke tests');
+    expect(fs.readFileSync(marker, 'utf8')).toBe('production knowledge');
+  });
+
+  it('refuses an inherited temporary directory inside the real home', () => {
+    const fixtureRoot = createTempDir('kb-smoke-hostile-tmp-');
+    const fakeRealHome = path.join(fixtureRoot, 'real-home');
+    const fakeRealVault = path.join(fakeRealHome, '.local', 'share', 'open-zk-kb');
+    const hostileTemp = path.join(fakeRealHome, 'tmp');
+    const marker = path.join(fakeRealVault, 'must-survive.md');
+    fs.mkdirSync(fakeRealVault, { recursive: true });
+    fs.mkdirSync(hostileTemp, { recursive: true });
+    fs.writeFileSync(marker, 'production knowledge');
+
+    const result = Bun.spawnSync(['bash', smokeScript, '--verify-sandbox'], {
+      env: { ...process.env, HOME: fakeRealHome, TMPDIR: hostileTemp },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain('smoke sandbox resolved inside user data');
+    expect(fs.readFileSync(marker, 'utf8')).toBe('production knowledge');
+    expect(fs.readdirSync(hostileTemp)).toEqual([]);
+  });
+
+  it('routes every recursive deletion through the sandbox guard', () => {
+    const script = fs.readFileSync(smokeScript, 'utf8');
+    const recursiveDeletes = script.split('\n').filter((line) => /\brm -rf\b/.test(line));
+
+    expect(recursiveDeletes).toEqual([
+      '    rm -rf -- "$target"',
+      '    rm -rf -- "$SMOKE_SANDBOX_ROOT"',
+    ]);
+    expect(script).not.toContain('git checkout package.json');
+    expect(script).not.toContain('VAULT_PATH="$HOME/.local/share/open-zk-kb"');
+  });
+
+  it('makes setup refuse smoke-test deletion outside the marked sandbox', async () => {
+    const fixtureRoot = createTempDir('kb-smoke-setup-refusal-');
+    const sandboxRoot = path.join(fixtureRoot, 'sandbox');
+    const outsideDataHome = path.join(fixtureRoot, 'outside-data');
+    const outsideVault = path.join(outsideDataHome, 'open-zk-kb');
+    const marker = path.join(outsideVault, 'must-survive.md');
+    fs.mkdirSync(sandboxRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(sandboxRoot, '.open-zk-kb-smoke-sandbox'),
+      'open-zk-kb destructive smoke-test sandbox',
+    );
+    fs.mkdirSync(outsideVault, { recursive: true });
+    fs.writeFileSync(marker, 'production knowledge');
+
+    process.env.HOME = path.join(fixtureRoot, 'home');
+    process.env.XDG_CONFIG_HOME = path.join(fixtureRoot, 'config');
+    process.env.XDG_DATA_HOME = outsideDataHome;
+    process.env.OPEN_ZK_KB_SMOKE_TEST = '1';
+    process.env.OPEN_ZK_KB_SMOKE_SANDBOX_ROOT = sandboxRoot;
+    const cursorConfig = path.join(process.env.HOME, '.cursor', 'mcp.json');
+    fs.mkdirSync(path.dirname(cursorConfig), { recursive: true });
+    fs.writeFileSync(cursorConfig, '{"mcpServers":{"open-zk-kb":{"command":"bun"}}}');
+
+    const setup = await import(`../src/setup.js?smoke-refusal=${Date.now()}-${Math.random()}`);
+    expect(() => setup.uninstall({ client: 'cursor', removeVault: true, confirm: true }))
+      .toThrow('Refusing vault deletion outside smoke-test sandbox');
+    expect(fs.readFileSync(marker, 'utf8')).toBe('production knowledge');
+  });
+
+  it('allows setup to delete only a vault inside the marked sandbox', async () => {
+    const sandboxRoot = createTempDir('kb-smoke-setup-allowed-');
+    const dataHome = path.join(sandboxRoot, 'home', '.local', 'share');
+    const vault = path.join(dataHome, 'open-zk-kb');
+    fs.mkdirSync(vault, { recursive: true });
+    fs.writeFileSync(
+      path.join(sandboxRoot, '.open-zk-kb-smoke-sandbox'),
+      'open-zk-kb destructive smoke-test sandbox',
+    );
+    fs.writeFileSync(path.join(vault, 'fixture.md'), 'test knowledge');
+
+    process.env.HOME = path.join(sandboxRoot, 'home');
+    process.env.XDG_CONFIG_HOME = path.join(sandboxRoot, 'home', '.config');
+    process.env.XDG_DATA_HOME = dataHome;
+    process.env.OPEN_ZK_KB_SMOKE_TEST = '1';
+    process.env.OPEN_ZK_KB_SMOKE_SANDBOX_ROOT = sandboxRoot;
+    const cursorConfig = path.join(process.env.HOME, '.cursor', 'mcp.json');
+    fs.mkdirSync(path.dirname(cursorConfig), { recursive: true });
+    fs.writeFileSync(cursorConfig, '{"mcpServers":{"open-zk-kb":{"command":"bun"}}}');
+
+    const setup = await import(`../src/setup.js?smoke-allowed=${Date.now()}-${Math.random()}`);
+    setup.uninstall({ client: 'cursor', removeVault: true, confirm: true });
+    expect(fs.existsSync(vault)).toBe(false);
+  });
+});

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import { handleStore, handleTemplate, handleHealth } from '../src/tool-handlers.js';
 import { cleanupTestHarness, createTestHarness, sleep, type TestContext } from './harness.js';
 import {
@@ -53,7 +54,7 @@ describe('getTemplate', () => {
   });
 
   it('returns project override when path exists', () => {
-    const tmpDir = fs.mkdtempSync('/tmp/tpl-test-');
+    const tmpDir = fs.mkdtempSync(path.join(process.env.TMPDIR || os.tmpdir(), 'tpl-test-'));
     const overridePath = path.join(tmpDir, 'decision.md');
     fs.writeFileSync(overridePath, '## Custom Decision Template\n');
 


### PR DESCRIPTION
## Summary

- refuse destructive smoke-suite execution on unmarked hosts
- isolate HOME, XDG, temporary, npm, Bun, and Git paths in a private sentinel-marked sandbox
- guard recursive deletion with canonical containment checks and add an independent setup-layer vault-deletion backstop
- stage package packing inside the sandbox instead of modifying the working tree
- update CI, Docker, contributor guidance, and regression coverage for destructive-test safety

## Motivation

The documented smoke command could be run directly on a host, inherit the caller's real `HOME`, and recursively delete the live knowledge vault while exercising uninstall and fresh-start behavior. This change makes a disposable runner the supported execution boundary and retains layered defenses inside it.

## Testing

- `bun run build`
- `bun run typecheck`
- `bun run lint` (zero errors; existing warnings only)
- `bash -n tests/docker/smoke-test.sh`
- `bun test tests/smoke-safety.test.ts` — 6 passed
- full canonical smoke suite — 98 passed, 0 failed
- verified the host vault file count was unchanged across the destructive suite


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

