### PR TITLE
Enforce project knowledge boundaries

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,3 +171,10 @@ Agents should treat `index` and `log` as secondary orientation surfaces, not as 
 
 ---
 For implementation details, see [src/AGENTS.md](../src/AGENTS.md) and [tests/AGENTS.md](../tests/AGENTS.md).
+
+
+## Knowledge scope boundary
+
+The repository enforces one routine visibility predicate before retrieval and ranking: current-project notes plus explicit `scope:global` notes, filtered by client applicability. Routine stored-knowledge handlers require project context and cannot escalate to full-vault access by omission. Exact IDs and related links use the same boundary. Routine writes are project-local.
+
+Maintenance is the administrative, full-vault boundary for cross-project review, dedupe, rebuild, formatting, embedding repair, scope and link audits, migration, and global publication. Publication creates a project-agnostic global derivative after preview and confirmation while preserving one-way provenance on the local source. This keeps the ownership model intact: **Server Computes, Agent Judges**—the server calculates deterministic scope and duplicate evidence; the agent interprets it and obtains confirmation.

--- a/docs/note-lifecycle.md
+++ b/docs/note-lifecycle.md
@@ -42,7 +42,7 @@ When a note is created, its `kind` determines its initial `status`. Some kinds a
 Because personalization notes default to permanent and may be exempt from review, apply the **durability test within the declared scope**: a project- or client-scoped preference must remain useful in future work within that scope after the current task and transient implementation, configuration, or subscription changes. A universal preference must also remain broadly useful across projects and clients.
 
 Applicability uses existing tags:
-- No `project:*` or `client:*` tags means universal.
+- `scope:global` means explicitly global; absence of a project scope is unclassified, not universal.
 - `project:<name>` means the preference applies to that project.
 - `client:<name>` means it applies to that client or harness.
 - Both tag families may be present when both constraints apply.
@@ -103,3 +103,10 @@ lifecycle:
 ```
 
 For a full list of configuration options, see the [Configuration Reference](configuration.md). The review system is exposed through the [`knowledge-maintain` tool](tools-reference.md#knowledge-maintain).
+
+
+## Applicability and publication lifecycle
+
+Every active content note is either project-local (exactly one `project:<name>` and no `scope:global`) or explicitly global (`scope:global` and no project tag). Conflicting or missing scope is unclassified and excluded from routine agent operations. Client tags remain an additional applicability filter. Routine capture always starts project-local.
+
+Global knowledge is a new, one-way derivative rather than a promotion or re-scope of its source. Through full-vault maintenance, an agent authors project-agnostic prose, previews `publish-global`, presents the server-computed evidence for human judgment, and applies it only after confirmation. The local source and its semantic fields remain intact and gain the outgoing relationship; the global derivative records no source project or reverse provenance. Legacy unclassified notes enter maintenance inventory for explicit project assignment or a separately distilled publication—never automatic global classification.

--- a/docs/obsidian.md
+++ b/docs/obsidian.md
@@ -28,7 +28,7 @@ The vault opens to a **Home** page showing:
 
 - Total note and project counts
 - Project table with note counts and last-active dates
-- Links to General Knowledge, Preferences, Review queue, and Operations Log
+- Links to confirmed Global Knowledge, Preferences, Review queue, and Operations Log
 
 ### Breadcrumb Navigation
 
@@ -69,7 +69,7 @@ Dataview tables on navigation pages include action buttons for each note:
 | pencil | Edit via QuickAdd |
 | trash | Delete (with confirmation) |
 | check-circle | Promote to permanent (review page only) |
-| + | Add new note of that kind (section headers) |
+| + | Add a project-local note of that kind (project section headers only) |
 
 ### Review Queue
 
@@ -84,7 +84,7 @@ The scaffold installs and configures 14 community plugins, plus the Border theme
 | [Dataview](https://github.com/blacksmithgu/obsidian-dataview) | Dynamic tables and lists on navigation pages |
 | [Breadcrumbs](https://github.com/SkepticMystic/breadcrumbs) | Hierarchical breadcrumb trails |
 | [Homepage](https://github.com/mirnovov/obsidian-homepage) | Opens Home on launch |
-| [QuickAdd](https://github.com/chhoumann/quickadd) | Templated note creation and editing |
+| [QuickAdd](https://github.com/chhoumann/quickadd) | Templated project-local note creation and editing |
 | [Templater](https://github.com/SilentVoid13/Templater) | Template engine for QuickAdd |
 | [Commander](https://github.com/phibr0/obsidian-commander) | Ribbon and page-header button management |
 | [Style Settings](https://github.com/mgmeyers/obsidian-style-settings) | Theme configuration (card layout) |

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -12,7 +12,7 @@ Bun remains required for the local MCP server and SQLite storage. Restart Pi aft
 
 ## Automatic Project Preferences
 
-When a Pi session starts, the extension derives the canonical project from the current working-directory basename and loads permanent preferences through `knowledge-context`. It supplies that project and `client: "pi"` on every routine stored-knowledge call it initiates; caller-supplied values cannot widen the boundary. The preference capsule enters model context through the system prompt, so it is available before the model responds and does not require a model-initiated `knowledge-search` call.
+When a Pi session starts, the extension derives the canonical project from the current working-directory basename and loads permanent preferences through `knowledge-context`. It supplies that project and `client: "pi"` on every routine stored-knowledge call it initiates; caller-supplied values cannot widen the boundary. Before session initialization establishes a canonical project, it removes any model-provided project and still supplies `client: "pi"`, so project-required calls fail closed at server validation. The preference capsule enters model context through the system prompt, so it is available before the model responds and does not require a model-initiated `knowledge-search` call.
 
 Pi separately displays an honest, deduplicated session entry:
 

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -12,7 +12,7 @@ Bun remains required for the local MCP server and SQLite storage. Restart Pi aft
 
 ## Automatic Project Preferences
 
-When a Pi session starts, the extension loads permanent preferences for the current project through `knowledge-context`. The preference capsule enters model context through the system prompt, so it is available before the model responds and does not require a model-initiated `knowledge-search` call.
+When a Pi session starts, the extension derives the canonical project from the current working-directory basename and loads permanent preferences through `knowledge-context`. It supplies that project and `client: "pi"` on every routine stored-knowledge call it initiates; caller-supplied values cannot widen the boundary. The preference capsule enters model context through the system prompt, so it is available before the model responds and does not require a model-initiated `knowledge-search` call.
 
 Pi separately displays an honest, deduplicated session entry:
 
@@ -66,3 +66,8 @@ The package registers all ten `knowledge-*` tools directly in Pi:
 Pi retains its native tool header and interaction shell. open-zk-kb supplies only knowledge-specific result content, with compact collapsed states and expanded detail where useful. Malformed responses and server errors fall back to complete raw output instead of hiding diagnostic information.
 
 For installation and troubleshooting, see the [Setup Guide](setup-guide.md#pi-installation). For tool parameters and response behavior, see the [Tools Reference](tools-reference.md).
+
+
+## Project boundaries
+
+Pi routine searches, exact-ID retrieval, context, health note metrics, stores, and mining operate on the current project plus explicitly global notes. Stores and mined notes remain project-local; normal calls cannot create global or unclassified notes. Maintenance remains full-vault and does not receive an implicit project restriction from the extension. Use maintenance to inventory legacy unclassified notes and to preview `publish-global`; show the evidence and obtain explicit confirmation before creating a project-agnostic derivative.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -178,6 +178,12 @@ server:
    - `knowledge-get` -- fetch a specific note by id
    - `knowledge-open` -- open the vault in Obsidian for visual browsing (see [Obsidian Guide](obsidian.md))
 
+## Initialize project-scoped use
+
+Configure each client or its agent instructions to pass the canonical current working-directory basename as `project` on every routine stored-knowledge call and its client identifier as `client`. Routine searches then see only that project's notes and explicitly global notes; routine capture always creates project-local notes. Do not configure normal global stores or omit project to request vault-wide behavior. Pi supplies its canonical project and `client: "pi"` automatically.
+
+When upgrading an existing vault, run the full-vault maintenance legacy-scope inventory first. Notes without exactly one project tag or `scope:global` are unclassified and hidden from routine calls. Explicitly assign local notes to a project. For reusable knowledge, first establish a local source, author a project-agnostic derivative, preview `publish-global`, inspect the server-computed evidence, and confirm before applying. Maintenance—not routine calls—owns full-vault review, migration, and publication.
+
 ## Agent Instructions
 
 During installation, open-zk-kb delivers knowledge base instructions to clients that support it. These instructions teach your agent when to search, what to store, and how to keep memory useful across sessions. The delivery mechanism varies by client:

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -271,7 +271,8 @@ Standalone tool for vault health metrics, staleness distribution, growth rates, 
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `project` | string | No | Scope metrics to a specific project |
+| `project` | string | Yes | Current project whose visible note metrics are requested |
+| `client` | string | No | Client applicability filter for note counts, links, embeddings, staleness, and growth |
 | `period` | string | No | Time window for growth rates: `"7d"`, `"30d"`, or `"90d"` (default: `"30d"`) |
 | `telemetry` | boolean | No | Include 30-day local-only tool invocation aggregates |
 | `model` | string | No | Your model identifier. Enables richer responses for capable models |
@@ -290,14 +291,14 @@ Standalone tool for vault health metrics, staleness distribution, growth rates, 
 ### Example
 
 ```json
-{ "project": "my-app", "period": "7d", "telemetry": true }
+{ "project": "my-app", "client": "pi", "period": "7d", "telemetry": true }
 ```
 
 ---
 
 ## knowledge-context
 
-Get the context visible to a required current project: project-local notes plus automatically visible explicit global knowledge, restricted by compatible client scope. Use at the start of a session to orient yourself.
+Get the context visible to a required current project: project-local notes plus automatically visible explicit global knowledge, restricted by compatible client scope. Use at the start of a session to orient yourself. When `client` is supplied, the shared project log is omitted because historical log entries do not carry enough scope metadata to filter safely.
 
 The Pi extension also requests a compact project preference capsule from this tool when a session starts. It injects the capsule through the system prompt and displays a separate, deduplicated TUI entry; the model does not need to initiate a search. See the [Pi Experience](pi.md#automatic-project-preferences).
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -297,7 +297,7 @@ Standalone tool for vault health metrics, staleness distribution, growth rates, 
 
 ## knowledge-context
 
-Get a global or project-scoped overview with a computed inventory of notes, recent activity, and resources. Use at the start of a session to orient yourself.
+Get the context visible to a required current project: project-local notes plus automatically visible explicit global knowledge, restricted by compatible client scope. Use at the start of a session to orient yourself.
 
 The Pi extension also requests a compact project preference capsule from this tool when a session starts. It injects the capsule through the system prompt and displays a separate, deduplicated TUI entry; the model does not need to initiate a search. See the [Pi Experience](pi.md#automatic-project-preferences).
 
@@ -305,24 +305,15 @@ The Pi extension also requests a compact project preference capsule from this to
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `project` | string | No | Project name. Omit for a global overview across all projects |
+| `project` | string | Yes | Current project whose visible context is requested |
 | `logEntries` | number | No | Number of recent log entries to include (default: 10) |
 | `includePreferences` | boolean | No | Include a compact capsule of matching permanent personalization notes |
 | `client` | string | No | Client identifier used to include matching client-scoped preferences |
 | `model` | string | No | Your model identifier. Enables richer responses for capable models |
 
-### Global overview (no `project`)
+### Project context
 
-Returns a high-level view across the entire vault:
-
-- List of all projects
-- Global inventory — note counts by kind
-- Recent notes across all projects
-- Resources
-
-### Project overview (`project` provided)
-
-Returns a focused view of a single project:
+Returns a focused view of the required current project together with explicit global notes that are automatically visible; no separate global request flag is needed:
 
 - **Domain note** — the project's domain note content (if one exists)
 - **Inventory by kind** — note counts broken down by kind for the project
@@ -346,6 +337,8 @@ Retrieve a single note by its exact ID. Faster and more precise than knowledge-s
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `noteId` | string | Yes | Exact note ID to retrieve |
+| `project` | string | Yes | Current project used to validate note visibility |
+| `client` | string | No | Optional client applicability filter |
 | `model` | string | No | Your model identifier. Enables richer responses for capable models |
 
 ### What happens
@@ -363,7 +356,7 @@ Retrieve a single note by its exact ID. Faster and more precise than knowledge-s
 ### Example
 
 ```json
-{ "noteId": "2026030919130100" }
+{ "noteId": "2026030919130100", "project": "example-project", "client": "pi" }
 ```
 
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -9,7 +9,7 @@ open-zk-kb exposes ten MCP tools. Your agent calls these automatically based on 
 | [`knowledge-search`](#knowledge-search) | Search the knowledge base before starting work |
 | [`knowledge-maintain`](#knowledge-maintain) | Review, promote, archive, and rebuild notes |
 | [`knowledge-health`](#knowledge-health) | Vault health metrics, staleness distribution, growth rates, and infrastructure status |
-| [`knowledge-context`](#knowledge-context) | Get a global or project overview with computed inventory and recent activity |
+| [`knowledge-context`](#knowledge-context) | Get a project overview of local and explicitly global knowledge |
 | `knowledge-template` | Get the canonical note template for a specific kind |
 | `knowledge-mine` | Bulk-screen candidates from session history for duplicates and store |
 | `knowledge-open` | Open the vault in [Obsidian](obsidian.md) with a scaffolded theme, plugins, and homepage |
@@ -35,7 +35,7 @@ Store knowledge in the persistent knowledge base. One concept per note.
 | `status` | enum | No | Override default: `fleeting`, `permanent`, or `archived`. Defaults based on kind (see [Note Lifecycle](note-lifecycle.md)) |
 | `lifecycle` | enum | No | `living` (mutable), `snapshot` (immutable), or `append-only`. Defaults based on kind |
 | `tags` | string[] | No | Tags for categorization |
-| `project` | string | No | Project scope — auto-adds `project:<name>` tag |
+| `project` | string | Yes | Current project; storage adds exactly one `project:<name>` tag |
 | `client` | string | No | Client identifier (e.g. `claude-code`, `opencode`). Auto-detected from content when omitted |
 | `related` | string[] | No | IDs of related notes to link via `[[wikilinks]]` |
 | `model` | string | No | Your model identifier. Enables richer responses for capable models |
@@ -167,7 +167,7 @@ Search the knowledge base using full-text search and semantic similarity. Return
 | `kind` | enum | No | Filter by note kind |
 | `status` | enum | No | Filter by status: `fleeting`, `permanent`, or `archived` |
 | `lifecycle` | enum | No | Filter by lifecycle: `living`, `snapshot`, or `append-only` |
-| `project` | string | No | Filter by project tag |
+| `project` | string | Yes | Current project visibility boundary |
 | `client` | string | No | Your client name — excludes notes scoped to other clients |
 | `tags` | string[] | No | Filter by tags (all must match) |
 | `limit` | number | No | Max results (default 10) |
@@ -365,3 +365,12 @@ Retrieve a single note by its exact ID. Faster and more precise than knowledge-s
 ```json
 { "noteId": "2026030919130100" }
 ```
+
+
+## Project visibility and authority
+
+Routine stored-knowledge tools (`knowledge-store`, `knowledge-search`, `knowledge-get`, `knowledge-context`, `knowledge-health`, and `knowledge-mine`) require an explicit current project. They can see that project's notes plus notes tagged `scope:global`, further restricted by compatible `client:*` tags. Notes belonging to other projects and unclassified notes are excluded before ranking, limiting, duplicate checks, links, counts, and exact-ID retrieval. Missing project context fails closed; there is no routine full-vault override. Ingest, template retrieval, and human-requested `knowledge-open` remain exceptions; Obsidian is a full-vault human browsing surface.
+
+Routine storage and mining create only project-local notes with exactly one `project:*` tag. They cannot create `scope:global` notes. Global creation uses maintenance `publish-global`: the agent authors a complete project-agnostic candidate from a local source, previews scope/link/duplicate evidence and a confirmation token, shows that evidence to the user, then applies only after explicit confirmation. The source remains local and points one way to the new derivative; the global note contains no reverse project provenance. The server computes evidence; the agent judges it.
+
+Maintenance actions—including review, dedupe, rebuild, format, embedding repair, audits, link health, migration, and publication—remain explicitly full-vault and label project ownership. Legacy notes with neither exactly one project tag nor `scope:global` are unclassified and invisible to routine calls. Use maintenance's legacy scope inventory and confirmed assignment to classify them; never silently treat them as global.

--- a/skill-templates/open-zk-kb/SKILL.md
+++ b/skill-templates/open-zk-kb/SKILL.md
@@ -25,7 +25,7 @@ allowed-tools:
 
 ## Storing Knowledge
 
-Use `knowledge-store` with **one concept per note**. Include `summary` (one-line takeaway) and `guidance` (imperative instruction for future agents). If you learn multiple things, make multiple store calls — don't bundle.
+Use `knowledge-store` with **one concept per note**. Pass the canonical current project on every call; routine capture is always project-local. Include `summary` (one-line takeaway) and `guidance` (imperative instruction for future agents). If you learn multiple things, make multiple store calls — don't bundle. Never use routine store or mine calls to create global knowledge.
 For structured kinds, `knowledge-template --kind {kind}` shows full templates with examples.
 
 **Kinds** (with key sections):
@@ -94,10 +94,9 @@ Use `personalization` only for an **enduring user preference or behavioral expec
 Apply the **durability test within the declared scope** before storing: *Would this still help a future agent working in that project or client after the current task and transient implementation, subscription, or configuration change?* Universal preferences must also remain broadly useful across projects and clients. If not, use `decision`, `reference`, `domain`, or a fleeting note as appropriate.
 
 Record applicability explicitly using existing scope parameters/tags:
-- **Universal** — omit both `project` and `client`; do this only when the preference applies across projects and harnesses.
-- **Project** — pass `project` (stored as `project:<name>`).
-- **Client/harness** — pass `client` (stored as `client:<name>`).
-- A preference may have both scopes when both genuinely apply.
+- **Project** — always pass `project` on routine storage (stored as exactly one `project:<name>` tag).
+- **Client/harness** — pass `client` when applicable (stored as `client:<name>`).
+- **Global** — do not omit `project` or add `scope:global` during routine capture. Publish only a separately distilled, project-agnostic derivative through confirmed maintenance.
 
 Do **not** store these as general personalization:
 - Exact configuration state, such as `#1E1E1E`, `/Users/me/.config/app`, or `model: claude-3-5-sonnet` → `reference`, or fleeting if temporary.
@@ -112,7 +111,7 @@ Do **not** store these as general personalization:
 ✅ **Always**:
 - One concept per note — split if in doubt
 - Include both `summary` and `guidance` on every store call
-- Search before storing to avoid duplicates
+- Search before storing to avoid duplicates, passing the current project explicitly
 
 ⚠️ **Ask first**:
 - Before archiving or deleting notes you didn't create this session
@@ -123,6 +122,7 @@ Do **not** store these as general personalization:
 - Use vague titles like "Notes" or "Stuff"
 - Store sensitive data (API keys, credentials, tokens)
 - Defer storage to after task completion
+- Store global or unscoped knowledge through routine tools
 
 ### Lifecycle
 Notes have a `lifecycle` field controlling mutability. The server enforces it.
@@ -151,13 +151,17 @@ When a useful URL comes up: `knowledge-ingest` to extract, then `knowledge-store
 
 ### Project Overview
 Use `knowledge-context` at the start of a session to orient yourself:
-- `knowledge-context(project: "my-project")` — returns computed inventory (note counts by kind, recent notes, resources) and recent log entries for a project
-- `knowledge-context()` — omit `project` for a global overview across all projects
+- `knowledge-context(project: "example-project")` — returns the current project's inventory plus explicitly global notes
+- Never omit `project` on routine stored-knowledge calls; omission does not grant vault-wide access
 - Optional: `logEntries` (number, default 10) to control how many log entries are shown
 
 ### Maintenance
 
-**Metrics**: `knowledge-health` — operational metrics including health counts, embedding coverage, link health, staleness distribution, growth by kind, and infrastructure status. Parameters: `project?`, `period?` ("7d"/"30d"/"90d", default "30d"), `telemetry?`.
+Maintenance is deliberately full-vault: review, dedupe, rebuild, formatting, embedding repair, audits, migration, and publication may inspect every project and must label ownership. The server computes validation and duplicate evidence; the agent judges what it means and what action to recommend.
+
+Global publication uses `publish-global`. Author a complete project-agnostic derivative from a project-local source, run a dry-run preview, show the user the evidence, and apply only with explicit confirmation and the matching token. Publication preserves the local source and records only a local-to-global relationship; the global derivative contains no reverse project provenance. Legacy notes without exactly one project tag or `scope:global` are unclassified: inventory them in maintenance and explicitly assign them to a project or publish a distilled derivative. Never silently make them global.
+
+**Metrics**: routine `knowledge-health` requires the current project for note metrics; infrastructure and telemetry may remain vault-level and are labeled separately.
 
 **One-command maintenance**: `knowledge-maintain(action: "full")` — runs rebuild → migrate-layout → format → dedupe → embed → link-health in dependency order.
 

--- a/src/git-versioning.ts
+++ b/src/git-versioning.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { logToFile } from './logger.js';
 import type { NoteKind, VersioningConfig } from './types.js';
 
-export type OpType = 'store' | 'update' | 'archive' | 'delete' | 'promote' | 'format';
+export type OpType = 'store' | 'update' | 'archive' | 'delete' | 'promote' | 'publish-global' | 'assign-project' | 'format';
 
 export interface PendingOp {
   op: OpType;

--- a/src/knowledge-scope.ts
+++ b/src/knowledge-scope.ts
@@ -1,0 +1,23 @@
+export type KnowledgeApplicability =
+  | { type: 'project-local'; project: string }
+  | { type: 'global' }
+  | { type: 'unclassified'; reason: 'missing' | 'multiple-projects' | 'conflict' };
+
+export interface VisibilityOptions {
+  project: string;
+  client?: string;
+}
+
+export function parseKnowledgeApplicability(tags: string[]): KnowledgeApplicability {
+  const projects = tags
+    .filter(tag => tag.startsWith('project:'))
+    .map(tag => tag.slice('project:'.length))
+    .filter(project => project.length > 0);
+  const global = tags.includes('scope:global');
+
+  if (global && projects.length === 0) return { type: 'global' };
+  if (!global && projects.length === 1) return { type: 'project-local', project: projects[0] };
+  if (global && projects.length > 0) return { type: 'unclassified', reason: 'conflict' };
+  if (projects.length > 1) return { type: 'unclassified', reason: 'multiple-projects' };
+  return { type: 'unclassified', reason: 'missing' };
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -371,6 +371,7 @@ export function createMcpServer(): McpServer {
     try {
       const result = await handleHealth({
         project: args.project,
+        client: args.client,
         period: args.period,
         telemetry: args.telemetry,
         model: args.model,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -345,6 +345,8 @@ export function createMcpServer(): McpServer {
       try {
         const result = handleGet({
           noteId: args.noteId,
+          project: args.project,
+          client: args.client,
           model: args.model,
         }, await getOrCreateRepo());
         return { content: [{ type: 'text' as const, text: result }] };
@@ -414,6 +416,9 @@ export function createMcpServer(): McpServer {
           days: args.days,
           limit: args.limit,
           dryRun: args.dryRun,
+          candidate: args.candidate,
+          confirm: args.confirm,
+          token: args.token,
           model: args.model,
         }, await getOrCreateRepo(), config, getEmbeddingConfig(), PKG_VERSION, gitVersioning);
         return { content: [{ type: 'text' as const, text: result }] };

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -460,6 +460,7 @@ export function createMcpServer(): McpServer {
             project: candidate.project as string | undefined,
           })),
           project: args.project,
+          client: args.client,
           dry_run: args.dry_run,
           model: args.model,
         }, await getOrCreateRepo(), getEmbeddingConfig(), config, gitVersioning);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -412,6 +412,7 @@ export function createMcpServer(): McpServer {
         const result = await handleMaintain({
           action: args.action,
           noteId: args.noteId,
+          project: args.project,
           filter: args.filter as 'fleeting' | 'permanent' | undefined,
           days: args.days,
           limit: args.limit,

--- a/src/obsidian-scaffold.ts
+++ b/src/obsidian-scaffold.ts
@@ -4,6 +4,7 @@ import * as crypto from 'crypto';
 import { fileURLToPath } from 'url';
 import type { ObsidianConfig } from './types.js';
 import { logToFile } from './logger.js';
+import { KIND_DIR_MAP } from './storage/path-resolver.js';
 
 export interface PluginRegistryEntry {
   id: string;
@@ -646,11 +647,6 @@ function buildProjectQuickAddChoices(): Array<Record<string, unknown>> {
     { id: 'project-preference', template: 'personalization-project.md', label: 'Project Preference' },
   ];
 
-  const kindDirMap: Record<string, string> = {
-    decision: 'decisions', observation: 'observations', procedure: 'procedures',
-    reference: 'references', resource: 'resources', personalization: 'preferences',
-  };
-
   return kinds.map(({ id, template, label }) => {
     const kind = id.replace('project-', '');
     return {
@@ -665,7 +661,7 @@ function buildProjectQuickAddChoices(): Array<Record<string, unknown>> {
       },
       folder: {
         enabled: true,
-        folders: [`projects/{{VALUE:project}}/${kindDirMap[kind] || `${kind}s`}`],
+        folders: [`projects/{{VALUE:project}}/${KIND_DIR_MAP[kind] || `${kind}s`}`],
         chooseWhenCreatingNote: false,
       },
       openFile: true,
@@ -783,14 +779,7 @@ function buildPluginData(pluginId: string, config: ObsidianConfig): Record<strin
       });
       return {
         showAddCommand: false,
-        leftRibbon: [
-          {
-            id: `quickadd:choice:${deterministicId('quickadd-new-note')}`,
-            icon: 'lucide-plus-circle',
-            name: 'New Note',
-            mode: 'any',
-          },
-        ],
+        leftRibbon: [],
         pageHeader: pageHeaderButtons,
       };
     }
@@ -1234,7 +1223,6 @@ function scaffoldWorkspaceDefaults(vaultPath: string): void {
     'command-palette:Open command palette': true,
     'bases:Create new base': true,
     'homepage:Open homepage': false,
-    'cmdr:New Note': false,
     'templater-obsidian:Templater': true,
     'iconic:Open rulebook': true,
   };

--- a/src/obsidian-scaffold.ts
+++ b/src/obsidian-scaffold.ts
@@ -636,50 +636,6 @@ function expectedDigest(fileDigests: Record<string, string>, fileName: string): 
   return digest;
 }
 
-function buildQuickAddChoices(): Array<Record<string, unknown>> {
-  const kinds = [
-    { id: 'decision', kind: 'decision', template: 'decision.md', label: 'Decision — choices & tradeoffs' },
-    { id: 'observation', kind: 'observation', template: 'observation.md', label: 'Observation — things you noticed' },
-    { id: 'procedure', kind: 'procedure', template: 'procedure.md', label: 'Procedure — step-by-step workflows' },
-    { id: 'reference', kind: 'reference', template: 'reference.md', label: 'Reference — sources & excerpts' },
-    { id: 'resource', kind: 'resource', template: 'resource.md', label: 'Resource — tools & URLs' },
-    { id: 'preference', kind: 'personalization', template: 'personalization.md', label: 'Preference — personal habits' },
-    { id: 'domain', kind: 'domain', template: 'domain.md', label: 'Domain — project manual for AI' },
-  ];
-
-  const kindDirMap: Record<string, string> = {
-    decision: 'decisions', observation: 'observations', procedure: 'procedures',
-    reference: 'references', resource: 'resources', personalization: 'preferences',
-    domain: '',
-  };
-
-  return kinds.map(({ id, kind, template, label }) => ({
-    name: label,
-    id: deterministicId(`quickadd-${id}`),
-    type: 'Template',
-    command: true,
-    templatePath: `templates/obsidian/${template}`,
-    fileNameFormat: {
-      enabled: true,
-      format: kind === 'domain'
-        ? 'domain'
-        : '{{DATE:YYYYMMDDHHmmss}}00-new-note',
-    },
-    folder: {
-      enabled: true,
-      folders: [kind === 'domain' ? 'general' : `general/${kindDirMap[kind] || `${kind}s`}`],
-      chooseWhenCreatingNote: false,
-    },
-    openFile: true,
-    fileOpening: {
-      location: 'tab',
-      direction: 'vertical',
-      mode: 'source',
-      focus: true,
-    },
-  }));
-}
-
 function buildProjectQuickAddChoices(): Array<Record<string, unknown>> {
   const kinds = [
     { id: 'project-decision', template: 'decision-project.md', label: 'Project Decision' },
@@ -805,21 +761,10 @@ function buildPluginData(pluginId: string, config: ObsidianConfig): Record<strin
           },
         },
       };
-    case 'quickadd': {
-      const multiChoiceId = deterministicId('quickadd-new-note');
+    case 'quickadd':
       return {
-        choices: [
-          {
-            name: 'New Note',
-            id: multiChoiceId,
-            type: 'Multi',
-            command: true,
-            choices: buildQuickAddChoices(),
-          },
-          ...buildProjectQuickAddChoices(),
-        ],
+        choices: buildProjectQuickAddChoices(),
       };
-    }
     case 'cmdr': {
       const pageHeaderButtons: Array<Record<string, unknown>> = [];
       if (!config.readOnly) {

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -23,6 +23,14 @@ interface BridgeOptions {
 type ToolName = (typeof TOOL_DEFINITIONS)[number]['name'];
 
 const MUTATING_TOOLS = new Set<ToolName>(['knowledge-store', 'knowledge-ingest', 'knowledge-maintain', 'knowledge-mine']);
+const ROUTINE_STORED_KNOWLEDGE_TOOLS = new Set<ToolName>([
+  'knowledge-store',
+  'knowledge-search',
+  'knowledge-get',
+  'knowledge-context',
+  'knowledge-health',
+  'knowledge-mine',
+]);
 
 function preferenceText(result: AgentToolResult<Record<string, unknown> | undefined>): string | undefined {
   const structured = result.details?.structuredContent;
@@ -374,7 +382,9 @@ export function createOpenZkKbPiExtension(options?: Partial<BridgeOptions>) {
         parameters,
         executionMode: definition.executionMode,
         execute: async (_toolCallId, params, signal) => {
-          const result = await bridge.callTool(definition.name, params as Record<string, unknown>, signal);
+          const args = params as Record<string, unknown>;
+          const routineArgs = ROUTINE_STORED_KNOWLEDGE_TOOLS.has(definition.name) && project ? { ...args, project, client: 'pi' } : args;
+          const result = await bridge.callTool(definition.name, routineArgs, signal);
           if (MUTATING_TOOLS.has(definition.name)) capsuleRequest = undefined;
           return result;
         },

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -383,7 +383,13 @@ export function createOpenZkKbPiExtension(options?: Partial<BridgeOptions>) {
         executionMode: definition.executionMode,
         execute: async (_toolCallId, params, signal) => {
           const args = params as Record<string, unknown>;
-          const routineArgs = ROUTINE_STORED_KNOWLEDGE_TOOLS.has(definition.name) && project ? { ...args, project, client: 'pi' } : args;
+          let routineArgs = args;
+          if (ROUTINE_STORED_KNOWLEDGE_TOOLS.has(definition.name)) {
+            const boundedArgs = { ...args };
+            delete boundedArgs.project;
+            delete boundedArgs.client;
+            routineArgs = { ...boundedArgs, ...(project ? { project } : {}), client: 'pi' };
+          }
           const result = await bridge.callTool(definition.name, routineArgs, signal);
           if (MUTATING_TOOLS.has(definition.name)) capsuleRequest = undefined;
           return result;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -420,7 +420,14 @@ function isOpenZkKbPiPackageSource(source: string): boolean {
 
 function isOpenZkKbLocalPackagePath(source: string): boolean {
   const normalized = path.normalize(source);
-  return path.basename(normalized) === PI_PACKAGE_NAME;
+  if (path.basename(normalized) === PI_PACKAGE_NAME) return true;
+
+  try {
+    const manifest = JSON.parse(fs.readFileSync(path.join(normalized, 'package.json'), 'utf-8')) as unknown;
+    return isJsonObject(manifest) && manifest.name === PI_PACKAGE_NAME;
+  } catch {
+    return false;
+  }
 }
 
 function normalizePiPackages(config: JsonObject, desiredSource: string): void {

--- a/src/storage/IndexBuilder.ts
+++ b/src/storage/IndexBuilder.ts
@@ -81,15 +81,6 @@ const QUICKADD_CHOICE_LABELS: Record<string, string> = {
   personalization: 'Project Preference',
 };
 
-const GENERAL_QUICKADD_CHOICE_LABELS: Record<string, string> = {
-  decision: 'Decision \u2014 choices & tradeoffs',
-  observation: 'Observation \u2014 things you noticed',
-  procedure: 'Procedure \u2014 step-by-step workflows',
-  reference: 'Reference \u2014 sources & excerpts',
-  resource: 'Resource \u2014 tools & URLs',
-  personalization: 'Preference \u2014 personal habits',
-};
-
 
 function formatDate(timestamp: number): string {
   const d = new Date(timestamp);
@@ -138,17 +129,6 @@ function buildQuickAddUri(project: string, kind: string): string | null {
     'value-scope': 'project',
     'value-project': project,
     'value-kind': kind,
-  });
-  return `obsidian://quickadd?${params.toString().replace(/\+/g, '%20')}`;
-}
-
-function buildGeneralQuickAddUri(kind: string): string | null {
-  const choice = GENERAL_QUICKADD_CHOICE_LABELS[kind];
-  if (!choice) return null;
-
-  const params = new URLSearchParams({
-    choice,
-    'value-scope': 'general',
   });
   return `obsidian://quickadd?${params.toString().replace(/\+/g, '%20')}`;
 }
@@ -420,7 +400,7 @@ export function buildGlobalIndexContent(
   lines.push('## Browse');
   lines.push('| Section | Notes | Description |');
   lines.push('|---------|-------|-------------|');
-  lines.push(`| [[general/${getGeneralFolderNoteBasename()}\\|General Knowledge]] | ${generalCount} | Unscoped references, decisions, observations |`);
+  lines.push(`| [[general/${getGeneralFolderNoteBasename()}\\|Global Knowledge]] | ${generalCount} | Confirmed, project-agnostic knowledge |`);
   lines.push(`| [[preferences/${getPreferencesFolderNoteBasename()}\\|Preferences]] | ${preferencesCount} | Personal style, habits, and tool preferences |`);
   if (includeReviewLink) {
     lines.push(`| [[review\\|Needs Review]] | ${fleetingCount} | Fleeting notes awaiting promotion or archive |`);
@@ -487,15 +467,15 @@ export function buildGeneralIndexContent(notes: NoteMetadata[]): string {
 
   lines.push(buildShellFrontmatter({
     kind: 'index',
-    title: 'General Knowledge',
+    title: 'Global Knowledge',
     'BC-folder-note': true,
-    aliases: ['General'],
+    aliases: ['Global Knowledge', 'General'],
     cssclasses: ['folder-note-shell'],
     up: `[[${getGlobalHomeNoteBasename()}|Home]]`,
   }).trimEnd());
   lines.push('');
-  lines.push('# `[!!library]` General Knowledge');
-  lines.push('`[!!info|Cross-cutting notes without a project scope|var(--color-cyan-rgb)]`');
+  lines.push('# `[!!library]` Global Knowledge');
+  lines.push('`[!!info|Confirmed, project-agnostic knowledge|var(--color-cyan-rgb)]`');
   lines.push('');
 
   const byKind = groupNotesByKind(notes);
@@ -509,11 +489,14 @@ export function buildGeneralIndexContent(notes: NoteMetadata[]): string {
       ? 'preferences'
       : `general/${KIND_DIR_MAP[kind] || `${kind}s`}`;
 
-    const generalAddUri = buildGeneralQuickAddUri(kind);
-    const addLink = generalAddUri ? ` [+](${generalAddUri})` : '';
-    lines.push(`## ${header}${addLink}`);
+    lines.push(`## ${header}`);
     lines.push('');
-    lines.push(...buildDataviewTable(source, kind, header));
+    lines.push(...buildDataviewTable(
+      source,
+      kind,
+      header,
+      `p => (p.file.tags || []).map(t => typeof t === "string" ? t.replace(/^#/, "") : String(t?.tag || t?.name || t).replace(/^#/, "")).includes("scope:global")`,
+    ));
     lines.push('');
   }
 
@@ -575,9 +558,7 @@ export function buildPreferencesIndexContent(_notes: NoteMetadata[]): string {
     up: `[[${getGlobalHomeNoteBasename()}|Home]]`,
   }).trimEnd());
   lines.push('');
-  const prefsAddUri = buildGeneralQuickAddUri('personalization');
-  const prefsAddLink = prefsAddUri ? ` [+](${prefsAddUri})` : '';
-  lines.push(`# \`[!!user-cog]\` Preferences${prefsAddLink}`);
+  lines.push('# `[!!user-cog]` Preferences');
   lines.push('`[!!info|Personal style, habits, and tool preferences|var(--color-pink-rgb)]`');
   lines.push('');
 
@@ -585,7 +566,7 @@ export function buildPreferencesIndexContent(_notes: NoteMetadata[]): string {
   lines.push('## Universal Preferences');
   lines.push('');
   lines.push(...buildPreferencesDataviewTable(
-    `p => !tagsFor(p).some(t => t.startsWith('project:') || t.startsWith('#project:') || t.startsWith('client:') || t.startsWith('#client:'))`,
+    `p => tagsFor(p).some(t => t === 'scope:global' || t === '#scope:global') && !tagsFor(p).some(t => t.startsWith('project:') || t.startsWith('#project:') || t.startsWith('client:') || t.startsWith('#client:'))`,
     `"Universal"`,
   ));
   lines.push('');
@@ -594,7 +575,7 @@ export function buildPreferencesIndexContent(_notes: NoteMetadata[]): string {
   lines.push('## Harness Preferences');
   lines.push('');
   lines.push(...buildPreferencesDataviewTable(
-    `p => tagsFor(p).some(t => t.startsWith('client:') || t.startsWith('#client:'))`,
+    `p => tagsFor(p).some(t => t.startsWith('client:') || t.startsWith('#client:')) && ((tagsFor(p).some(t => t === 'scope:global' || t === '#scope:global') && !tagsFor(p).some(t => t.startsWith('project:') || t.startsWith('#project:'))) || (!tagsFor(p).some(t => t === 'scope:global' || t === '#scope:global') && tagsFor(p).filter(t => t.startsWith('project:') || t.startsWith('#project:')).length === 1))`,
     `tagsFor(p).filter(t => t.startsWith('client:') || t.startsWith('#client:') || t.startsWith('project:') || t.startsWith('#project:')).map(t => t.replace(/^#/, '')).join(', ') || 'Universal'`,
   ));
   lines.push('');
@@ -603,7 +584,7 @@ export function buildPreferencesIndexContent(_notes: NoteMetadata[]): string {
   lines.push('## Project Preferences');
   lines.push('');
   lines.push(...buildPreferencesDataviewTable(
-    `p => tagsFor(p).some(t => t.startsWith('project:') || t.startsWith('#project:'))`,
+    `p => !tagsFor(p).some(t => t === 'scope:global' || t === '#scope:global') && tagsFor(p).filter(t => t.startsWith('project:') || t.startsWith('#project:')).length === 1`,
     `tagsFor(p).filter(t => t.startsWith('client:') || t.startsWith('#client:') || t.startsWith('project:') || t.startsWith('#project:')).map(t => t.replace(/^#/, '')).join(', ') || 'Universal'`,
   ));
   lines.push('');
@@ -620,23 +601,28 @@ export function buildGeneralKindIndexContent(kind: string, _notes: NoteMetadata[
 
   lines.push(buildShellFrontmatter({
     kind: 'index',
-    title: `General ${header}`,
+    title: `Global ${header}`,
     'BC-folder-note': true,
     'BC-folder-note-field': 'up',
     aliases: [header],
     cssclasses: ['folder-note-shell'],
-    up: `[[general/${getGeneralFolderNoteBasename()}|General]]`,
+    up: `[[general/${getGeneralFolderNoteBasename()}|Global]]`,
   }).trimEnd());
   lines.push('');
-  lines.push(`# General — ${header}`);
+  lines.push(`# Global — ${header}`);
   const kindDesc = SECTION_DESCRIPTIONS[kind];
   const kindColor = SECTION_COLORS[kind];
   const kindIcon = SECTION_ICONS[kind];
   if (kindDesc && kindColor && kindIcon) {
-    lines.push(`\`[!!info|${kindDesc} — not scoped to a project|${kindColor}]\``);
+    lines.push(`\`[!!info|${kindDesc} — confirmed for global use|${kindColor}]\``);
   }
   lines.push('');
-  lines.push(...buildDataviewTable(`general/${KIND_DIR_MAP[kind] || `${kind}s`}`, kind, header));
+  lines.push(...buildDataviewTable(
+    `general/${KIND_DIR_MAP[kind] || `${kind}s`}`,
+    kind,
+    header,
+    `p => (p.file.tags || []).map(t => typeof t === "string" ? t.replace(/^#/, "") : String(t?.tag || t?.name || t).replace(/^#/, "")).includes("scope:global")`,
+  ));
   lines.push('');
   lines.push('---');
   lines.push(`Last rebuilt: ${formatDateTime()}`);

--- a/src/storage/IndexBuilder.ts
+++ b/src/storage/IndexBuilder.ts
@@ -72,6 +72,11 @@ const SECTION_COLORS: Record<string, string> = {
   personalization: 'var(--color-pink-rgb)',
 };
 
+export const GLOBAL_SCOPE_PREDICATE = `p => {
+  const tags = (p.file.tags || []).map(t => typeof t === "string" ? t : (t && typeof t.tag === "string" ? t.tag : (t && typeof t.name === "string" ? t.name : String(t)))).map(t => t.replace(/^#/, ""));
+  return tags.includes("scope:global") && !tags.some(t => t.startsWith("project:"));
+}`;
+
 const QUICKADD_CHOICE_LABELS: Record<string, string> = {
   decision: 'Project Decision',
   observation: 'Project Observation',
@@ -495,7 +500,7 @@ export function buildGeneralIndexContent(notes: NoteMetadata[]): string {
       source,
       kind,
       header,
-      `p => (p.file.tags || []).map(t => typeof t === "string" ? t.replace(/^#/, "") : String(t?.tag || t?.name || t).replace(/^#/, "")).includes("scope:global")`,
+      GLOBAL_SCOPE_PREDICATE,
     ));
     lines.push('');
   }
@@ -621,7 +626,7 @@ export function buildGeneralKindIndexContent(kind: string, _notes: NoteMetadata[
     `general/${KIND_DIR_MAP[kind] || `${kind}s`}`,
     kind,
     header,
-    `p => (p.file.tags || []).map(t => typeof t === "string" ? t.replace(/^#/, "") : String(t?.tag || t?.name || t).replace(/^#/, "")).includes("scope:global")`,
+    GLOBAL_SCOPE_PREDICATE,
   ));
   lines.push('');
   lines.push('---');

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -1071,8 +1071,8 @@ export class NoteRepository {
   /**
    * Get embedding stats for maintenance reporting.
    */
-  getEmbeddingStats(project?: string): { total: number; withEmbedding: number; withoutEmbedding: number; models: Record<string, number> } {
-    const visibility = project ? this.visibilityPredicate('notes', { project }) : { sql: '', params: [] as string[] };
+  getEmbeddingStats(project?: string, client?: string): { total: number; withEmbedding: number; withoutEmbedding: number; models: Record<string, number> } {
+    const visibility = project ? this.visibilityPredicate('notes', { project, client }) : { sql: '', params: [] as string[] };
     const projectClause = project ? ` AND kind NOT IN ('index', 'log')${visibility.sql}` : '';
     const projectParam = visibility.params;
     const counts = this.db.prepare(`
@@ -1640,8 +1640,8 @@ export class NoteRepository {
     }
   }
 
-  getStats(project?: string): { total: number; fleeting: number; permanent: number; archived: number; other: number } {
-    const visibility = project ? this.visibilityPredicate('notes', { project }) : { sql: '', params: [] as string[] };
+  getStats(project?: string, client?: string): { total: number; fleeting: number; permanent: number; archived: number; other: number } {
+    const visibility = project ? this.visibilityPredicate('notes', { project, client }) : { sql: '', params: [] as string[] };
     const filter = `WHERE kind NOT IN ('index', 'log')${visibility.sql}`;
     const params = visibility.params;
     const stmt = this.db.prepare(`
@@ -1680,8 +1680,8 @@ export class NoteRepository {
    * Get notes created within a time window, grouped by kind.
    * Used by knowledge-health for growth rate reporting.
    */
-  getGrowthByKind(sinceMs: number, project?: string): Record<string, number> {
-    const visibility = project ? this.visibilityPredicate('notes', { project }) : { sql: '', params: [] as string[] };
+  getGrowthByKind(sinceMs: number, project?: string, client?: string): Record<string, number> {
+    const visibility = project ? this.visibilityPredicate('notes', { project, client }) : { sql: '', params: [] as string[] };
     const projectClause = project ? ` AND kind NOT IN ('index', 'log')${visibility.sql}` : '';
     const params: (number | string)[] = [sinceMs, ...visibility.params];
     const rows = this.db.prepare(`
@@ -1701,12 +1701,12 @@ export class NoteRepository {
    * Get staleness distribution across buckets: 0-7d, 7-30d, 30-90d, 90d+.
    * Staleness = days since last access (or creation if never accessed).
    */
-  getStalenessDistribution(project?: string): { fresh: number; recent: number; aging: number; stale: number } {
+  getStalenessDistribution(project?: string, client?: string): { fresh: number; recent: number; aging: number; stale: number } {
     const now = Date.now();
     const d7 = now - 7 * 86400000;
     const d30 = now - 30 * 86400000;
     const d90 = now - 90 * 86400000;
-    const visibility = project ? this.visibilityPredicate('notes', { project }) : { sql: '', params: [] as string[] };
+    const visibility = project ? this.visibilityPredicate('notes', { project, client }) : { sql: '', params: [] as string[] };
     const projectClause = project ? ` AND kind NOT IN ('index', 'log')${visibility.sql}` : '';
     const params: (number | string)[] = [d7, d7, d30, d30, d90, d90, ...visibility.params];
     const row = this.db.prepare(`
@@ -2299,25 +2299,29 @@ export class NoteRepository {
     }));
   }
 
-  getUnlinkedNotes(project?: string): NoteMetadata[] {
-    // Only count links where the neighbor is also non-archived (live links)
-    const projectClause = project ? ` AND tags LIKE ?` : '';
-    const projectParam = project ? [`%"project:${project}"%`] : [];
+  getUnlinkedNotes(project?: string, client?: string): NoteMetadata[] {
+    // Only count links where the neighbor is also active and visible.
+    const visibility = project ? { project, client } : undefined;
+    const noteScope = this.visibilityPredicate('n', visibility);
+    const targetScope = this.visibilityPredicate('target', visibility);
+    const sourceScope = this.visibilityPredicate('source', visibility);
     const stmt = this.db.prepare(`
-      SELECT * FROM notes
-      WHERE status != 'archived'
-        AND kind NOT IN ('index', 'log')${projectClause}
-        AND id NOT IN (
+      SELECT n.* FROM notes n
+      WHERE n.status != 'archived'
+        AND n.kind NOT IN ('index', 'log')${noteScope.sql}
+        AND n.id NOT IN (
           SELECT l.source_id FROM note_links l
-          JOIN notes n ON l.target_id = n.id WHERE n.status != 'archived'
+          JOIN notes target ON l.target_id = target.id
+          WHERE target.status != 'archived'${targetScope.sql}
         )
-        AND id NOT IN (
+        AND n.id NOT IN (
           SELECT l.target_id FROM note_links l
-          JOIN notes n ON l.source_id = n.id WHERE n.status != 'archived'
+          JOIN notes source ON l.source_id = source.id
+          WHERE source.status != 'archived'${sourceScope.sql}
         )
-      ORDER BY created_at DESC
+      ORDER BY n.created_at DESC
     `);
-    const results = stmt.all(...projectParam) as NoteMetadata[];
+    const results = stmt.all(...noteScope.params, ...targetScope.params, ...sourceScope.params) as NoteMetadata[];
     const parsed = results.map(r => ({
       ...r,
       kind: (r.kind || 'observation') as NoteKind,
@@ -2330,9 +2334,10 @@ export class NoteRepository {
   }
 
 
-  getOneWayLinks(project?: string): Array<{ sourceId: string; sourceTitle: string; targetId: string; targetTitle: string }> {
-    const projectClause = project ? ` AND s.tags LIKE ? AND t.tags LIKE ?` : '';
-    const projectParam = project ? [`%"project:${project}"%`, `%"project:${project}"%`] : [];
+  getOneWayLinks(project?: string, client?: string): Array<{ sourceId: string; sourceTitle: string; targetId: string; targetTitle: string }> {
+    const visibility = project ? { project, client } : undefined;
+    const sourceScope = this.visibilityPredicate('s', visibility);
+    const targetScope = this.visibilityPredicate('t', visibility);
     const stmt = this.db.prepare(`
       SELECT l.source_id AS sourceId, s.title AS sourceTitle,
              l.target_id AS targetId, t.title AS targetTitle
@@ -2342,23 +2347,22 @@ export class NoteRepository {
       WHERE s.status != 'archived'
         AND t.status != 'archived'
         AND s.kind NOT IN ('index', 'log')
-        AND t.kind NOT IN ('index', 'log')${projectClause}
+        AND t.kind NOT IN ('index', 'log')${sourceScope.sql}${targetScope.sql}
         AND NOT EXISTS (
           SELECT 1 FROM note_links r
           WHERE r.source_id = l.target_id AND r.target_id = l.source_id
         )
       ORDER BY s.title, t.title
     `);
-    return stmt.all(...projectParam) as Array<{ sourceId: string; sourceTitle: string; targetId: string; targetTitle: string }>;
+    return stmt.all(...sourceScope.params, ...targetScope.params) as Array<{ sourceId: string; sourceTitle: string; targetId: string; targetTitle: string }>;
   }
 
 
-  getBrokenLinks(project?: string): Array<{ sourceId: string; sourceTitle: string; brokenTarget: string; line: number }> {
-    let allNotes = this.getAll(Number.MAX_SAFE_INTEGER).filter(n => n.status !== 'archived');
-    if (project) {
-      const tag = `project:${project}`;
-      allNotes = allNotes.filter(n => Array.isArray(n.tags) && n.tags.includes(tag));
-    }
+  getBrokenLinks(project?: string, client?: string): Array<{ sourceId: string; sourceTitle: string; brokenTarget: string; line: number }> {
+    const visibility = project ? { project, client } : undefined;
+    const allNotes = visibility
+      ? this.getRecentNotes(Number.MAX_SAFE_INTEGER, visibility)
+      : this.getAll(Number.MAX_SAFE_INTEGER).filter(n => n.status !== 'archived');
     const broken: Array<{ sourceId: string; sourceTitle: string; brokenTarget: string; line: number }> = [];
     const linkPattern = /\[\[([^\]]+)\]\]/g;
 
@@ -2370,7 +2374,8 @@ export class NoteRepository {
         for (let match = linkPattern.exec(lines[i]); match !== null; match = linkPattern.exec(lines[i])) {
           const slug = parseWikiLink(match[1]).slug;
           const resolved = this.resolveLink(slug);
-          if (!resolved) {
+          const visibleTarget = resolved && visibility ? this.getByIdVisible(resolved, visibility) : resolved;
+          if (!visibleTarget) {
             broken.push({
               sourceId: note.id,
               sourceTitle: note.title,

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -22,6 +22,7 @@ import {
   getPreferencesFolderNoteBasename,
 } from './path-resolver.js';
 import type { ConformanceRecord, ConformanceAggregates } from '../template-handler.js';
+import type { VisibilityOptions } from '../knowledge-scope.js';
 
 export class LifecycleViolationError extends Error {
   constructor(message: string) {
@@ -614,6 +615,13 @@ export class NoteRepository {
     const noteKindForPath = options.kind || 'observation';
     const project = extractProjectFromTags(options.tags || []);
     const isUpdate = !!options.existingId;
+    // Timestamps are the optimistic-concurrency version used by publication
+    // confirmation tokens. Ensure an immediate update cannot reuse the same
+    // millisecond and accidentally validate an old token.
+    const existingForVersion = isUpdate ? this.getById(id) : null;
+    const versionedNow = existingForVersion
+      ? Math.max(now, existingForVersion.updated_at + 1)
+      : now;
 
     let filePath: string;
     if (isUpdate) {
@@ -685,7 +693,7 @@ export class NoteRepository {
       summary: summaryStr || undefined,
       extraFrontmatter: options.extraFrontmatter,
       created_at: createdAt,
-      updated_at: now,
+      updated_at: versionedNow,
     });
 
     const noteBody = this.buildNoteBody({
@@ -720,7 +728,7 @@ export class NoteRepository {
     `).run(
       id, filePath, title, content, noteKind,
       options.status || 'fleeting', noteLifecycle, noteType,
-      tagsJson, summaryStr, guidanceStr, contextStr, now, createdAt, wordCount
+      tagsJson, summaryStr, guidanceStr, contextStr, versionedNow, createdAt, wordCount
     );
 
     // Insert into FTS
@@ -736,12 +744,36 @@ export class NoteRepository {
     };
   }
 
+  private visibilityPredicate(alias: string, visibility?: VisibilityOptions): { sql: string; params: string[] } {
+    if (!visibility) return { sql: '', params: [] };
+
+    let sql = ` AND (
+      (EXISTS (SELECT 1 FROM json_each(${alias}.tags) WHERE value = ?)
+        AND NOT EXISTS (SELECT 1 FROM json_each(${alias}.tags) WHERE value = 'scope:global')
+        AND (SELECT COUNT(*) FROM json_each(${alias}.tags) WHERE value LIKE 'project:%') = 1)
+      OR (EXISTS (SELECT 1 FROM json_each(${alias}.tags) WHERE value = 'scope:global')
+        AND (SELECT COUNT(*) FROM json_each(${alias}.tags) WHERE value LIKE 'project:%') = 0)
+    )`;
+    const params = [`project:${visibility.project}`];
+
+    if (visibility.client) {
+      sql += ` AND (
+        (SELECT COUNT(*) FROM json_each(${alias}.tags) WHERE value LIKE 'client:%') = 0
+        OR EXISTS (SELECT 1 FROM json_each(${alias}.tags) WHERE value = 'client:all')
+        OR EXISTS (SELECT 1 FROM json_each(${alias}.tags) WHERE value = ?)
+      )`;
+      params.push(`client:${visibility.client}`);
+    }
+    return { sql, params };
+  }
+
   search(query: string, options: {
     status?: NoteStatus;
     kind?: NoteKind;
     tags?: string[];
     context?: string;
     limit?: number;
+    visibility?: VisibilityOptions;
   } = {}): NoteMetadata[] {
     const sanitizedQuery = this.sanitizeFTS5Query(query);
 
@@ -752,6 +784,9 @@ export class NoteRepository {
       WHERE notes_fts MATCH ?
     `;
     const params: (string | number)[] = [sanitizedQuery];
+    const visibility = this.visibilityPredicate('n', options.visibility);
+    sql += visibility.sql;
+    params.push(...visibility.params);
 
     if (options.status) {
       sql += ' AND n.status = ?';
@@ -797,12 +832,16 @@ export class NoteRepository {
     status?: NoteStatus;
     kind?: NoteKind;
     limit?: number;
+    visibility?: VisibilityOptions;
   } = {}): Array<NoteMetadata & { similarity: number }> {
     let sql = `
       SELECT * FROM notes
       WHERE embedding IS NOT NULL
     `;
     const params: (string | number)[] = [];
+    const visibility = this.visibilityPredicate('notes', options.visibility);
+    sql += visibility.sql;
+    params.push(...visibility.params);
 
     if (options.status) {
       sql += ' AND status = ?';
@@ -844,6 +883,7 @@ export class NoteRepository {
       tags?: string[];
       context?: string;
       limit?: number;
+      visibility?: VisibilityOptions;
     } = {}
   ): NoteMetadata[] {
     const limit = options.limit || 10;
@@ -856,6 +896,7 @@ export class NoteRepository {
       status: options.status,
       kind: options.kind,
       limit: limit * 2,
+      visibility: options.visibility,
     });
 
     let filteredVecResults = vecResults;
@@ -923,12 +964,13 @@ export class NoteRepository {
     }));
   }
 
-  findNearDuplicates(hash: string, threshold: number = 3): NoteMetadata[] {
+  findNearDuplicates(hash: string, threshold: number = 3, visibility?: VisibilityOptions): NoteMetadata[] {
     type NoteRow = Omit<NoteMetadata, 'tags'> & { tags: string; content_hash: string };
 
+    const scope = this.visibilityPredicate('notes', visibility);
     const rows = this.db.prepare(
-      "SELECT * FROM notes WHERE content_hash IS NOT NULL AND status != 'archived'"
-    ).all() as NoteRow[];
+      `SELECT * FROM notes WHERE content_hash IS NOT NULL AND status != 'archived'${scope.sql}`
+    ).all(...scope.params) as NoteRow[];
 
     const targetBigInt = BigInt(`0x${hash}`);
     const matches = rows.filter((row) => {
@@ -1026,8 +1068,9 @@ export class NoteRepository {
    * Get embedding stats for maintenance reporting.
    */
   getEmbeddingStats(project?: string): { total: number; withEmbedding: number; withoutEmbedding: number; models: Record<string, number> } {
-    const projectClause = project ? ` AND kind NOT IN ('index', 'log') AND tags LIKE ?` : '';
-    const projectParam = project ? [`%"project:${project}"%`] : [];
+    const visibility = project ? this.visibilityPredicate('notes', { project }) : { sql: '', params: [] as string[] };
+    const projectClause = project ? ` AND kind NOT IN ('index', 'log')${visibility.sql}` : '';
+    const projectParam = visibility.params;
     const counts = this.db.prepare(`
       SELECT
         COUNT(*) as total,
@@ -1055,17 +1098,18 @@ export class NoteRepository {
    * Look up notes by exact tag match using SQL LIKE on the JSON tags column.
    * More reliable than FTS5 search + post-filter for tag-based lookups.
    */
-  getByTag(tag: string, limit: number = 10): NoteMetadata[] {
+  getByTag(tag: string, limit: number = 10, visibility?: VisibilityOptions): NoteMetadata[] {
     // Tags are stored as JSON arrays, e.g. '["project:myapp","typescript"]'
     const pattern = `%"${tag}"%`;
+    const scope = this.visibilityPredicate('notes', visibility);
     const stmt = this.db.prepare(`
       SELECT * FROM notes
-      WHERE tags LIKE ? AND status != 'archived'
+      WHERE tags LIKE ? AND status != 'archived'${scope.sql}
       ORDER BY updated_at DESC
       LIMIT ?
     `);
 
-    const results = stmt.all(pattern, limit) as NoteMetadata[];
+    const results = stmt.all(pattern, ...scope.params, limit) as NoteMetadata[];
     return results.map(r => ({
       ...r,
       kind: (r.kind || 'observation') as NoteKind,
@@ -1204,7 +1248,8 @@ export class NoteRepository {
   getUnscopedNotes(): NoteMetadata[] {
     const stmt = this.db.prepare(`
       SELECT * FROM notes
-      WHERE tags NOT LIKE '%"project:%'
+      WHERE EXISTS (SELECT 1 FROM json_each(notes.tags) WHERE value = 'scope:global')
+        AND NOT EXISTS (SELECT 1 FROM json_each(notes.tags) WHERE value LIKE 'project:%')
         AND status != 'archived'
         AND kind NOT IN ('index', 'log')
         AND kind != 'personalization'
@@ -1285,6 +1330,19 @@ export class NoteRepository {
 
     if (!result) return null;
 
+    return {
+      ...result,
+      kind: (result.kind || 'observation') as NoteKind,
+      tags: JSON.parse(result.tags as unknown as string),
+    };
+  }
+
+  getByIdVisible(id: string, visibility: VisibilityOptions): NoteMetadata | null {
+    const scope = this.visibilityPredicate('notes', visibility);
+    const result = this.db.prepare(
+      `SELECT * FROM notes WHERE id = ? AND status != 'archived'${scope.sql}`
+    ).get(id, ...scope.params) as NoteMetadata | undefined;
+    if (!result) return null;
     return {
       ...result,
       kind: (result.kind || 'observation') as NoteKind,
@@ -1381,17 +1439,18 @@ export class NoteRepository {
    * Get notes accessed within the last N days.
    * Captures "hot" notes from recent sessions.
    */
-  getRecentlyAccessedNotes(days: number = 7, limit: number = 10): NoteMetadata[] {
+  getRecentlyAccessedNotes(days: number = 7, limit: number = 10, visibility?: VisibilityOptions): NoteMetadata[] {
     const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
+    const scope = this.visibilityPredicate('notes', visibility);
     const stmt = this.db.prepare(`
       SELECT * FROM notes
       WHERE status != 'archived' 
         AND last_accessed_at > ?
-        AND access_count > 0
+        AND access_count > 0${scope.sql}
       ORDER BY last_accessed_at DESC
       LIMIT ?
     `);
-    const results = stmt.all(cutoff, limit) as NoteMetadata[];
+    const results = stmt.all(cutoff, ...scope.params, limit) as NoteMetadata[];
     return results.map(r => ({
       ...r,
       kind: (r.kind || 'observation') as NoteKind,
@@ -1491,18 +1550,65 @@ export class NoteRepository {
 
     const now = Date.now();
     const tagsJson = JSON.stringify(tags);
+    const oldTagsJson = JSON.stringify(note.tags);
     this.db.prepare('UPDATE notes SET tags = ?, updated_at = ? WHERE id = ?').run(tagsJson, now, id);
     this.ftsUpdate(id, note.title, note.content, tagsJson, note.context || '');
-    this.rewriteNoteFile(note, { tags, updated_at: now });
+    if (this.rewriteNoteFile(note, { tags, updated_at: now })) return true;
 
-    return true;
+    this.db.prepare('UPDATE notes SET tags = ?, updated_at = ? WHERE id = ?').run(oldTagsJson, note.updated_at, id);
+    this.ftsUpdate(id, note.title, note.content, oldTagsJson, note.context || '');
+    return false;
+  }
+
+  assignProject(id: string, project: string, tags: string[]): { oldPath: string; newPath: string } | null {
+    const note = this.getById(id);
+    if (!note) return null;
+    const newPath = resolveNotePath(this.docsPath, note.kind, project, note.id, this.slugify(note.title));
+    // Validate filesystem preconditions before rewriting tags/DB so a failed move
+    // cannot leave a partially applied assignment. Never overwrite another note.
+    if (!fs.existsSync(note.path)) return null;
+    if (newPath !== note.path && fs.existsSync(newPath)) return null;
+    // Move first: metadata updates must not make a note claim a path that was
+    // never successfully created. Restore exact source bytes and indexed state
+    // if any subsequent update fails.
+    const oldPath = note.path;
+    const oldFile = fs.readFileSync(oldPath, 'utf-8');
+    const oldTagsJson = JSON.stringify(note.tags);
+    let moved = false;
+    try {
+      if (newPath !== oldPath) {
+        fs.mkdirSync(path.dirname(newPath), { recursive: true });
+        fs.renameSync(oldPath, newPath);
+        moved = true;
+        if (!this.updatePath(id, newPath)) throw new Error('Failed to update note path');
+      }
+      if (!this.updateTags(id, tags)) throw new Error('Failed to update note tags');
+      return { oldPath, newPath };
+    } catch (error) {
+      // A failed initial rename has not changed note bytes or indexed metadata.
+      // A same-path assignment may already have attempted a tag rewrite and
+      // must still restore the original file and index state.
+      if (!moved && newPath !== oldPath) return null;
+      try {
+        if (moved) fs.renameSync(newPath, oldPath);
+        fs.writeFileSync(oldPath, oldFile, 'utf-8');
+        this.db.prepare('UPDATE notes SET path = ?, tags = ?, updated_at = ? WHERE id = ?')
+          .run(oldPath, oldTagsJson, note.updated_at, id);
+        this.ftsUpdate(id, note.title, note.content, oldTagsJson, note.context || '');
+      } catch (rollbackError) {
+        logToFile('ERROR', 'Failed to roll back project assignment', {
+          noteId: id, error: String(rollbackError), originalError: String(error),
+        });
+      }
+      return null;
+    }
   }
 
   private updateFrontmatterStatus(note: NoteMetadata, newStatus: NoteStatus): void {
     this.rewriteNoteFile(note, { status: newStatus, updated_at: Date.now() });
   }
 
-  private rewriteNoteFile(note: NoteMetadata, overrides: Partial<NoteMetadata>): void {
+  private rewriteNoteFile(note: NoteMetadata, overrides: Partial<NoteMetadata>): boolean {
     try {
       const fileContent = fs.readFileSync(note.path, 'utf-8');
       const { frontmatter: oldFm, body: rawBody } = this.parseFrontmatter(fileContent);
@@ -1521,14 +1627,17 @@ export class NoteRepository {
       const userContent = bodySections.content;
       const noteBody = this.buildNoteBody({ content: userContent, guidance, context, relatedContent: bodySections.related });
       fs.writeFileSync(note.path, newFrontmatter + navBreadcrumb + titleLine + noteBody, 'utf-8');
+      return true;
     } catch (err) {
       logToFile('WARN', 'Failed to rewrite note file', { noteId: note.id, error: String(err) });
+      return false;
     }
   }
 
   getStats(project?: string): { total: number; fleeting: number; permanent: number; archived: number; other: number } {
-    const filter = project ? `WHERE kind NOT IN ('index', 'log') AND tags LIKE ?` : `WHERE kind NOT IN ('index', 'log')`;
-    const params = project ? [`%"project:${project}"%`] : [];
+    const visibility = project ? this.visibilityPredicate('notes', { project }) : { sql: '', params: [] as string[] };
+    const filter = `WHERE kind NOT IN ('index', 'log')${visibility.sql}`;
+    const params = visibility.params;
     const stmt = this.db.prepare(`
       SELECT
         COUNT(*) as total,
@@ -1566,9 +1675,9 @@ export class NoteRepository {
    * Used by knowledge-health for growth rate reporting.
    */
   getGrowthByKind(sinceMs: number, project?: string): Record<string, number> {
-    const projectClause = project ? ` AND kind NOT IN ('index', 'log') AND tags LIKE ?` : '';
-    const params: (number | string)[] = [sinceMs];
-    if (project) params.push(`%"project:${project}"%`);
+    const visibility = project ? this.visibilityPredicate('notes', { project }) : { sql: '', params: [] as string[] };
+    const projectClause = project ? ` AND kind NOT IN ('index', 'log')${visibility.sql}` : '';
+    const params: (number | string)[] = [sinceMs, ...visibility.params];
     const rows = this.db.prepare(`
       SELECT kind, COUNT(*) as count
       FROM notes
@@ -1591,9 +1700,9 @@ export class NoteRepository {
     const d7 = now - 7 * 86400000;
     const d30 = now - 30 * 86400000;
     const d90 = now - 90 * 86400000;
-    const projectClause = project ? ` AND kind NOT IN ('index', 'log') AND tags LIKE ?` : '';
-    const params: (number | string)[] = [d7, d7, d30, d30, d90, d90];
-    if (project) params.push(`%"project:${project}"%`);
+    const visibility = project ? this.visibilityPredicate('notes', { project }) : { sql: '', params: [] as string[] };
+    const projectClause = project ? ` AND kind NOT IN ('index', 'log')${visibility.sql}` : '';
+    const params: (number | string)[] = [d7, d7, d30, d30, d90, d90, ...visibility.params];
     const row = this.db.prepare(`
       SELECT
         COALESCE(SUM(CASE WHEN COALESCE(last_accessed_at, created_at) >= ? THEN 1 ELSE 0 END), 0) as fresh,
@@ -2091,7 +2200,7 @@ export class NoteRepository {
     return parseAllWikiLinks(content).map(link => link.slug);
   }
 
-  private resolveLink(linkText: string): string | null {
+  public resolveLink(linkText: string): string | null {
     const parsed = parseWikiLink(linkText);
 
     const byPath = this.db.prepare('SELECT id FROM notes WHERE path LIKE ?').get(`%/${parsed.slug}.md`) as { id: string } | undefined;
@@ -2127,16 +2236,16 @@ export class NoteRepository {
     }
   }
 
-  getBacklinks(noteId: string): Array<{ note: NoteMetadata; link_text: string }> {
+  getBacklinks(noteId: string, visibility?: VisibilityOptions): Array<{ note: NoteMetadata; link_text: string }> {
     const stmt = this.db.prepare(`
       SELECT n.*, l.link_text
       FROM note_links l
       JOIN notes n ON l.source_id = n.id
-      WHERE l.target_id = ?
+      WHERE l.target_id = ?${this.visibilityPredicate('n', visibility).sql}
       ORDER BY l.created_at DESC
     `);
-
-    const results = stmt.all(noteId) as Array<NoteMetadata & { link_text: string }>;
+    const scope = this.visibilityPredicate('n', visibility);
+    const results = stmt.all(noteId, ...scope.params) as Array<NoteMetadata & { link_text: string }>;
 
     return results.map(r => ({
       note: {
@@ -2148,16 +2257,17 @@ export class NoteRepository {
     }));
   }
 
-  getOutgoingLinks(noteId: string): Array<{ note: NoteMetadata; link_text: string }> {
+  getOutgoingLinks(noteId: string, visibility?: VisibilityOptions): Array<{ note: NoteMetadata; link_text: string }> {
+    const scope = this.visibilityPredicate('n', visibility);
     const stmt = this.db.prepare(`
       SELECT n.*, l.link_text
       FROM note_links l
       JOIN notes n ON l.target_id = n.id
-      WHERE l.source_id = ?
+      WHERE l.source_id = ?${scope.sql}
       ORDER BY l.created_at DESC
     `);
 
-    const results = stmt.all(noteId) as Array<NoteMetadata & { link_text: string }>;
+    const results = stmt.all(noteId, ...scope.params) as Array<NoteMetadata & { link_text: string }>;
 
     return results.map(r => ({
       note: {
@@ -2236,9 +2346,8 @@ export class NoteRepository {
       const content = note.content || '';
       const lines = content.split('\n');
       for (let i = 0; i < lines.length; i++) {
-        let match;
         linkPattern.lastIndex = 0;
-        while ((match = linkPattern.exec(lines[i])) !== null) {
+        for (let match = linkPattern.exec(lines[i]); match !== null; match = linkPattern.exec(lines[i])) {
           const slug = parseWikiLink(match[1]).slug;
           const resolved = this.resolveLink(slug);
           if (!resolved) {
@@ -2333,15 +2442,16 @@ export class NoteRepository {
     }));
   }
 
-  getRecentNotes(limit: number = 5): NoteMetadata[] {
+  getRecentNotes(limit: number = 5, visibility?: VisibilityOptions): NoteMetadata[] {
+    const scope = this.visibilityPredicate('notes', visibility);
     const stmt = this.db.prepare(`
       SELECT * FROM notes 
       WHERE status != 'archived'
-        AND kind NOT IN ('index', 'log')
+        AND kind NOT IN ('index', 'log')${scope.sql}
       ORDER BY updated_at DESC 
       LIMIT ?
     `);
-    const results = stmt.all(limit) as NoteMetadata[];
+    const results = stmt.all(...scope.params, limit) as NoteMetadata[];
     return results.map(r => ({
       ...r,
       kind: (r.kind || 'observation') as NoteKind,
@@ -2512,6 +2622,94 @@ export class NoteRepository {
     if (this._closed) return;
     this._closed = true;
     this.db.close();
+  }
+
+  // ---- Global scope helpers ----
+
+  getAllGlobalNotes(limit: number = 100): NoteMetadata[] {
+    const stmt = this.db.prepare(`
+      SELECT * FROM notes
+      WHERE EXISTS (SELECT 1 FROM json_each(notes.tags) WHERE value = ?)
+        AND NOT EXISTS (SELECT 1 FROM json_each(notes.tags) WHERE substr(value, 1, 8) = ?)
+        AND status != ?
+      ORDER BY updated_at DESC, id ASC
+      LIMIT ?
+    `);
+    const results = stmt.all('scope:global', 'project:', 'archived', limit) as NoteMetadata[];
+    return results.map(r => ({
+      ...r,
+      kind: (r.kind || 'observation') as NoteKind,
+      tags: JSON.parse(r.tags as unknown as string),
+    }));
+  }
+
+  getAllActiveNotes(): NoteMetadata[] {
+    const results = this.db.prepare("SELECT * FROM notes WHERE status != 'archived' ORDER BY id ASC").all() as NoteMetadata[];
+    return results.map(r => ({ ...r, kind: (r.kind || 'observation') as NoteKind, tags: JSON.parse(r.tags as unknown as string) }));
+  }
+
+  /** Backlinks safe for display on a global note: global sources only. */
+  getGlobalBacklinks(noteId: string): Array<{ note: NoteMetadata; link_text: string }> {
+    const target = this.getById(noteId);
+    if (!target || !target.tags.includes('scope:global')) return [];
+    return this.getBacklinks(noteId).filter(({ note }) =>
+      note.tags.includes('scope:global') && !note.tags.some(tag => tag.startsWith('project:')),
+    );
+  }
+
+  validateGlobalEdge(sourceId: string, targetId: string): void {
+    const source = this.getById(sourceId);
+    const target = this.getById(targetId);
+    if (!source || !target) throw new Error('Link endpoint not found');
+    if (!source.tags.includes('scope:global') || source.tags.some(tag => tag.startsWith('project:')))
+      throw new Error('Source note must be global');
+    if (!target.tags.includes('scope:global') || target.tags.some(tag => tag.startsWith('project:')))
+      throw new Error('Global notes may link only to global notes');
+  }
+
+  addLocalToGlobalRelation(sourceId: string, globalId: string): void {
+    const sourceNote = this.getById(sourceId);
+    if (!sourceNote) throw new Error('Source note not found');
+    const globalNote = this.getById(globalId);
+    if (!globalNote) throw new Error('Global note not found');
+    const sourceProjects = sourceNote.tags.filter(tag => tag.startsWith('project:'));
+    if (sourceProjects.length !== 1 || sourceNote.tags.includes('scope:global')) {
+      throw new Error('Source note must have exactly one project scope');
+    }
+    if (!globalNote.tags.includes('scope:global') || globalNote.tags.some(tag => tag.startsWith('project:'))) {
+      throw new Error('Global note must have scope:global and no project tag');
+    }
+
+    const originalContent = fs.readFileSync(sourceNote.path, 'utf-8');
+    const globalRelativePath = path.relative(this.docsPath, globalNote.path).replace(/\.md$/, '');
+    if (originalContent.includes(`[[${globalRelativePath}|`) || originalContent.includes(`[[${globalNote.id}`)) return;
+
+    const globalLink = `- [[${globalRelativePath}|${globalNote.title}]]`;
+    const relatedHeading = /^## Related\s*$/m.exec(originalContent);
+    let updatedContent: string;
+    if (relatedHeading?.index !== undefined) {
+      const sectionStart = relatedHeading.index + relatedHeading[0].length;
+      const nextHeadingOffset = originalContent.slice(sectionStart).search(/\n## /);
+      const insertAt = nextHeadingOffset >= 0 ? sectionStart + nextHeadingOffset : originalContent.length;
+      const before = originalContent.slice(0, insertAt);
+      const after = originalContent.slice(insertAt);
+      updatedContent = `${before}${before.endsWith('\n') ? '' : '\n'}${globalLink}\n${after}`;
+    } else {
+      const separator = originalContent.endsWith('\n\n') ? '' : originalContent.endsWith('\n') ? '\n' : '\n\n';
+      updatedContent = `${originalContent}${separator}## Related\n\n${globalLink}\n`;
+    }
+
+    const updatedAt = Math.max(Date.now(), sourceNote.updated_at + 1);
+    try {
+      fs.writeFileSync(sourceNote.path, updatedContent, 'utf-8');
+      this.db.prepare('UPDATE notes SET updated_at = ? WHERE id = ?').run(updatedAt, sourceId);
+      this.syncLinks(sourceId, updatedContent);
+    } catch (error) {
+      fs.writeFileSync(sourceNote.path, originalContent, 'utf-8');
+      this.db.prepare('UPDATE notes SET updated_at = ? WHERE id = ?').run(sourceNote.updated_at, sourceId);
+      this.syncLinks(sourceId, originalContent);
+      throw error;
+    }
   }
 }
 

--- a/src/storage/NoteRepository.ts
+++ b/src/storage/NoteRepository.ts
@@ -791,6 +791,8 @@ export class NoteRepository {
     if (options.status) {
       sql += ' AND n.status = ?';
       params.push(options.status);
+    } else {
+      sql += " AND n.status != 'archived'";
     }
 
     if (options.kind) {
@@ -846,6 +848,8 @@ export class NoteRepository {
     if (options.status) {
       sql += ' AND status = ?';
       params.push(options.status);
+    } else {
+      sql += " AND status != 'archived'";
     }
     if (options.kind) {
       sql += ' AND kind = ?';
@@ -1245,7 +1249,7 @@ export class NoteRepository {
     return row.count;
   }
 
-  getUnscopedNotes(): NoteMetadata[] {
+  getGeneralGlobalNotes(): NoteMetadata[] {
     const stmt = this.db.prepare(`
       SELECT * FROM notes
       WHERE EXISTS (SELECT 1 FROM json_each(notes.tags) WHERE value = 'scope:global')
@@ -1580,9 +1584,9 @@ export class NoteRepository {
         fs.mkdirSync(path.dirname(newPath), { recursive: true });
         fs.renameSync(oldPath, newPath);
         moved = true;
-        if (!this.updatePath(id, newPath)) throw new Error('Failed to update note path');
+        if (!withBusyRetry(() => this.updatePath(id, newPath))) throw new Error('Failed to update note path');
       }
-      if (!this.updateTags(id, tags)) throw new Error('Failed to update note tags');
+      if (!withBusyRetry(() => this.updateTags(id, tags))) throw new Error('Failed to update note tags');
       return { oldPath, newPath };
     } catch (error) {
       // A failed initial rename has not changed note bytes or indexed metadata.
@@ -1592,9 +1596,11 @@ export class NoteRepository {
       try {
         if (moved) fs.renameSync(newPath, oldPath);
         fs.writeFileSync(oldPath, oldFile, 'utf-8');
-        this.db.prepare('UPDATE notes SET path = ?, tags = ?, updated_at = ? WHERE id = ?')
-          .run(oldPath, oldTagsJson, note.updated_at, id);
-        this.ftsUpdate(id, note.title, note.content, oldTagsJson, note.context || '');
+        withBusyRetry(() => {
+          this.db.prepare('UPDATE notes SET path = ?, tags = ?, updated_at = ? WHERE id = ?')
+            .run(oldPath, oldTagsJson, note.updated_at, id);
+          this.ftsUpdate(id, note.title, note.content, oldTagsJson, note.context || '');
+        });
       } catch (rollbackError) {
         logToFile('ERROR', 'Failed to roll back project assignment', {
           noteId: id, error: String(rollbackError), originalError: String(error),
@@ -2021,6 +2027,7 @@ export class NoteRepository {
     const indexNotes = new Map<string, string>();
     const logNotes = new Map<string, string>();
     const warnings: string[] = [];
+    const rawLinkSources = new Map<string, string>();
     let errors = 0;
 
     // Embeddings live only in SQLite (not in .md files), so save before DELETE.
@@ -2085,7 +2092,7 @@ export class NoteRepository {
 
         this.ftsDelete(id);
         this.ftsInsert(id, title, indexBody, tagsJson, context);
-        this.syncLinks(id, body);
+        rawLinkSources.set(id, rawContent);
         uniqueIds.add(id);
 
         if (kind === 'domain' || kind === 'index' || kind === 'log') {
@@ -2105,6 +2112,11 @@ export class NoteRepository {
         errors++;
       }
     }
+
+    // Resolve links only after every note is loaded. This makes link rebuilding
+    // independent of filesystem traversal order and applies scope validation
+    // against the complete persisted note set.
+    for (const [id, rawContent] of rawLinkSources) this.syncLinks(id, rawContent);
 
     if (savedEmbeddings.length > 0) {
       const restoreStmt = this.db.prepare(
@@ -2222,12 +2234,20 @@ export class NoteRepository {
   syncLinks(noteId: string, content: string): void {
     this.db.prepare('DELETE FROM note_links WHERE source_id = ?').run(noteId);
 
+    const source = this.getById(noteId);
+    const sourceIsGlobal = source?.tags.includes('scope:global') === true
+      && !source.tags.some(tag => tag.startsWith('project:'));
     const links = this.extractWikiLinks(content);
     const now = Date.now();
 
     for (const linkText of links) {
       const targetId = this.resolveLink(linkText);
-      if (targetId) {
+      const target = targetId ? this.getById(targetId) : null;
+      if (targetId && target) {
+        const targetIsActiveGlobal = target.status !== 'archived'
+          && target.tags.includes('scope:global')
+          && !target.tags.some(tag => tag.startsWith('project:'));
+        if (sourceIsGlobal && !targetIsActiveGlobal) continue;
         this.db.prepare(`
           INSERT OR REPLACE INTO note_links (source_id, target_id, link_text, created_at)
           VALUES (?, ?, ?, ?)
@@ -2237,14 +2257,14 @@ export class NoteRepository {
   }
 
   getBacklinks(noteId: string, visibility?: VisibilityOptions): Array<{ note: NoteMetadata; link_text: string }> {
+    const scope = this.visibilityPredicate('n', visibility);
     const stmt = this.db.prepare(`
       SELECT n.*, l.link_text
       FROM note_links l
       JOIN notes n ON l.source_id = n.id
-      WHERE l.target_id = ?${this.visibilityPredicate('n', visibility).sql}
+      WHERE l.target_id = ?${scope.sql}
       ORDER BY l.created_at DESC
     `);
-    const scope = this.visibilityPredicate('n', visibility);
     const results = stmt.all(noteId, ...scope.params) as Array<NoteMetadata & { link_text: string }>;
 
     return results.map(r => ({
@@ -2663,8 +2683,8 @@ export class NoteRepository {
     if (!source || !target) throw new Error('Link endpoint not found');
     if (!source.tags.includes('scope:global') || source.tags.some(tag => tag.startsWith('project:')))
       throw new Error('Source note must be global');
-    if (!target.tags.includes('scope:global') || target.tags.some(tag => tag.startsWith('project:')))
-      throw new Error('Global notes may link only to global notes');
+    if (target.status === 'archived' || !target.tags.includes('scope:global') || target.tags.some(tag => tag.startsWith('project:')))
+      throw new Error('Global notes may link only to active global notes');
   }
 
   addLocalToGlobalRelation(sourceId: string, globalId: string): void {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -215,6 +215,7 @@ export interface MineCandidate {
 export interface MineArgs {
   candidates: MineCandidate[];
   project: string;
+  client?: string;
   dry_run?: boolean;
   model?: string;
 }
@@ -798,7 +799,7 @@ function updateGlobalNavigation(
   if (!vaultPath) return [];
   const changedPaths: string[] = [];
   let fleetingNotes: NoteMetadata[] | null = null;
-  let unscopedNotes: NoteMetadata[] | null = null;
+  let generalGlobalNotes: NoteMetadata[] | null = null;
   let applicablePersonalizations: NoteMetadata[] | null = null;
 
   const getFleetingNotes = (): NoteMetadata[] => {
@@ -806,9 +807,9 @@ function updateGlobalNavigation(
     return fleetingNotes;
   };
 
-  const getUnscopedNotes = (): NoteMetadata[] => {
-    if (!unscopedNotes) unscopedNotes = repo.getUnscopedNotes();
-    return unscopedNotes;
+  const getGeneralGlobalNotes = (): NoteMetadata[] => {
+    if (!generalGlobalNotes) generalGlobalNotes = repo.getGeneralGlobalNotes();
+    return generalGlobalNotes;
   };
 
   const getApplicablePersonalizations = (): NoteMetadata[] => {
@@ -824,7 +825,7 @@ function updateGlobalNavigation(
       const projectStats = repo.getProjectStats();
       const totalNoteCount = repo.getStats().total;
       const prefsCount = getApplicablePersonalizations().length;
-      const generalCount = getUnscopedNotes().length;
+      const generalCount = getGeneralGlobalNotes().length;
       const fleetingCount = getFleetingNotes().length;
       const content = buildGlobalIndexContent(projectStats, prefsCount, generalCount, fleetingCount, totalNoteCount, {
         includeReviewLink: config?.navigation?.enableReviewMoc !== false,
@@ -889,7 +890,7 @@ function updateGlobalNavigation(
 
   if (config?.navigation?.enableGlobalIndex !== false) {
     try {
-      const unscopedNotes = getUnscopedNotes();
+      const unscopedNotes = getGeneralGlobalNotes();
       const personalizationNotes = getApplicablePersonalizations();
       const generalDir = path.join(vaultPath, 'general');
       if (unscopedNotes.length > 0) {
@@ -1286,7 +1287,9 @@ export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedd
 
   // Always-include domain note for project-scoped searches
   let domainNote: NoteMetadata | null = null;
-  if (args.project && config?.search?.alwaysIncludeDomainNote !== false) {
+  const requestedStatus = args.status ? toNoteStatus(args.status, 'fleeting') : undefined;
+  if (args.project && config?.search?.alwaysIncludeDomainNote !== false &&
+      (!requestedStatus || requestedStatus === 'permanent')) {
     domainNote = repo.getDomainNote(project);
     if (domainNote) {
       const domainId = domainNote.id;
@@ -1395,8 +1398,9 @@ function canonicalPublishCandidate(candidate: PublishGlobalCandidate): string {
 }
 
 function publicationToken(source: NoteMetadata, candidate: PublishGlobalCandidate): string {
+  const persistedSourceHash = createHash('sha256').update(fs.readFileSync(source.path)).digest('hex');
   return createHash('sha256')
-    .update(JSON.stringify({ sourceId: source.id, sourceUpdatedAt: source.updated_at, candidate: canonicalPublishCandidate(candidate), scope: 'global' }))
+    .update(JSON.stringify({ sourceId: source.id, persistedSourceHash, candidate: canonicalPublishCandidate(candidate), scope: 'global' }))
     .digest('hex');
 }
 
@@ -1445,16 +1449,29 @@ function globalReferenceEvidence(candidate: PublishGlobalCandidate, repo: NoteRe
       projectReferences.push(`tag:${tag}`);
     }
   }
-  for (const link of extractWikiLinks(candidate.content)) {
-    const targetId = repo.resolveLink(link.slug);
-    if (!targetId) outboundLinks.push(`unresolved:[[${link.slug}]]`);
-    else {
-      const target = repo.getById(targetId);
-      const targetScope = target ? parseKnowledgeApplicability(target.tags).type : 'missing';
-      outboundLinks.push(`${targetScope === 'global' ? 'global' : targetScope}:[[${link.slug}]]->${targetId}`);
+  for (const field of fields) {
+    for (const link of extractWikiLinks(candidate[field] || '')) {
+      const targetId = repo.resolveLink(link.slug);
+      const prefix = field === 'content' ? '' : `${field}:`;
+      if (!targetId) outboundLinks.push(`${prefix}unresolved:[[${link.slug}]]`);
+      else {
+        const target = repo.getById(targetId);
+        const targetScope = target?.status === 'archived'
+          ? 'archived'
+          : target ? parseKnowledgeApplicability(target.tags).type : 'missing';
+        outboundLinks.push(`${prefix}${targetScope === 'global' ? 'global' : targetScope}:[[${link.slug}]]->${targetId}`);
+      }
     }
   }
   return { projectReferences: [...new Set(projectReferences)].sort(), outboundLinks: [...new Set(outboundLinks)].sort() };
+}
+
+function isGlobalOutboundEvidence(evidence: string): boolean {
+  return /^(?:(?:title|summary|guidance):)?global:/.test(evidence);
+}
+
+function isUnresolvedOutboundEvidence(evidence: string): boolean {
+  return /^(?:(?:title|summary|guidance):)?unresolved:/.test(evidence);
 }
 
 function publicationValidation(source: NoteMetadata | null, candidate: PublishGlobalCandidate | undefined, repo: NoteRepository): {
@@ -1504,8 +1521,8 @@ function publicationValidation(source: NoteMetadata | null, candidate: PublishGl
     }
   }
   for (const evidence of outboundLinks) {
-    if (evidence.startsWith('unresolved:')) errors.push(`candidate.content: ${evidence}`);
-    else if (!evidence.startsWith('global:')) errors.push(`candidate.content: outbound target is not global (${evidence})`);
+    if (isUnresolvedOutboundEvidence(evidence)) errors.push(`candidate: ${evidence}`);
+    else if (!isGlobalOutboundEvidence(evidence)) errors.push(`candidate: outbound target is not active global (${evidence})`);
   }
   return { errors: [...new Set(errors)], duplicates, projectReferences, outboundLinks };
 }
@@ -1567,7 +1584,7 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
           summary: note.summary || '', guidance: note.guidance || '', tags: note.tags,
         }, repo, true);
         return { id: note.id, title: note.title, ...evidence };
-      }).filter(item => item.projectReferences.length > 0 || item.outboundLinks.some(link => !link.startsWith('global:')));
+      }).filter(item => item.projectReferences.length > 0 || item.outboundLinks.some(link => !isGlobalOutboundEvidence(link)));
       return JSON.stringify({ action: 'global-reference-audit', mutated: false, scanned: notes.length, findings }, null, 2);
     }
     case 'publish-global': {
@@ -2845,7 +2862,7 @@ export async function handleMine(args: MineArgs, repo: NoteRepository, embedding
     const embedding = embeddings[i]?.embedding;
 
     if (embedding) {
-      const vectorMatches = repo.searchVector(embedding, { limit: 5, visibility: { project } }).filter(note => note.status !== 'archived');
+      const vectorMatches = repo.searchVector(embedding, { limit: 5, visibility: { project, client: args.client } });
       const best = vectorMatches[0];
       matches = vectorMatches.map(note => ({ id: note.id, title: note.title, similarity: note.similarity }));
 
@@ -2857,14 +2874,14 @@ export async function handleMine(args: MineArgs, repo: NoteRepository, embedding
         rationale = `Partial match (similarity: ${best.similarity.toFixed(2)})`;
       }
     } else {
-      const simHashMatches = repo.findNearDuplicates(hash, 3, { project });
+      const simHashMatches = repo.findNearDuplicates(hash, 3, { project, client: args.client });
       if (simHashMatches.length > 0) {
         classification = 'SKIP';
         rationale = 'Similar to existing note by SimHash';
         matches = simHashMatches.slice(0, 5).map(note => ({ id: note.id, title: note.title }));
       } else {
         const query = [candidate.title, candidate.summary].filter(Boolean).join(' ');
-        const ftsMatches = query.trim() ? repo.search(query, { limit: 5, visibility: { project } }).filter(note => note.status !== 'archived') : [];
+        const ftsMatches = query.trim() ? repo.search(query, { limit: 5, visibility: { project, client: args.client } }) : [];
         if (ftsMatches.length > 0) {
           classification = 'REVIEW';
           rationale = 'Keyword overlap found (FTS5 fallback)';
@@ -2891,6 +2908,7 @@ export async function handleMine(args: MineArgs, repo: NoteRepository, embedding
           summary: result.candidate.summary,
           guidance: result.candidate.guidance,
           project: candidateProject,
+          client: args.client,
           model: args.model,
         }, repo, embeddingConfig, config, gitVersioning);
         const storedId = extractStoredId(storeResult);

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -292,6 +292,7 @@ export interface ContextResult {
 
 export interface HealthArgs {
   project: string;
+  client?: string;
   period?: string;
   telemetry?: boolean;
   model?: string;
@@ -397,9 +398,9 @@ export async function handleHealth(args: HealthArgs, repo: NoteRepository, confi
   if (!project) return 'Error: A valid project is required for knowledge health metrics.';
   const days = parsePeriodToDays(args.period);
   const periodLabel = `${days}d`;
-  const stats = repo.getStats(project);
-  const embeddingStats = repo.getEmbeddingStats(project);
-  const staleness = repo.getStalenessDistribution(project);
+  const stats = repo.getStats(project, args.client);
+  const embeddingStats = repo.getEmbeddingStats(project, args.client);
+  const staleness = repo.getStalenessDistribution(project, args.client);
 
   let output = project ? `# Knowledge Base Stats — ${project}\n\n` : '# Knowledge Base Stats\n\n';
 
@@ -425,9 +426,9 @@ export async function handleHealth(args: HealthArgs, repo: NoteRepository, confi
   }
 
   {
-    const brokenLinks = filterFalsePositiveBrokenLinks(repo.getBrokenLinks(project), config?.vault);
-    const oneWayLinks = repo.getOneWayLinks(project);
-    const unlinkedNotes = repo.getUnlinkedNotes(project);
+    const brokenLinks = filterFalsePositiveBrokenLinks(repo.getBrokenLinks(project, args.client), config?.vault);
+    const oneWayLinks = repo.getOneWayLinks(project, args.client);
+    const unlinkedNotes = repo.getUnlinkedNotes(project, args.client);
     const linkIssueCount = brokenLinks.length + oneWayLinks.length + unlinkedNotes.length;
     output += '\n## Link Health\n';
     if (linkIssueCount > 0) {
@@ -449,7 +450,7 @@ export async function handleHealth(args: HealthArgs, repo: NoteRepository, confi
 
   // --- Growth & activity ---
   const sinceMs = Date.now() - days * 86400000;
-  const growth = repo.getGrowthByKind(sinceMs, project);
+  const growth = repo.getGrowthByKind(sinceMs, project, args.client);
   const totalCreated = Object.values(growth).reduce((s, n) => s + n, 0);
   output += `\n## Growth (last ${periodLabel})\n`;
   output += `- Notes created: ${totalCreated}\n`;
@@ -1290,7 +1291,10 @@ export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedd
   const requestedStatus = args.status ? toNoteStatus(args.status, 'fleeting') : undefined;
   if (args.project && config?.search?.alwaysIncludeDomainNote !== false &&
       (!requestedStatus || requestedStatus === 'permanent')) {
-    domainNote = repo.getDomainNote(project);
+    const domainCandidate = repo.getDomainNote(project);
+    domainNote = domainCandidate
+      ? repo.getByIdVisible(domainCandidate.id, { project, client: args.client })
+      : null;
     if (domainNote) {
       const domainId = domainNote.id;
       results = results.filter(r => r.id !== domainId);
@@ -1421,8 +1425,12 @@ function globalReferenceEvidence(candidate: PublishGlobalCandidate, repo: NoteRe
   const projectReferences: string[] = [];
   const outboundLinks: string[] = [];
   const fields = ['title', 'content', 'summary', 'guidance'] as const;
-  const active = repo.getAllActiveNotes();
-  const localNotes = active.filter(note => parseKnowledgeApplicability(note.tags).type === 'project-local');
+  const allNotes = repo.getAll(Number.MAX_SAFE_INTEGER);
+  const scopedNotes = allNotes.map(note => ({ note, applicability: parseKnowledgeApplicability(note.tags) }));
+  const localNotes = scopedNotes
+    .filter(item => item.applicability.type === 'project-local')
+    .map(item => item.note);
+  const nonGlobalNotes = scopedNotes.filter(item => item.applicability.type !== 'global');
   const registeredNames = new Set(repo.getAllProjects());
   for (const note of localNotes) {
     if (note.kind === 'index') registeredNames.add(note.title);
@@ -1436,11 +1444,15 @@ function globalReferenceEvidence(candidate: PublishGlobalCandidate, repo: NoteRe
     }
     const projectPath = value.match(/(?:^|\b|[\\/])projects[\\/][^\s\]|)]+/iu);
     if (projectPath) projectReferences.push(`${field}:project-path:${projectPath[0].trim().replace(/^[/\\]/, '')}`);
-    for (const note of localNotes) {
-      const slug = path.basename(note.path, '.md').replace(`${note.id}-`, '');
-      if (new RegExp(`(^|[^\\p{L}\\p{N}])${escapeReferenceRegex(note.id)}(?=$|[^\\p{L}\\p{N}])`, 'iu').test(value)) projectReferences.push(`${field}:local-id:${note.id}`);
-      if (slug && new RegExp(`\\[\\[[^\\]]*${escapeReferenceRegex(slug)}(?:\\||\\]\\])`, 'iu').test(value)) {
-        projectReferences.push(`${field}:local-wikilink:${slug}`);
+    for (const { note, applicability } of nonGlobalNotes) {
+      if (new RegExp(`(^|[^\\p{L}\\p{N}])${escapeReferenceRegex(note.id)}(?=$|[^\\p{L}\\p{N}])`, 'iu').test(value)) {
+        projectReferences.push(`${field}:${applicability.type === 'project-local' ? 'local' : 'unclassified'}-id:${note.id}`);
+      }
+      if (applicability.type === 'project-local') {
+        const slug = path.basename(note.path, '.md').replace(`${note.id}-`, '');
+        if (slug && new RegExp(`\\[\\[[^\\]]*${escapeReferenceRegex(slug)}(?:\\||\\]\\])`, 'iu').test(value)) {
+          projectReferences.push(`${field}:local-wikilink:${slug}`);
+        }
       }
     }
   }
@@ -1598,7 +1610,8 @@ export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, c
       const token = publicationToken(source, args.candidate);
       const valid = evidence.errors.length === 0 && evidence.duplicates.length === 0;
       if (isPreview) {
-        return JSON.stringify({ action: 'publish-global', mode: 'preview', valid, source: { id: source.id, updated_at: source.updated_at }, targetScope: 'global', candidateHash: createHash('sha256').update(canonicalPublishCandidate(args.candidate)).digest('hex'), confirmationToken: token, ...evidence }, null, 2);
+        const preview = { action: 'publish-global', mode: 'preview', valid, source: { id: source.id, updated_at: source.updated_at }, targetScope: 'global', candidateHash: createHash('sha256').update(canonicalPublishCandidate(args.candidate)).digest('hex'), ...evidence };
+        return JSON.stringify(valid ? { ...preview, confirmationToken: token } : preview, null, 2);
       }
       if (!args.confirm) return 'Error: confirm=true is required to apply publish-global.';
       if (!args.token) return 'Error: confirmation token is required to apply publish-global.';
@@ -2574,7 +2587,9 @@ function formatProjectOverview(project: string, logLimit: number, repo: NoteRepo
   const domainCandidate = repo.getDomainNote(project);
   const domainNote = domainCandidate ? repo.getByIdVisible(domainCandidate.id, visibility) : null;
   const projectNotes = repo.getRecentNotes(Number.MAX_SAFE_INTEGER, visibility);
-  const logNote = repo.getLogNote(project);
+  // Project logs contain titles for every client-scoped event and cannot be
+  // losslessly filtered because historical entries do not carry note IDs.
+  const logNote = client ? null : repo.getLogNote(project);
 
   if (projectNotes.length === 0 && !domainNote && !logNote) {
     return `No notes found for project "${project}". Store a project-scoped note first (include project parameter).`;

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -1057,7 +1057,7 @@ export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddi
 
   let content = args.content;
   if (args.related && args.related.length > 0) {
-    const relatedNotes = args.related.map(id => repo.getByIdVisible(id, { project, client: args.client }));
+    const relatedNotes = args.related.map(id => repo.getByIdVisible(id, { project, client: resolvedClient || undefined }));
     const hiddenIndex = relatedNotes.findIndex(note => note === null);
     if (hiddenIndex >= 0) {
       return `Error: Related note not found or not visible: ${args.related[hiddenIndex]}`;
@@ -1145,7 +1145,7 @@ export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddi
     try {
       if (noteEmbedding) {
         // Embedding-based similarity search
-        const vecResults = repo.searchVector(noteEmbedding, { limit: fetchLimit, visibility: { project, client: args.client } });
+        const vecResults = repo.searchVector(noteEmbedding, { limit: fetchLimit, visibility: { project, client: resolvedClient || undefined } });
         relatedNotes = vecResults
           .filter(n => isCandidate(n) && n.similarity >= minSimilarity)
           .slice(0, maxResults)
@@ -1154,7 +1154,7 @@ export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddi
         // FTS5 fallback — use title + summary as query
         const queryText = [args.title, args.summary].filter(Boolean).join(' ');
         if (queryText.trim()) {
-          const ftsResults = repo.search(queryText, { limit: fetchLimit, visibility: { project, client: args.client } });
+          const ftsResults = repo.search(queryText, { limit: fetchLimit, visibility: { project, client: resolvedClient || undefined } });
           relatedNotes = ftsResults
             .filter(n => isCandidate(n))
             .slice(0, maxResults)

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -2,10 +2,16 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { createHash } from 'crypto';
 import type { NoteKind, NoteStatus, Lifecycle, AppConfig } from './types.js';
 import { KIND_DEFAULT_STATUS, KIND_DEFAULT_LIFECYCLE, VALID_LIFECYCLES } from './types.js';
 
 const VALID_STATUSES = new Set<string>(['fleeting', 'permanent', 'archived']);
+
+function validateCurrentProject(project: string | undefined): string | undefined {
+  if (typeof project !== 'string' || project.trim() === '') return undefined;
+  return extractProjectTag([`project:${project}`]) || undefined;
+}
 
 function toNoteStatus(status: string | undefined, fallback: NoteStatus): NoteStatus {
   if (status && VALID_STATUSES.has(status)) return status as NoteStatus;
@@ -17,7 +23,7 @@ function toLifecycle(lifecycle: string | undefined, fallback: Lifecycle): Lifecy
   return fallback;
 }
 import type { NoteRepository, NoteMetadata } from './storage/NoteRepository.js';
-import { formatWikiLink } from './utils/wikilink.js';
+import { extractWikiLinks, formatWikiLink } from './utils/wikilink.js';
 import { renderNoteForSearch, renderNoteForAgent, computeStaleness } from './prompts.js';
 import { buildIndexContent, buildGlobalIndexContent, buildProjectsIndexContent, buildGeneralIndexContent, buildPreferencesIndexContent, buildGeneralKindIndexContent } from './storage/IndexBuilder.js';
 import { buildLogEntry, buildInitialLogContent, appendToLogContent, buildGlobalLogEntry, buildInitialGlobalLogContent, migrateGlobalLogContent } from './storage/LogAppender.js';
@@ -52,6 +58,7 @@ import { ensureObsidianScaffold, getObsidianScaffoldStatus } from './obsidian-sc
 import { contractPath } from './utils/path.js';
 import { getTemplate, getExpectedCategories, matchCategories, extractHeaders, stripExamplesBlock, CONFORMANCE_KINDS } from './template-handler.js';
 import type { GitVersioning } from './git-versioning.js';
+import { parseKnowledgeApplicability } from './knowledge-scope.js';
 
 // ---- Constants ----
 
@@ -188,7 +195,7 @@ export interface StoreArgs {
   tags?: string[];
   summary: string;
   guidance: string;
-  project?: string;
+  project: string;
   client?: string;
   related?: string[];
   model?: string;
@@ -207,7 +214,7 @@ export interface MineCandidate {
 
 export interface MineArgs {
   candidates: MineCandidate[];
-  project?: string;
+  project: string;
   dry_run?: boolean;
   model?: string;
 }
@@ -217,11 +224,20 @@ export interface SearchArgs {
   kind?: NoteKind;
   status?: string;
   lifecycle?: string;
-  project?: string;
+  project: string;
   client?: string;
   tags?: string[];
   limit?: number;
   model?: string;
+}
+
+export interface PublishGlobalCandidate {
+  title: string;
+  content: string;
+  kind: NoteKind;
+  summary: string;
+  guidance: string;
+  tags?: string[];
 }
 
 export interface MaintainArgs {
@@ -231,6 +247,10 @@ export interface MaintainArgs {
   days?: number;
   limit?: number;
   dryRun?: boolean;
+  candidate?: PublishGlobalCandidate;
+  confirm?: boolean;
+  token?: string;
+  project?: string;
   model?: string;
 }
 
@@ -241,7 +261,7 @@ export interface IngestArgs {
 }
 
 export interface ContextArgs {
-  project?: string;
+  project: string;
   logEntries?: number;
   model?: string;
   includePreferences?: boolean;
@@ -270,7 +290,7 @@ export interface ContextResult {
 }
 
 export interface HealthArgs {
-  project?: string;
+  project: string;
   period?: string;
   telemetry?: boolean;
   model?: string;
@@ -372,9 +392,10 @@ function parsePeriodToDays(period?: string): number {
 }
 
 export async function handleHealth(args: HealthArgs, repo: NoteRepository, config: AppConfig, embeddingConfig?: EmbeddingConfig | null, currentVersion?: string, gitVersioning?: GitVersioning | null): Promise<string> {
+  const project = validateCurrentProject(args.project);
+  if (!project) return 'Error: A valid project is required for knowledge health metrics.';
   const days = parsePeriodToDays(args.period);
   const periodLabel = `${days}d`;
-  const project = args.project;
   const stats = repo.getStats(project);
   const embeddingStats = repo.getEmbeddingStats(project);
   const staleness = repo.getStalenessDistribution(project);
@@ -771,12 +792,14 @@ function updateGlobalNavigation(
   event: string,
   repo: NoteRepository,
   config?: AppConfig,
+  options: { appendLog?: boolean } = {},
 ): string[] {
   const vaultPath = config?.vault;
   if (!vaultPath) return [];
   const changedPaths: string[] = [];
   let fleetingNotes: NoteMetadata[] | null = null;
   let unscopedNotes: NoteMetadata[] | null = null;
+  let applicablePersonalizations: NoteMetadata[] | null = null;
 
   const getFleetingNotes = (): NoteMetadata[] => {
     if (!fleetingNotes) fleetingNotes = repo.getFleetingNotes();
@@ -788,11 +811,19 @@ function updateGlobalNavigation(
     return unscopedNotes;
   };
 
+  const getApplicablePersonalizations = (): NoteMetadata[] => {
+    if (!applicablePersonalizations) {
+      applicablePersonalizations = repo.getPersonalizationNotes()
+        .filter(note => parseKnowledgeApplicability(note.tags).type !== 'unclassified');
+    }
+    return applicablePersonalizations;
+  };
+
   if (config?.navigation?.enableGlobalIndex !== false) {
     try {
       const projectStats = repo.getProjectStats();
       const totalNoteCount = repo.getStats().total;
-      const prefsCount = repo.getPersonalizationNotes().length;
+      const prefsCount = getApplicablePersonalizations().length;
       const generalCount = getUnscopedNotes().length;
       const fleetingCount = getFleetingNotes().length;
       const content = buildGlobalIndexContent(projectStats, prefsCount, generalCount, fleetingCount, totalNoteCount, {
@@ -822,7 +853,7 @@ function updateGlobalNavigation(
     }
   }
 
-  if (config?.navigation?.enableGlobalLog !== false) {
+  if (config?.navigation?.enableGlobalLog !== false && options.appendLog !== false) {
     try {
       const globalLogPath = path.join(vaultPath, 'log.md');
       const entry = buildGlobalLogEntry(project, event);
@@ -859,7 +890,7 @@ function updateGlobalNavigation(
   if (config?.navigation?.enableGlobalIndex !== false) {
     try {
       const unscopedNotes = getUnscopedNotes();
-      const personalizationNotes = repo.getPersonalizationNotes();
+      const personalizationNotes = getApplicablePersonalizations();
       const generalDir = path.join(vaultPath, 'general');
       if (unscopedNotes.length > 0) {
         const content = buildGeneralIndexContent(unscopedNotes);
@@ -976,9 +1007,17 @@ function updateGlobalNavigation(
 // ---- Handlers ----
 
 export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddingConfig?: EmbeddingConfig | null, config?: AppConfig, gitVersioning?: GitVersioning | null): Promise<string> {
-  const project = args.project === undefined ? undefined : extractProjectTag([`project:${args.project}`]);
-  if (args.project !== undefined && !project) {
-    return `Error: Invalid project name: "${args.project}"`;
+  const project = validateCurrentProject(args.project);
+  if (!project) {
+    return 'Error: A valid project is required for routine knowledge storage.';
+  }
+  const suppliedTags = args.tags || [];
+  const projectTags = suppliedTags.filter(tag => tag.startsWith('project:'));
+  if (suppliedTags.includes('scope:global')) {
+    return 'Error: Routine storage cannot create global knowledge. Global creation requires maintenance publication.';
+  }
+  if (projectTags.length > 1 || projectTags.some(tag => tag !== `project:${project}`)) {
+    return `Error: Tags must contain at most the current project tag project:${project}.`;
   }
 
   const effectiveStatus = toNoteStatus(args.status, KIND_DEFAULT_STATUS[args.kind]);
@@ -989,14 +1028,8 @@ export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddi
   if (!lifecycleExplicit && lifecycleDefaults?.detectSnapshotFromSlug !== false && /\d{4}-\d{2}-\d{2}/.test(args.title)) {
     effectiveLifecycle = 'snapshot';
   }
-  const tags = [...(args.tags || [])];
-
-  if (project) {
-    for (let i = tags.length - 1; i >= 0; i--) {
-      if (tags[i].startsWith('project:')) tags.splice(i, 1);
-    }
-    tags.push(`project:${project}`);
-  }
+  const tags = suppliedTags.filter(tag => !tag.startsWith('project:'));
+  tags.push(`project:${project}`);
 
   if (STRUCTURAL_KINDS.has(args.kind)) {
     return `Error: ${args.kind} notes are auto-generated per project. Use knowledge-context to view them.`;
@@ -1023,12 +1056,14 @@ export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddi
 
   let content = args.content;
   if (args.related && args.related.length > 0) {
-    const links = args.related.map(id => {
-      const existing = repo.getById(id);
-      if (existing) {
-        return formatWikiLink({ id, display: existing.title });
-      }
-      return formatWikiLink({ id });
+    const relatedNotes = args.related.map(id => repo.getByIdVisible(id, { project, client: args.client }));
+    const hiddenIndex = relatedNotes.findIndex(note => note === null);
+    if (hiddenIndex >= 0) {
+      return `Error: Related note not found or not visible: ${args.related[hiddenIndex]}`;
+    }
+    const links = args.related.map((id, index) => {
+      const existing = relatedNotes[index];
+      return formatWikiLink({ id, display: existing?.title });
     });
     content += '\n\n## Related\n' + links.map(l => `- ${l}`).join('\n');
   }
@@ -1109,7 +1144,7 @@ export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddi
     try {
       if (noteEmbedding) {
         // Embedding-based similarity search
-        const vecResults = repo.searchVector(noteEmbedding, { limit: fetchLimit });
+        const vecResults = repo.searchVector(noteEmbedding, { limit: fetchLimit, visibility: { project, client: args.client } });
         relatedNotes = vecResults
           .filter(n => isCandidate(n) && n.similarity >= minSimilarity)
           .slice(0, maxResults)
@@ -1118,7 +1153,7 @@ export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddi
         // FTS5 fallback — use title + summary as query
         const queryText = [args.title, args.summary].filter(Boolean).join(' ');
         if (queryText.trim()) {
-          const ftsResults = repo.search(queryText, { limit: fetchLimit });
+          const ftsResults = repo.search(queryText, { limit: fetchLimit, visibility: { project, client: args.client } });
           relatedNotes = ftsResults
             .filter(n => isCandidate(n))
             .slice(0, maxResults)
@@ -1217,12 +1252,15 @@ export async function handleStore(args: StoreArgs, repo: NoteRepository, embeddi
 export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedding?: number[] | null, config?: AppConfig): string {
   const requestedLimit = args.limit || 10;
   const excludeStructuralKinds = config?.search?.excludeLogFromSearch !== false && !STRUCTURAL_KINDS.has(args.kind as string);
-  const searchLimit = args.project || excludeStructuralKinds ? Math.min(requestedLimit * 10, 100) : requestedLimit;
+  const project = validateCurrentProject(args.project);
+  if (!project) return 'Error: A valid project is required for knowledge search.';
+  const searchLimit = excludeStructuralKinds ? Math.min(requestedLimit * 10, 100) : requestedLimit;
   let results = repo.searchHybrid(args.query, queryEmbedding || null, {
     kind: args.kind,
     status: args.status ? toNoteStatus(args.status, 'fleeting') : undefined,
     tags: args.tags,
     limit: searchLimit,
+    visibility: { project, client: args.client },
   });
 
   if (excludeStructuralKinds) {
@@ -1232,14 +1270,6 @@ export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedd
   if (args.lifecycle) {
     const lifecycleFilter = args.lifecycle;
     results = results.filter(note => note.lifecycle === lifecycleFilter);
-  }
-
-  if (args.project) {
-    const projectPrefix = `project:${args.project}`;
-    results = results.filter(note => {
-      const tags = Array.isArray(note.tags) ? note.tags : [];
-      return tags.some(t => t === projectPrefix || t.startsWith(`${projectPrefix}:`));
-    });
   }
 
   if (args.client) {
@@ -1257,7 +1287,7 @@ export function handleSearch(args: SearchArgs, repo: NoteRepository, queryEmbedd
   // Always-include domain note for project-scoped searches
   let domainNote: NoteMetadata | null = null;
   if (args.project && config?.search?.alwaysIncludeDomainNote !== false) {
-    domainNote = repo.getDomainNote(args.project);
+    domainNote = repo.getDomainNote(project);
     if (domainNote) {
       const domainId = domainNote.id;
       results = results.filter(r => r.id !== domainId);
@@ -1351,10 +1381,243 @@ function detectPreferenceAuditSignals(note: NoteMetadata): PreferenceAuditSignal
   return signals;
 }
 
+const PUBLISHABLE_KINDS = new Set<NoteKind>(['personalization', 'reference', 'decision', 'procedure', 'resource', 'observation']);
+
+function canonicalPublishCandidate(candidate: PublishGlobalCandidate): string {
+  return JSON.stringify({
+    title: candidate.title.trim(),
+    content: candidate.content.trim(),
+    kind: candidate.kind,
+    summary: candidate.summary.trim(),
+    guidance: candidate.guidance.trim(),
+    tags: [...new Set(candidate.tags || [])].sort(),
+  });
+}
+
+function publicationToken(source: NoteMetadata, candidate: PublishGlobalCandidate): string {
+  return createHash('sha256')
+    .update(JSON.stringify({ sourceId: source.id, sourceUpdatedAt: source.updated_at, candidate: canonicalPublishCandidate(candidate), scope: 'global' }))
+    .digest('hex');
+}
+
+function projectAssignmentToken(note: NoteMetadata, project: string): string {
+  return createHash('sha256')
+    .update(JSON.stringify({ noteId: note.id, noteUpdatedAt: note.updated_at, currentTags: [...note.tags].sort(), project }))
+    .digest('hex');
+}
+
+function escapeReferenceRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function globalReferenceEvidence(candidate: PublishGlobalCandidate, repo: NoteRepository, allowGlobalTag = false): {
+  projectReferences: string[];
+  outboundLinks: string[];
+} {
+  const projectReferences: string[] = [];
+  const outboundLinks: string[] = [];
+  const fields = ['title', 'content', 'summary', 'guidance'] as const;
+  const active = repo.getAllActiveNotes();
+  const localNotes = active.filter(note => parseKnowledgeApplicability(note.tags).type === 'project-local');
+  const registeredNames = new Set(repo.getAllProjects());
+  for (const note of localNotes) {
+    if (note.kind === 'index') registeredNames.add(note.title);
+  }
+  const values: Array<[string, string]> = fields.map(field => [field, candidate[field] || '']);
+  values.push(['tags', (candidate.tags || []).join('\n')]);
+  for (const [field, value] of values) {
+    for (const name of [...registeredNames].sort()) {
+      const match = value.match(new RegExp(`(^|[^\\p{L}\\p{N}])${escapeReferenceRegex(name)}(?=$|[^\\p{L}\\p{N}])`, 'iu'));
+      if (match) projectReferences.push(`${field}:project-name:${name}`);
+    }
+    const projectPath = value.match(/(?:^|\b|[\\/])projects[\\/][^\s\]|)]+/iu);
+    if (projectPath) projectReferences.push(`${field}:project-path:${projectPath[0].trim().replace(/^[/\\]/, '')}`);
+    for (const note of localNotes) {
+      const slug = path.basename(note.path, '.md').replace(`${note.id}-`, '');
+      if (new RegExp(`(^|[^\\p{L}\\p{N}])${escapeReferenceRegex(note.id)}(?=$|[^\\p{L}\\p{N}])`, 'iu').test(value)) projectReferences.push(`${field}:local-id:${note.id}`);
+      if (slug && new RegExp(`\\[\\[[^\\]]*${escapeReferenceRegex(slug)}(?:\\||\\]\\])`, 'iu').test(value)) {
+        projectReferences.push(`${field}:local-wikilink:${slug}`);
+      }
+    }
+  }
+  for (const tag of candidate.tags || []) {
+    if ((!allowGlobalTag && tag === 'scope:global') || tag.startsWith('project:') || tag.startsWith('scope:')) {
+      projectReferences.push(`tag:${tag}`);
+    }
+  }
+  for (const link of extractWikiLinks(candidate.content)) {
+    const targetId = repo.resolveLink(link.slug);
+    if (!targetId) outboundLinks.push(`unresolved:[[${link.slug}]]`);
+    else {
+      const target = repo.getById(targetId);
+      const targetScope = target ? parseKnowledgeApplicability(target.tags).type : 'missing';
+      outboundLinks.push(`${targetScope === 'global' ? 'global' : targetScope}:[[${link.slug}]]->${targetId}`);
+    }
+  }
+  return { projectReferences: [...new Set(projectReferences)].sort(), outboundLinks: [...new Set(outboundLinks)].sort() };
+}
+
+function publicationValidation(source: NoteMetadata | null, candidate: PublishGlobalCandidate | undefined, repo: NoteRepository): {
+  errors: string[];
+  duplicates: string[];
+  projectReferences: string[];
+  outboundLinks: string[];
+} {
+  const errors: string[] = [];
+  const duplicates: string[] = [];
+  const projectReferences: string[] = [];
+  const outboundLinks: string[] = [];
+  if (!source) errors.push('source: not found');
+  else {
+    const scope = parseKnowledgeApplicability(source.tags);
+    if (source.status === 'archived') errors.push('source: must be active');
+    if (scope.type !== 'project-local') errors.push('source: must have exactly one project scope');
+  }
+  if (!candidate) {
+    errors.push('candidate: required');
+    return { errors, duplicates, projectReferences, outboundLinks };
+  }
+  for (const field of ['title', 'content', 'summary', 'guidance'] as const) {
+    if (!candidate[field]?.trim()) errors.push(`candidate.${field}: required`);
+  }
+  if (!PUBLISHABLE_KINDS.has(candidate.kind)) errors.push('candidate.kind: must be non-domain and non-structural');
+  const referenceEvidence = globalReferenceEvidence(candidate, repo);
+  projectReferences.push(...referenceEvidence.projectReferences);
+  outboundLinks.push(...referenceEvidence.outboundLinks);
+  if ((candidate.tags || []).some(tag => tag === 'scope:global' || tag.startsWith('project:') || tag.startsWith('scope:'))) {
+    errors.push('candidate.tags: project and scope tags are server-managed');
+  }
+  if (projectReferences.length > 0) errors.push('candidate: contains project-specific evidence');
+
+  const canonical = canonicalPublishCandidate(candidate);
+  for (const note of repo.getAllGlobalNotes(Number.MAX_SAFE_INTEGER)) {
+    const noteCanonical = canonicalPublishCandidate({
+      title: note.title,
+      content: note.content,
+      kind: note.kind,
+      summary: note.summary || '',
+      guidance: note.guidance || '',
+      tags: note.tags.filter(tag => tag !== 'scope:global'),
+    });
+    if (noteCanonical === canonical || note.title.trim().toLowerCase() === candidate.title.trim().toLowerCase()) {
+      duplicates.push(`${note.id}:${note.title}`);
+    }
+  }
+  for (const evidence of outboundLinks) {
+    if (evidence.startsWith('unresolved:')) errors.push(`candidate.content: ${evidence}`);
+    else if (!evidence.startsWith('global:')) errors.push(`candidate.content: outbound target is not global (${evidence})`);
+  }
+  return { errors: [...new Set(errors)], duplicates, projectReferences, outboundLinks };
+}
+
 export async function handleMaintain(args: MaintainArgs, repo: NoteRepository, config: AppConfig, embeddingConfig?: EmbeddingConfig | null, currentVersion?: string, gitVersioning?: GitVersioning | null): Promise<string> {
   scheduleTelemetryWrite('maintain', () => repo.recordToolInvocation('maintain', args.action, undefined, args.model));
 
   switch (args.action) {
+    case 'scope-inventory': {
+      const notes = repo.getAll(Number.MAX_SAFE_INTEGER)
+        .filter(note => note.status !== 'archived')
+        .map(note => ({ note, applicability: parseKnowledgeApplicability(note.tags || []) }))
+        .filter((item): item is typeof item & { applicability: { type: 'unclassified'; reason: 'missing' | 'multiple-projects' | 'conflict' } } => item.applicability.type === 'unclassified')
+        .sort((a, b) => a.note.id.localeCompare(b.note.id));
+      const groups: Record<string, unknown[]> = {};
+      for (const { note, applicability } of notes) {
+        const relativePath = path.relative(config.vault, note.path).split(path.sep).join('/');
+        const pathProject = relativePath.match(/^projects\/([^/]+)\//)?.[1];
+        const tagProjects = [...new Set(note.tags.filter(tag => tag.startsWith('project:')).map(tag => tag.slice(8)).filter(Boolean))].sort();
+        const key = `${applicability.reason}|${note.kind}|${relativePath}|${note.status}`;
+        if (!groups[key]) groups[key] = [];
+        groups[key].push({ id: note.id, title: note.title, evidence: { tagProjects, pathProject: pathProject || null } });
+      }
+      return JSON.stringify({
+        action: 'scope-inventory', mutated: false,
+        strictVisibility: { active: true, mode: 'fail-closed', unclassifiedExcluded: true },
+        counts: { activeUnclassified: notes.length, ready: notes.length === 0 }, groups,
+      }, null, 2);
+    }
+    case 'assign-project': {
+      if (!args.noteId) return 'Error: noteId is required for assign-project action.';
+      const targetProject = validateCurrentProject(args.project);
+      if (!targetProject) return 'Error: a valid project is required for assign-project action.';
+      const note = repo.getById(args.noteId);
+      if (!note) return `Note not found: ${args.noteId}`;
+      const applicability = parseKnowledgeApplicability(note.tags || []);
+      if (note.status === 'archived' || STRUCTURAL_KINDS.has(note.kind) || applicability.type !== 'unclassified') {
+        return 'Error: assign-project accepts only active unclassified non-structural notes.';
+      }
+      const tags = [...note.tags.filter(tag => !tag.startsWith('project:') && !tag.startsWith('scope:')), `project:${targetProject}`];
+      const token = projectAssignmentToken(note, targetProject);
+      const preview = { action: 'assign-project', noteId: note.id, project: targetProject, removedScopeTags: note.tags.filter(tag => tag.startsWith('project:') || tag.startsWith('scope:')), tags };
+      if (args.dryRun !== false) return JSON.stringify({ ...preview, mode: 'preview', mutated: false, confirmationToken: token }, null, 2);
+      if (!args.confirm) return 'Error: confirm=true is required to apply assign-project.';
+      if (!args.token) return 'Error: confirmation token is required to apply assign-project.';
+      if (args.token !== token) return 'Error: confirmation token is stale or does not match the note and target project.';
+      const moved = repo.assignProject(note.id, targetProject, tags);
+      if (!moved) return `Error: project assignment failed for note ${args.noteId}; the note was not changed.`;
+      const changedPaths = [...new Set([moved.oldPath, moved.newPath, ...updateProjectNavigation(targetProject, `Assigned "${note.title}" to project ${targetProject}`, repo, config), ...updateGlobalNavigation(targetProject, `Assigned "${note.title}" to project ${targetProject}`, repo, config)])];
+      logToFile('INFO', 'Assigned legacy note to project', { noteId: note.id, project: targetProject });
+      if (gitVersioning) await gitVersioning.recordImmediate({ op: 'assign-project', noteId: note.id, title: note.title, kind: note.kind, project: targetProject }, changedPaths);
+      return JSON.stringify({ ...preview, mode: 'apply', mutated: true, oldPath: moved.oldPath, path: moved.newPath }, null, 2);
+    }
+    case 'global-reference-audit': {
+      const notes = repo.getAllGlobalNotes(Number.MAX_SAFE_INTEGER).sort((a, b) => a.id.localeCompare(b.id));
+      const findings = notes.map(note => {
+        const evidence = globalReferenceEvidence({
+          title: note.title, content: note.content, kind: note.kind,
+          summary: note.summary || '', guidance: note.guidance || '', tags: note.tags,
+        }, repo, true);
+        return { id: note.id, title: note.title, ...evidence };
+      }).filter(item => item.projectReferences.length > 0 || item.outboundLinks.some(link => !link.startsWith('global:')));
+      return JSON.stringify({ action: 'global-reference-audit', mutated: false, scanned: notes.length, findings }, null, 2);
+    }
+    case 'publish-global': {
+      if (!args.noteId) return 'Error: noteId is required for publish-global action.';
+      const source = repo.getById(args.noteId);
+      const evidence = publicationValidation(source, args.candidate, repo);
+      const isPreview = args.dryRun !== false;
+      if (!source || !args.candidate) {
+        return JSON.stringify({ action: 'publish-global', mode: isPreview ? 'preview' : 'apply', valid: false, ...evidence }, null, 2);
+      }
+      const token = publicationToken(source, args.candidate);
+      const valid = evidence.errors.length === 0 && evidence.duplicates.length === 0;
+      if (isPreview) {
+        return JSON.stringify({ action: 'publish-global', mode: 'preview', valid, source: { id: source.id, updated_at: source.updated_at }, targetScope: 'global', candidateHash: createHash('sha256').update(canonicalPublishCandidate(args.candidate)).digest('hex'), confirmationToken: token, ...evidence }, null, 2);
+      }
+      if (!args.confirm) return 'Error: confirm=true is required to apply publish-global.';
+      if (!args.token) return 'Error: confirmation token is required to apply publish-global.';
+      if (args.token !== token) return 'Error: confirmation token is stale or does not match the source and canonical candidate.';
+      if (!valid) {
+        return JSON.stringify({ action: 'publish-global', mode: 'apply', valid: false, ...evidence }, null, 2);
+      }
+
+      const candidateTags = [...new Set([...(args.candidate.tags || []), 'scope:global'])];
+      const derivative = repo.store(args.candidate.content.trim(), {
+        title: args.candidate.title.trim(),
+        kind: args.candidate.kind,
+        status: 'permanent',
+        lifecycle: KIND_DEFAULT_LIFECYCLE[args.candidate.kind],
+        tags: candidateTags,
+        summary: args.candidate.summary.trim(),
+        guidance: args.candidate.guidance.trim(),
+      });
+      try {
+        repo.addLocalToGlobalRelation(source.id, derivative.id);
+      } catch (error) {
+        repo.remove(derivative.id);
+        return `Error: Failed to link the local source to its global derivative; publication was rolled back (${error instanceof Error ? error.message : String(error)}).`;
+      }
+      const projectScope = parseKnowledgeApplicability(source.tags);
+      const changedPaths = [source.path, derivative.path];
+      if (projectScope.type === 'project-local') {
+        changedPaths.push(...updateProjectNavigation(projectScope.project, `Published global derivative "${args.candidate.title.trim()}" from "${source.title}"`, repo, config));
+      }
+      changedPaths.push(...updateGlobalNavigation(null, `Published global note "${args.candidate.title.trim()}"`, repo, config, { appendLog: false }));
+      logToFile('INFO', 'Published global derivative', { sourceId: source.id, derivativeId: derivative.id });
+      if (gitVersioning) {
+        await gitVersioning.recordImmediate({ op: 'publish-global', noteId: source.id, title: args.candidate.title.trim(), kind: args.candidate.kind, project: projectScope.type === 'project-local' ? projectScope.project : undefined }, changedPaths);
+      }
+      return JSON.stringify({ action: 'publish-global', mode: 'apply', created: derivative.id, source: source.id, relation: `${source.id}->${derivative.id}` }, null, 2);
+    }
     case 'promote': {
       if (!args.noteId) return 'Error: noteId is required for promote action.';
       const note = repo.getById(args.noteId);
@@ -2226,12 +2489,13 @@ export function buildPreferenceCapsule(
   const scoped: NoteMetadata[] = [];
 
   for (const note of repo.getPermanentPersonalizations()) {
-    const projects = note.tags.filter(tag => tag.startsWith('project:')).map(tag => tag.slice('project:'.length));
+    const applicability = parseKnowledgeApplicability(note.tags);
     const clients = note.tags.filter(tag => tag.startsWith('client:')).map(tag => tag.slice('client:'.length));
-    const projectMatches = projects.length === 0 || (targets.project !== undefined && projects.includes(targets.project));
+    const projectMatches = applicability.type === 'global'
+      || (applicability.type === 'project-local' && applicability.project === targets.project);
     const clientMatches = clients.length === 0 || clients.includes('all') || (targets.client !== undefined && clients.includes(targets.client));
     if (!projectMatches || !clientMatches) continue;
-    (projects.length === 0 && clients.length === 0 ? universal : scoped).push(note);
+    (applicability.type === 'global' && clients.length === 0 ? universal : scoped).push(note);
   }
 
   const ranked: NoteMetadata[] = [];
@@ -2271,11 +2535,10 @@ export function buildPreferenceCapsule(
 }
 
 export function handleContextResult(args: ContextArgs, repo: NoteRepository, config?: AppConfig): ContextResult {
-  const project = args.project;
+  const project = validateCurrentProject(args.project);
+  if (!project) return { text: 'Error: A valid project is required for knowledge context.' };
   const logLimit = Math.max(1, args.logEntries ?? config?.navigation?.overviewLogEntryLimit ?? 10);
-  const text = project
-    ? formatProjectOverview(project, logLimit, repo, config, args.model)
-    : formatGlobalOverview(logLimit, repo, config, args.model);
+  const text = formatProjectOverview(project, logLimit, repo, args.client, args.model);
 
   return {
     text,
@@ -2289,9 +2552,11 @@ export function handleContext(args: ContextArgs, repo: NoteRepository, config?: 
   return handleContextResult(args, repo, config).text;
 }
 
-function formatProjectOverview(project: string, logLimit: number, repo: NoteRepository, config?: AppConfig, model?: string): string {
-  const domainNote = repo.getDomainNote(project);
-  const projectNotes = repo.getProjectNotes(project);
+function formatProjectOverview(project: string, logLimit: number, repo: NoteRepository, client?: string, model?: string): string {
+  const visibility = { project, client };
+  const domainCandidate = repo.getDomainNote(project);
+  const domainNote = domainCandidate ? repo.getByIdVisible(domainCandidate.id, visibility) : null;
+  const projectNotes = repo.getRecentNotes(Number.MAX_SAFE_INTEGER, visibility);
   const logNote = repo.getLogNote(project);
 
   if (projectNotes.length === 0 && !domainNote && !logNote) {
@@ -2370,76 +2635,6 @@ function formatProjectOverview(project: string, logLimit: number, repo: NoteRepo
   return output;
 }
 
-function formatGlobalOverview(logLimit: number, repo: NoteRepository, config?: AppConfig, model?: string): string {
-  const projectStats = repo.getProjectStats();
-  const kindStats = repo.getStatsByKind();
-  const stats = repo.getStats();
-  const recentNotes = repo.getRecentNotes(logLimit);
-
-  let output = '## Knowledge Base Overview\n\n';
-
-  // Projects
-  if (projectStats.length > 0) {
-    output += '### Projects\n';
-    for (const ps of projectStats) {
-      output += `- **${ps.project}**: ${ps.noteCount} notes\n`;
-    }
-    output += '\n';
-  }
-
-  // Inventory by kind
-  const kindEntries = Object.entries(kindStats)
-    .filter(([kind]) => kind !== 'index' && kind !== 'log')
-    .sort((a, b) => b[1].total - a[1].total);
-  if (kindEntries.length > 0) {
-    output += '### Inventory\n';
-    const parts = kindEntries.map(([kind, s]) => `${s.total} ${kind}`);
-    output += parts.join(', ') + `  (${stats.total} total)\n\n`;
-  }
-
-  // Unscoped count — use direct DB count to avoid double-counting multi-project notes
-  const scopedCount = repo.getScopedNoteCount();
-  const unscopedCount = stats.total - stats.archived - scopedCount;
-  if (unscopedCount > 0) {
-    output += `Unscoped notes: ${unscopedCount}\n\n`;
-  }
-
-  // Recent notes
-  if (recentNotes.length > 0) {
-    output += '### Recent Notes\n';
-    for (const note of recentNotes) {
-      const status = note.status === 'permanent' ? '⦸' : note.status === 'archived' ? '▪' : '▫';
-      const project = extractProjectFromTags(note.tags);
-      const projectSuffix = project ? ` [${project}]` : '';
-      output += `- ${status} **${note.title}** (${note.kind})${projectSuffix}\n`;
-    }
-    if (stats.total > recentNotes.length) {
-      output += `\n(showing ${recentNotes.length} of ${stats.total})\n`;
-    }
-    output += '\n';
-  }
-
-  // Resources
-  const allNotes = repo.getAll(Number.MAX_SAFE_INTEGER);
-  const resources = allNotes.filter(n => n.kind === 'resource' && n.status !== 'archived');
-  if (resources.length > 0) {
-    output += '### Resources\n';
-    for (const note of resources.slice(0, 20)) {
-      output += `- **${note.title}** [${note.id}]\n`;
-    }
-    if (resources.length > 20) {
-      output += `\n(showing 20 of ${resources.length})\n`;
-    }
-    output += '\n';
-  }
-
-  if (!model) {
-    output += MODEL_HINT;
-  }
-
-  return output;
-}
-
 export async function handleOpen(args: OpenArgs, config: AppConfig, repo?: NoteRepository): Promise<string> {
   const vaultPath = config.vault;
 
@@ -2480,7 +2675,7 @@ export async function handleOpen(args: OpenArgs, config: AppConfig, repo?: NoteR
   if (error) {
     return `Failed to launch Obsidian: ${error}`;
   }
-  return formatSuccessMessage(vaultPath, resolvedProject);
+  return `${formatSuccessMessage(vaultPath, resolvedProject)}\nObsidian is a full-vault human browsing surface; project focus does not isolate other projects.`;
 }
 
 export interface TemplateArgs {
@@ -2491,11 +2686,15 @@ export interface TemplateArgs {
 
 export interface GetArgs {
   noteId: string;
+  project: string;
+  client?: string;
   model?: string;
 }
 
 export function handleGet(args: GetArgs, repo: NoteRepository): string {
-  const note = repo.getById(args.noteId);
+  const project = validateCurrentProject(args.project);
+  if (!project) return 'Error: A valid project is required to retrieve knowledge.';
+  const note = repo.getByIdVisible(args.noteId, { project, client: args.client });
   if (!note) return `Note not found: ${args.noteId}`;
   scheduleTelemetryWrite('get access', () => repo.updateLastAccessed([note.id]));
 
@@ -2568,6 +2767,8 @@ function extractStoredId(result: string): string | undefined {
 }
 
 export async function handleMine(args: MineArgs, repo: NoteRepository, embeddingConfig?: EmbeddingConfig | null, config?: AppConfig, gitVersioning?: GitVersioning | null): Promise<string> {
+  const project = validateCurrentProject(args.project);
+  if (!project) return 'Error: A valid project is required for knowledge mining.';
   if (args.candidates.length === 0) {
     return 'No mining candidates provided. Extract candidate notes first, then call knowledge-mine with at least one candidate.';
   }
@@ -2577,8 +2778,18 @@ export async function handleMine(args: MineArgs, repo: NoteRepository, embedding
 
   const validationErrors: string[] = [];
   for (let i = 0; i < args.candidates.length; i++) {
-    const validation = validateMineCandidate(args.candidates[i], i + 1, args.project);
+    const candidate = args.candidates[i];
+    const validation = validateMineCandidate(candidate, i + 1, project);
     if (validation) validationErrors.push(validation);
+    const tags = candidate.tags || [];
+    const projectTags = tags.filter(tag => tag.startsWith('project:'));
+    if (tags.includes('scope:global')) validationErrors.push(`Candidate ${i + 1}: routine mining cannot create global knowledge.`);
+    if (projectTags.length > 1 || projectTags.some(tag => tag !== `project:${project}`)) {
+      validationErrors.push(`Candidate ${i + 1}: project tags conflict with project:${project}.`);
+    }
+    if (candidate.project !== undefined && candidate.project !== project) {
+      validationErrors.push(`Candidate ${i + 1}: candidate project conflicts with project:${project}.`);
+    }
   }
   if (validationErrors.length > 0) {
     return `Error: ${validationErrors.join('\n')}`;
@@ -2634,7 +2845,7 @@ export async function handleMine(args: MineArgs, repo: NoteRepository, embedding
     const embedding = embeddings[i]?.embedding;
 
     if (embedding) {
-      const vectorMatches = repo.searchVector(embedding, { limit: 5 }).filter(note => note.status !== 'archived');
+      const vectorMatches = repo.searchVector(embedding, { limit: 5, visibility: { project } }).filter(note => note.status !== 'archived');
       const best = vectorMatches[0];
       matches = vectorMatches.map(note => ({ id: note.id, title: note.title, similarity: note.similarity }));
 
@@ -2646,14 +2857,14 @@ export async function handleMine(args: MineArgs, repo: NoteRepository, embedding
         rationale = `Partial match (similarity: ${best.similarity.toFixed(2)})`;
       }
     } else {
-      const simHashMatches = repo.findNearDuplicates(hash);
+      const simHashMatches = repo.findNearDuplicates(hash, 3, { project });
       if (simHashMatches.length > 0) {
         classification = 'SKIP';
         rationale = 'Similar to existing note by SimHash';
         matches = simHashMatches.slice(0, 5).map(note => ({ id: note.id, title: note.title }));
       } else {
         const query = [candidate.title, candidate.summary].filter(Boolean).join(' ');
-        const ftsMatches = query.trim() ? repo.search(query, { limit: 5 }).filter(note => note.status !== 'archived') : [];
+        const ftsMatches = query.trim() ? repo.search(query, { limit: 5, visibility: { project } }).filter(note => note.status !== 'archived') : [];
         if (ftsMatches.length > 0) {
           classification = 'REVIEW';
           rationale = 'Keyword overlap found (FTS5 fallback)';
@@ -2670,7 +2881,7 @@ export async function handleMine(args: MineArgs, repo: NoteRepository, embedding
       if (result.classification === 'SKIP') continue;
       const tags = [...(result.candidate.tags || [])];
       if (result.candidate.source) tags.push(`mined:${result.candidate.source}`);
-      const project = result.candidate.project ?? args.project;
+      const candidateProject = project;
       try {
         const storeResult = await handleStore({
           title: result.candidate.title,
@@ -2679,7 +2890,7 @@ export async function handleMine(args: MineArgs, repo: NoteRepository, embedding
           tags,
           summary: result.candidate.summary,
           guidance: result.candidate.guidance,
-          project,
+          project: candidateProject,
           model: args.model,
         }, repo, embeddingConfig, config, gitVersioning);
         const storedId = extractStoredId(storeResult);

--- a/src/tool-meta.ts
+++ b/src/tool-meta.ts
@@ -39,6 +39,7 @@ export const STORABLE_KINDS = [
 
 export const ALL_KINDS = [...STORABLE_KINDS, "index", "log"] as const;
 export const TEMPLATE_KINDS = [...STORABLE_KINDS, "log"] as const;
+export const PUBLISHABLE_KINDS = STORABLE_KINDS.filter(kind => kind !== "domain");
 
 export const STATUSES = ["fleeting", "permanent", "archived"] as const;
 
@@ -86,7 +87,7 @@ export const PUBLISH_GLOBAL_CANDIDATE_PROPERTIES: Record<string, ParamDef> = {
 		type: "string",
 		required: true,
 		description: "Global note kind — must be storable, non-domain, non-structural",
-		enum: STORABLE_KINDS,
+		enum: PUBLISHABLE_KINDS,
 	},
 	summary: {
 		type: "string",
@@ -371,8 +372,8 @@ export const TOOL_DEFINITIONS = [
 		name: "knowledge-context",
 		label: "Knowledge Context",
 		description:
-			"Get a context of the knowledge base. With project: domain note, inventory by kind, recent notes, " +
-			"resources, and activity log. Without project: all projects with note counts, global inventory, and recent notes.",
+			"Get context visible to the required current project: its domain note, inventory by kind, recent notes, " +
+			"resources, activity log, and automatically visible explicit global knowledge.",
 		promptSnippet:
 			"Load an open-zk-kb project context at the start of project work.",
 		promptGuidelines: [
@@ -607,6 +608,11 @@ export const TOOL_DEFINITIONS = [
 				type: "string",
 				required: true,
 				description: "Current project for duplicate screening and stored candidates",
+			},
+			client: {
+				type: "string",
+				required: false,
+				description: "Optional client applicability filter for duplicate screening",
 			},
 			dry_run: {
 				type: "boolean",

--- a/src/tool-meta.ts
+++ b/src/tool-meta.ts
@@ -478,6 +478,11 @@ export const TOOL_DEFINITIONS = [
 				required: true,
 				description: "Current project for scoped note metrics",
 			},
+			client: {
+				type: "string",
+				required: false,
+				description: "Optional client applicability filter for scoped note metrics",
+			},
 			period: {
 				type: "string",
 				required: false,

--- a/src/tool-meta.ts
+++ b/src/tool-meta.ts
@@ -58,6 +58,8 @@ export const MAINTAIN_ACTIONS = [
 	"embed",
 	"agent-docs",
 	"scope-audit",
+	"scope-inventory",
+	"assign-project",
 	"preference-audit",
 	"unlinked",
 	"broken-links",
@@ -65,7 +67,44 @@ export const MAINTAIN_ACTIONS = [
 	"migrate-layout",
 	"upgrade-vault",
 	"full",
+	"publish-global",
+	"global-reference-audit",
 ] as const;
+
+export const PUBLISH_GLOBAL_CANDIDATE_PROPERTIES: Record<string, ParamDef> = {
+	title: {
+		type: "string",
+		required: true,
+		description: "Distilled global note title — 3-6 word scannable label (max 10 words / 80 chars).",
+	},
+	content: {
+		type: "string",
+		required: true,
+		description: "Distilled global note content — project-agnostic knowledge",
+	},
+	kind: {
+		type: "string",
+		required: true,
+		description: "Global note kind — must be storable, non-domain, non-structural",
+		enum: STORABLE_KINDS,
+	},
+	summary: {
+		type: "string",
+		required: true,
+		description: "One-line present-tense key takeaway for global context",
+	},
+	guidance: {
+		type: "string",
+		required: true,
+		description: "Imperative actionable instruction for global agent use",
+	},
+	tags: {
+		type: "array",
+		required: false,
+		description: "Additional topical tags (must not contain project:* or scope:global — added automatically)",
+		items: { type: "string", required: true },
+	},
+};
 
 // ─── Content Structure Hints ──────────────────────────────────────────────────
 
@@ -193,8 +232,8 @@ export const TOOL_DEFINITIONS = [
 			},
 			project: {
 				type: "string",
-				required: false,
-				description: "Project scope — auto-adds project:<name> tag",
+				required: true,
+				description: "Current project scope — adds exactly one project:<name> tag",
 			},
 			client: {
 				type: "string",
@@ -296,8 +335,8 @@ export const TOOL_DEFINITIONS = [
 			},
 			project: {
 				type: "string",
-				required: false,
-				description: "Filter by project tag",
+				required: true,
+				description: "Current project; searches this project plus explicit global knowledge",
 			},
 			client: {
 				type: "string",
@@ -343,9 +382,8 @@ export const TOOL_DEFINITIONS = [
 		params: {
 			project: {
 				type: "string",
-				required: false,
-				description:
-					"Project name to get context for. Omit for global context.",
+				required: true,
+				description: "Current project whose visible context is requested",
 			},
 			logEntries: {
 				type: "number",
@@ -376,8 +414,8 @@ export const TOOL_DEFINITIONS = [
 		name: "knowledge-open",
 		label: "Open in Obsidian",
 		description:
-			"Open the knowledge base vault in Obsidian for visual browsing. " +
-			"Detects Obsidian installation and launches it pointed at the vault.",
+			"Open the knowledge base vault in Obsidian for full-vault human browsing. " +
+			"A project focuses its index but does not isolate the vault.",
 		promptSnippet:
 			"Open open-zk-kb notes in Obsidian for human review when requested.",
 		executionMode: "sequential",
@@ -404,6 +442,16 @@ export const TOOL_DEFINITIONS = [
 				required: true,
 				description: "Exact note ID to retrieve",
 			},
+			project: {
+				type: "string",
+				required: true,
+				description: "Current project used to validate note visibility",
+			},
+			client: {
+				type: "string",
+				required: false,
+				description: "Optional client applicability filter",
+			},
 			model: {
 				type: "string",
 				required: false,
@@ -426,8 +474,8 @@ export const TOOL_DEFINITIONS = [
 		params: {
 			project: {
 				type: "string",
-				required: false,
-				description: "Scope all metrics to a project",
+				required: true,
+				description: "Current project for scoped note metrics",
 			},
 			period: {
 				type: "string",
@@ -467,10 +515,12 @@ export const TOOL_DEFINITIONS = [
 					"Maintenance action: review (pending notes), dedupe (duplicates), promote, archive, delete, rebuild, " +
 					"format (re-serialize all note files with canonical frontmatter and navigation), upgrade, " +
 					"embed (backfill embeddings), agent-docs (audit/repair managed agent instruction files), " +
-					"scope-audit (detect mis-scoped client tags), preference-audit (read-only deterministic evidence for active personalization notes; never changes notes), unlinked (notes with no wikilinks), " +
+					"scope-audit (detect mis-scoped client tags), scope-inventory (read-only legacy applicability/readiness report), assign-project (confirmed legacy note classification), preference-audit (read-only deterministic evidence for active personalization notes; never changes notes), unlinked (notes with no wikilinks), " +
 					"broken-links (wikilinks to non-existent notes), link-health (combined report: unlinked notes + broken links + one-way links), " +
 					"migrate-layout (move flat vault to kind-based directory structure), " +
-					"upgrade-vault (refresh Obsidian scaffold assets), or " +
+					"upgrade-vault (refresh Obsidian scaffold assets), " +
+					"publish-global (project-local → global confirmed publication with preview + token), " +
+					"global-reference-audit (read-only explicit-global reference evidence), or " +
 					"full (composite: rebuild → migrate-layout → format → dedupe → embed → link-health, in dependency order).",
 				enum: MAINTAIN_ACTIONS,
 			},
@@ -478,7 +528,12 @@ export const TOOL_DEFINITIONS = [
 				type: "string",
 				required: false,
 				description:
-					"Note ID (required for promote/archive/delete; migration ID for upgrade-read)",
+					"Note ID (required for promote/archive/delete/assign-project; source note ID for publish-global; migration ID for upgrade-read)",
+			},
+			project: {
+				type: "string",
+				required: false,
+				description: "Target project (required for assign-project)",
 			},
 			filter: {
 				type: "string",
@@ -501,6 +556,22 @@ export const TOOL_DEFINITIONS = [
 				type: "boolean",
 				required: false,
 				description: "Preview changes without applying",
+			},
+			candidate: {
+				type: "object",
+				required: false,
+				description: "Distilled global candidate for publish-global action (required when action is publish-global)",
+				properties: PUBLISH_GLOBAL_CANDIDATE_PROPERTIES,
+			},
+			confirm: {
+				type: "boolean",
+				required: false,
+				description: "Explicit confirmation required for publish-global or assign-project apply",
+			},
+			token: {
+				type: "string",
+				required: false,
+				description: "Confirmation token from publish-global or assign-project preview (required for apply)",
 			},
 			model: {
 				type: "string",
@@ -534,9 +605,8 @@ export const TOOL_DEFINITIONS = [
 			},
 			project: {
 				type: "string",
-				required: false,
-				description:
-					"Project scope — auto-adds project:<name> tag to all candidates",
+				required: true,
+				description: "Current project for duplicate screening and stored candidates",
 			},
 			dry_run: {
 				type: "boolean",

--- a/templates/install/agent-instructions-compact.md
+++ b/templates/install/agent-instructions-compact.md
@@ -2,10 +2,10 @@
 Persistent cross-session memory via `knowledge-*` MCP tools.
 **Pre-flight before work:**
 `knowledge-search` for relevant context.
-Filter by `project` and `kind`; follow each note's `<guidance>`.
+Pass the current project explicitly on every routine stored-knowledge call; follow each note's `<guidance>`.
 **`knowledge-store` immediately, never defer:**
-- enduring preference/correction → personalization, with explicit universal/project/client scope. Apply durability within its declared scope: it must outlast the current task and transient implementation/configuration/subscription; universal preferences must also remain broadly useful across projects and clients. Otherwise use decision/reference/domain instead. Weighed choice → decision; non-obvious gotcha → observation; looked up twice → reference; multi-step workflow discovered → procedure; useful URL → resource (`knowledge-ingest` first).
+- enduring preference/correction → project-local personalization, optionally restricted by client. Apply durability within its declared scope: it must outlast the current task and transient implementation/configuration/subscription. Otherwise use decision/reference/domain instead. Weighed choice → decision; non-obvious gotcha → observation; looked up twice → reference; multi-step workflow discovered → procedure; useful URL → resource (`knowledge-ingest` first).
 **Each note:** one concept only.
 Include a `summary` and imperative `guidance`.
-**Project session start:** `knowledge-context`.
+**Project session start:** `knowledge-context` with the current project. Routine capture is project-local; never create global knowledge with `knowledge-store` or `knowledge-mine`. Global publication is maintenance-only: author a project-agnostic derivative, preview `publish-global`, show the evidence, and apply only after user confirmation. Maintenance remains full-vault and must classify legacy unscoped notes instead of treating them as global.
 **Full detail:** `knowledge-template --kind {kind}` and the `open-zk-kb` skill where supported.

--- a/templates/install/agent-instructions-full.md
+++ b/templates/install/agent-instructions-full.md
@@ -2,10 +2,10 @@
 Persistent cross-session memory via `knowledge-*` MCP tools.
 **Pre-flight before work:**
 `knowledge-search` for relevant context.
-Filter by `project` and `kind`; follow each note's `<guidance>`.
+Pass the current project explicitly on every routine stored-knowledge call; follow each note's `<guidance>`.
 **`knowledge-store` immediately, never defer:**
-- enduring preference/correction → personalization, with explicit universal/project/client scope. Apply durability within its declared scope: it must outlast the current task and transient implementation/configuration/subscription; universal preferences must also remain broadly useful across projects and clients. Otherwise use decision/reference/domain instead. Weighed choice → decision; non-obvious gotcha → observation; looked up twice → reference; multi-step workflow discovered → procedure; useful URL → resource (`knowledge-ingest` first).
+- enduring preference/correction → project-local personalization, optionally restricted by client. Apply durability within its declared scope: it must outlast the current task and transient implementation/configuration/subscription. Otherwise use decision/reference/domain instead. Weighed choice → decision; non-obvious gotcha → observation; looked up twice → reference; multi-step workflow discovered → procedure; useful URL → resource (`knowledge-ingest` first).
 **Each note:** one concept only.
 Include a `summary` and imperative `guidance`.
-**Project session start:** `knowledge-context`.
+**Project session start:** `knowledge-context` with the current project. Routine capture is project-local; never create global knowledge with `knowledge-store` or `knowledge-mine`. Global publication is maintenance-only: author a project-agnostic derivative, preview `publish-global`, show the evidence, and apply only after user confirmation. Maintenance remains full-vault and must classify legacy unscoped notes instead of treating them as global.
 **Full detail:** `knowledge-template --kind {kind}` and the `open-zk-kb` skill where supported.

--- a/templates/install/agent-instructions-preflight.md
+++ b/templates/install/agent-instructions-preflight.md
@@ -2,10 +2,10 @@
 Persistent cross-session memory via `knowledge-*` MCP tools.
 **Pre-flight before work:**
 `knowledge-search` for relevant context.
-Filter by `project` and `kind`; follow each note's `<guidance>`.
+Pass the current project explicitly on every routine stored-knowledge call; follow each note's `<guidance>`.
 **`knowledge-store` immediately, never defer:**
-- enduring preference/correction → personalization, with explicit universal/project/client scope. Apply durability within its declared scope: it must outlast the current task and transient implementation/configuration/subscription; universal preferences must also remain broadly useful across projects and clients. Otherwise use decision/reference/domain instead. Weighed choice → decision; non-obvious gotcha → observation; looked up twice → reference; multi-step workflow discovered → procedure; useful URL → resource (`knowledge-ingest` first).
+- enduring preference/correction → project-local personalization, optionally restricted by client. Apply durability within its declared scope: it must outlast the current task and transient implementation/configuration/subscription. Otherwise use decision/reference/domain instead. Weighed choice → decision; non-obvious gotcha → observation; looked up twice → reference; multi-step workflow discovered → procedure; useful URL → resource (`knowledge-ingest` first).
 **Each note:** one concept only.
 Include a `summary` and imperative `guidance`.
-**Project session start:** `knowledge-context`.
+**Project session start:** `knowledge-context` with the current project. Routine capture is project-local; never create global knowledge with `knowledge-store` or `knowledge-mine`. Global publication is maintenance-only: author a project-agnostic derivative, preview `publish-global`, show the evidence, and apply only after user confirmation. Maintenance remains full-vault and must classify legacy unscoped notes instead of treating them as global.
 **Full detail:** `skill://open-zk-kb`.

--- a/templates/install/agent-instructions-rules.md
+++ b/templates/install/agent-instructions-rules.md
@@ -2,10 +2,10 @@
 Persistent cross-session memory via `knowledge-*` MCP tools.
 **Pre-flight before work:**
 `knowledge-search` for relevant context.
-Filter by `project` and `kind`; follow each note's `<guidance>`.
+Pass the current project explicitly on every routine stored-knowledge call; follow each note's `<guidance>`.
 **`knowledge-store` immediately, never defer:**
-- enduring preference/correction → personalization, with explicit universal/project/client scope. Apply durability within its declared scope: it must outlast the current task and transient implementation/configuration/subscription; universal preferences must also remain broadly useful across projects and clients. Otherwise use decision/reference/domain instead. Weighed choice → decision; non-obvious gotcha → observation; looked up twice → reference; multi-step workflow discovered → procedure; useful URL → resource (`knowledge-ingest` first).
+- enduring preference/correction → project-local personalization, optionally restricted by client. Apply durability within its declared scope: it must outlast the current task and transient implementation/configuration/subscription. Otherwise use decision/reference/domain instead. Weighed choice → decision; non-obvious gotcha → observation; looked up twice → reference; multi-step workflow discovered → procedure; useful URL → resource (`knowledge-ingest` first).
 **Each note:** one concept only.
 Include a `summary` and imperative `guidance`.
-**Project session start:** `knowledge-context`.
+**Project session start:** `knowledge-context` with the current project. Routine capture is project-local; never create global knowledge with `knowledge-store` or `knowledge-mine`. Global publication is maintenance-only: author a project-agnostic derivative, preview `publish-global`, show the evidence, and apply only after user confirmation. Maintenance remains full-vault and must classify legacy unscoped notes instead of treating them as global.
 **Full detail:** `knowledge-template --kind {kind}` and the `open-zk-kb` skill where supported.

--- a/tests/coverage-boost.test.ts
+++ b/tests/coverage-boost.test.ts
@@ -513,7 +513,7 @@ describe('NoteRepository — Coverage Boost', () => {
   describe('getAll', () => {
     it('should return all notes up to limit', () => {
       for (let i = 0; i < 5; i++) {
-        ctx.engine.store(`Note ${i}`, { title: `Note ${i}`, kind: 'reference' });
+        ctx.engine.store(`Note ${i}`, { title: `Note ${i}`, kind: 'reference', tags: ['project:test-project'] });
       }
       const all = ctx.engine.getAll(3);
       expect(all.length).toBe(3);
@@ -668,7 +668,7 @@ describe('Tool Handlers — Coverage Boost', () => {
 
   describe('handleStore edge cases', () => {
     it('should handle related IDs that do not exist', async () => {
-      const output = await handleStore({
+      const output = await handleStore({ project: 'test-project',
         title: 'With missing related',
         content: 'Content',
         kind: 'reference',
@@ -677,14 +677,14 @@ describe('Tool Handlers — Coverage Boost', () => {
         guidance: 'Test',
       }, ctx.engine);
 
-      expect(output).toContain('Stored ');
+      expect(output).toContain('Related note not found or not visible');
     });
   });
 
   describe('handleHealth — coverage', () => {
     it('should show embedding provider when config passed', async () => {
       const output = await handleHealth(
-        {},
+        { project: 'test-project' },
         ctx.engine,
         ctx.config,
         { provider: 'local', model: 'test-model', dimensions: 384 }
@@ -694,10 +694,10 @@ describe('Tool Handlers — Coverage Boost', () => {
 
     it('should include growth rate for recently created notes', async () => {
       for (let i = 0; i < 6; i++) {
-        ctx.engine.store(`Note ${i}`, { title: `Note ${i}`, kind: 'reference' });
+        ctx.engine.store(`Note ${i}`, { title: `Note ${i}`, kind: 'reference', tags: ['project:test-project'] });
       }
 
-      const output = await handleHealth({}, ctx.engine, ctx.config);
+      const output = await handleHealth({ project: 'test-project',}, ctx.engine, ctx.config);
       expect(output).toContain('Notes created: 6');
     });
   });
@@ -723,7 +723,7 @@ describe('Tool Handlers — Coverage Boost', () => {
 
   describe('handleMaintain — upgrade', () => {
     it('should return "no upgrade needed" when all notes are complete', async () => {
-      await handleStore({
+      await handleStore({ project: 'test-project',
         title: 'Complete',
         content: 'Content',
         kind: 'reference',
@@ -749,8 +749,8 @@ describe('Tool Handlers — Coverage Boost', () => {
 
   describe('handleMaintain — dedupe', () => {
     it('should report no duplicates for unique notes', async () => {
-      await handleStore({ title: 'Unique A', content: 'AAA', kind: 'reference', summary: 'A', guidance: 'A' }, ctx.engine);
-      await handleStore({ title: 'Unique B', content: 'BBB', kind: 'reference', summary: 'B', guidance: 'B' }, ctx.engine);
+      await handleStore({ project: 'test-project', title: 'Unique A', content: 'AAA', kind: 'reference', summary: 'A', guidance: 'A' }, ctx.engine);
+      await handleStore({ project: 'test-project', title: 'Unique B', content: 'BBB', kind: 'reference', summary: 'B', guidance: 'B' }, ctx.engine);
 
       const output = await handleMaintain({ action: 'dedupe' }, ctx.engine, ctx.config);
       expect(output).toContain('No duplicate notes found');
@@ -759,15 +759,14 @@ describe('Tool Handlers — Coverage Boost', () => {
 
   describe('handleMaintain — embed', () => {
     it('should error when no embeddingConfig', async () => {
-      await handleStore({ title: 'Note', content: 'C', kind: 'reference', summary: 'S', guidance: 'G' }, ctx.engine);
+      await handleStore({ project: 'test-project', title: 'Note', content: 'C', kind: 'reference', summary: 'S', guidance: 'G' }, ctx.engine);
       const output = await handleMaintain({ action: 'embed' }, ctx.engine, ctx.config);
       expect(output).toContain('Embedding not configured');
     });
 
     it('should report nothing to backfill when all embedded', async () => {
-      const r = await handleStore({ title: 'Note', content: 'C', kind: 'reference', summary: 'S', guidance: 'G' }, ctx.engine);
-      const id = r.match(/→ (\S+)/)?.[1];
-      if (id) ctx.engine.storeEmbedding(id, [0.1, 0.2], 'test');
+      await handleStore({ project: 'test-project', title: 'Note', content: 'C', kind: 'reference', summary: 'S', guidance: 'G' }, ctx.engine);
+      for (const note of ctx.engine.getAll()) ctx.engine.storeEmbedding(note.id, [0.1, 0.2], 'test');
 
       const output = await handleMaintain(
         { action: 'embed' },
@@ -779,7 +778,7 @@ describe('Tool Handlers — Coverage Boost', () => {
     });
 
     it('should support dry run for embed', async () => {
-      await handleStore({ title: 'Note', content: 'C', kind: 'reference', summary: 'S', guidance: 'G' }, ctx.engine);
+      await handleStore({ project: 'test-project', title: 'Note', content: 'C', kind: 'reference', summary: 'S', guidance: 'G' }, ctx.engine);
       const output = await handleMaintain(
         { action: 'embed', dryRun: true },
         ctx.engine,
@@ -791,7 +790,7 @@ describe('Tool Handlers — Coverage Boost', () => {
 
     it('should actually embed notes via batch API', async () => {
       const originalFetch = globalThis.fetch;
-      await handleStore({ title: 'Embed Me', content: 'Content to embed', kind: 'reference', summary: 'S', guidance: 'G' }, ctx.engine);
+      await handleStore({ project: 'test-project', title: 'Embed Me', content: 'Content to embed', kind: 'reference', summary: 'S', guidance: 'G' }, ctx.engine);
 
       // Mock fetch to return embedding
       globalThis.fetch = (async () => new Response(JSON.stringify({
@@ -816,8 +815,8 @@ describe('Tool Handlers — Coverage Boost', () => {
 
   describe('handleMaintain — dedupe with duplicates', () => {
     it('should detect title-based duplicates', async () => {
-      await handleStore({ title: 'Same Title', content: 'First version', kind: 'reference', summary: 'A', guidance: 'A' }, ctx.engine);
-      await handleStore({ title: 'Same Title', content: 'Second version', kind: 'reference', summary: 'B', guidance: 'B' }, ctx.engine);
+      await handleStore({ project: 'test-project', title: 'Same Title', content: 'First version', kind: 'reference', summary: 'A', guidance: 'A' }, ctx.engine);
+      await handleStore({ project: 'test-project', title: 'Same Title', content: 'Second version', kind: 'reference', summary: 'B', guidance: 'B' }, ctx.engine);
 
       const output = await handleMaintain({ action: 'dedupe' }, ctx.engine, ctx.config);
       expect(output).toContain('Title-Based Duplicates');
@@ -854,14 +853,14 @@ describe('Tool Handlers — Coverage Boost', () => {
 
   describe('handleSearch', () => {
     it('should find notes by keyword', () => {
-      ctx.engine.store('TypeScript best practices for beginners', { title: 'TS Guide', kind: 'reference' });
-      const output = handleSearch({ query: 'TypeScript' }, ctx.engine);
+      ctx.engine.store('TypeScript best practices for beginners', { title: 'TS Guide', kind: 'reference', tags: ['project:test-project'] });
+      const output = handleSearch({ project: 'test-project', query: 'TypeScript' }, ctx.engine);
       expect(output).toContain('TS Guide');
       expect(output).toContain('Found');
     });
 
     it('should return no results message for missing keywords', () => {
-      const output = handleSearch({ query: 'xyznonexistent123' }, ctx.engine);
+      const output = handleSearch({ project: 'test-project', query: 'xyznonexistent123' }, ctx.engine);
       expect(output).toContain('No matching notes found');
     });
 
@@ -891,13 +890,13 @@ describe('Tool Handlers — Coverage Boost', () => {
 
   describe('handleMaintain — stats with other status', () => {
     it('should show "other" count when unknown status exists', async () => {
-      await handleStore({ title: 'Normal', content: 'C', kind: 'reference', summary: 'S', guidance: 'G' }, ctx.engine);
+      await handleStore({ project: 'test-project', title: 'Normal', content: 'C', kind: 'reference', summary: 'S', guidance: 'G' }, ctx.engine);
       // Inject a note with an invalid status directly
       ctx.engine['db'].prepare(
         "UPDATE notes SET status = 'unknown' WHERE id = (SELECT id FROM notes LIMIT 1)"
       ).run();
 
-      const output = await handleHealth({}, ctx.engine, ctx.config);
+      const output = await handleHealth({ project: 'test-project',}, ctx.engine, ctx.config);
       // Stats should still work, may or may not show "Other" depending on getStats impl
       expect(output).toContain('Knowledge Base Stats');
     });

--- a/tests/docker/mcp-protocol-test.ts
+++ b/tests/docker/mcp-protocol-test.ts
@@ -52,6 +52,7 @@ async function run() {
     const storeResult = await client.callTool({
       name: 'knowledge-store',
       arguments: {
+        project: 'docker-test',
         title: 'Docker smoke test note',
         content: 'This is a test note created during Docker smoke testing.',
         kind: 'observation',
@@ -68,7 +69,7 @@ async function run() {
   try {
     const searchResult = await client.callTool({
       name: 'knowledge-search',
-      arguments: { query: 'Docker smoke test' },
+      arguments: { project: 'docker-test', query: 'Docker smoke test' },
     });
     const searchText = JSON.stringify(searchResult);
     check('knowledge-search finds note', searchText.includes('Docker smoke test'));
@@ -79,7 +80,7 @@ async function run() {
   try {
     const emptySearch = await client.callTool({
       name: 'knowledge-search',
-      arguments: { query: 'xyznonexistent999' },
+      arguments: { project: 'docker-test', query: 'xyznonexistent999' },
     });
     const emptyText = JSON.stringify(emptySearch);
     const isEmptyResult = emptyText.includes('No matching notes');
@@ -93,7 +94,7 @@ async function run() {
   try {
     const statsResult = await client.callTool({
       name: 'knowledge-health',
-      arguments: {},
+      arguments: { project: 'docker-test' },
     });
     const statsText = JSON.stringify(statsResult);
     check('knowledge-health returns health info', statsText.includes('Health'));
@@ -117,6 +118,7 @@ async function run() {
     await client.callTool({
       name: 'knowledge-store',
       arguments: {
+        project: 'docker-test',
         title: 'Claude Exclusive Smoke Note',
         content: 'This note is scoped to claude code only for verification.',
         kind: 'reference',
@@ -129,7 +131,7 @@ async function run() {
     // Search as claude-code — should find it
     const claudeSearch = await client.callTool({
       name: 'knowledge-search',
-      arguments: { query: 'claude exclusive smoke verification', client: 'claude-code' },
+      arguments: { project: 'docker-test', query: 'claude exclusive smoke verification', client: 'claude-code' },
     });
     const claudeText = JSON.stringify(claudeSearch);
     check('client-scoped note visible to matching client', claudeText.includes('Claude only smoke test note'));
@@ -137,7 +139,7 @@ async function run() {
     // Search as opencode — should NOT find it
     const openCodeSearch = await client.callTool({
       name: 'knowledge-search',
-      arguments: { query: 'claude exclusive smoke verification', client: 'opencode' },
+      arguments: { project: 'docker-test', query: 'claude exclusive smoke verification', client: 'opencode' },
     });
     const openCodeText = JSON.stringify(openCodeSearch);
     const hidden = !openCodeText.includes('Claude only smoke test note');
@@ -147,7 +149,7 @@ async function run() {
     // Search without client — should find it (backward compat)
     const allSearch = await client.callTool({
       name: 'knowledge-search',
-      arguments: { query: 'claude exclusive smoke verification' },
+      arguments: { project: 'docker-test', query: 'claude exclusive smoke verification' },
     });
     const allText = JSON.stringify(allSearch);
     check('client-scoped note visible without client filter (backward compat)', allText.includes('Claude only smoke test note'));

--- a/tests/docker/model-smoke-test.ts
+++ b/tests/docker/model-smoke-test.ts
@@ -85,6 +85,7 @@ async function testKbRoundTripWithEmbeddings() {
     await client.callTool({
       name: 'knowledge-store',
       arguments: {
+        project: 'model-smoke',
         title: 'Prefer Tailwind CSS for styling',
         content: 'Use Tailwind CSS utility classes for all frontend styling. Avoid Bootstrap.',
         kind: 'personalization',
@@ -96,6 +97,7 @@ async function testKbRoundTripWithEmbeddings() {
     await client.callTool({
       name: 'knowledge-store',
       arguments: {
+        project: 'model-smoke',
         title: 'PostgreSQL for all databases',
         content: 'We chose PostgreSQL for consistency across services. It handles ACID transactions well.',
         kind: 'decision',
@@ -106,14 +108,14 @@ async function testKbRoundTripWithEmbeddings() {
 
     const searchResult = await client.callTool({
       name: 'knowledge-search',
-      arguments: { query: 'What CSS framework should I use for styling?' },
+      arguments: { project: 'model-smoke', query: 'What CSS framework should I use for styling?' },
     });
     const searchText = text(searchResult);
     check('semantic search finds relevant note', searchText.includes('Tailwind'), `search: ${searchText.substring(0, 100)}`);
 
     const statsResult = await client.callTool({
       name: 'knowledge-health',
-      arguments: {},
+      arguments: { project: 'model-smoke' },
     });
     const statsText = text(statsResult);
     const embeddedMatch = statsText.match(/Embedded: (\d+)\/(\d+)/);

--- a/tests/docker/smoke-test.sh
+++ b/tests/docker/smoke-test.sh
@@ -220,6 +220,7 @@ if TEST_OUTPUT=$(bun test 2>&1); then
 else
   FAIL_LINE=$(echo "$TEST_OUTPUT" | grep -oE "[0-9]+ fail" | head -1 || true)
   fail "unit tests" "${FAIL_LINE:-bun test exited non-zero without a matching summary line}"
+  echo "$TEST_OUTPUT"
 fi
 echo ""
 
@@ -588,6 +589,7 @@ kind: decision
 status: permanent
 tags:
   - architecture
+  - project:smoke-test-project
 created: 2025-01-01T12:00:00.000Z
 ---
 
@@ -601,6 +603,7 @@ kind: personalization
 status: permanent
 tags:
   - ui
+  - project:smoke-test-project
 created: 2025-01-02T12:00:00.000Z
 ---
 
@@ -634,10 +637,16 @@ EXISTING_OUTPUT=$(timeout 15 bun -e "
   const rebuild = await client.callTool({ name: 'knowledge-maintain', arguments: { action: 'rebuild' } });
   const rebuildText = JSON.stringify(rebuild);
 
-  const search = await client.callTool({ name: 'knowledge-search', arguments: { query: 'PostgreSQL database' } });
+  const search = await client.callTool({
+    name: 'knowledge-search',
+    arguments: { query: 'PostgreSQL database', project: 'smoke-test-project' },
+  });
   const searchText = JSON.stringify(search);
 
-  const stats = await client.callTool({ name: 'knowledge-health', arguments: {} });
+  const stats = await client.callTool({
+    name: 'knowledge-health',
+    arguments: { project: 'smoke-test-project' },
+  });
   const statsText = JSON.stringify(stats);
 
   await client.close();

--- a/tests/edge-cases.test.ts
+++ b/tests/edge-cases.test.ts
@@ -18,6 +18,7 @@ describe('FTS5 Edge Cases', () => {
       status: 'fleeting',
       summary: 'TypeScript overview',
       guidance: 'Reference for TypeScript basics',
+      tags: ['project:test-project'],
     });
     ctx.engine.store('PostgreSQL handles concurrent writes with MVCC', {
       title: 'PostgreSQL Concurrency',
@@ -25,38 +26,39 @@ describe('FTS5 Edge Cases', () => {
       status: 'permanent',
       summary: 'PostgreSQL concurrency model',
       guidance: 'Use when discussing DB concurrency',
+      tags: ['project:test-project'],
     });
   });
 
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should handle FTS5 operators in query (AND, OR, NOT)', () => {
-    const output = handleSearch({ query: 'TypeScript AND PostgreSQL' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'TypeScript AND PostgreSQL' }, ctx.engine);
     expect(output).toContain('Found');
     expect(output).toContain('TypeScript overview');
   });
 
   it('should handle FTS5 special characters (* " ())', () => {
-    const output = handleSearch({ query: '"TypeScript"*()' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: '"TypeScript"*()' }, ctx.engine);
     expect(output).toContain('Found');
     expect(output).toContain('TypeScript overview');
   });
 
   it('should handle NEAR operator in query', () => {
-    const output = handleSearch({ query: 'NEAR(TypeScript, superset)' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'NEAR(TypeScript, superset)' }, ctx.engine);
     expect(output).toContain('Found');
     expect(output).toContain('TypeScript overview');
   });
 
   it('should handle SQL injection attempt in search query', () => {
-    const output = handleSearch({ query: "'; DROP TABLE notes; --" }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: "'; DROP TABLE notes; --" }, ctx.engine);
     expect(output).toContain('No matching notes found');
     const verifyIntact = ctx.engine.search('TypeScript');
     expect(verifyIntact.length).toBe(1);
   });
 
   it('should handle SQL injection attempt in store content', async () => {
-    const output = await handleStore({
+    const output = await handleStore({ project: 'test-project',
       title: "Robert'; DROP TABLE notes;--",
       content: "Content with '; DELETE FROM notes WHERE '1'='1",
       kind: 'observation',
@@ -70,7 +72,7 @@ describe('FTS5 Edge Cases', () => {
   });
 
   it('should handle unicode and emoji in content and search', async () => {
-    await handleStore({
+    await handleStore({ project: 'test-project',
       title: 'Unicode Test',
       content: 'Supports CJK characters and emoji: cafe, resume, naive',
       kind: 'reference',
@@ -78,12 +80,12 @@ describe('FTS5 Edge Cases', () => {
       guidance: 'Verify unicode handling',
     }, ctx.engine);
 
-    const output = handleSearch({ query: 'cafe' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'cafe' }, ctx.engine);
     expect(output).toContain('Unicode content test');
   });
 
   it('should handle CJK characters in content', async () => {
-    await handleStore({
+    await handleStore({ project: 'test-project',
       title: 'CJK Note',
       content: 'This note contains CJK: hello world testing',
       kind: 'reference',
@@ -91,40 +93,40 @@ describe('FTS5 Edge Cases', () => {
       guidance: 'Test CJK search',
     }, ctx.engine);
 
-    const output = handleSearch({ query: 'CJK' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'CJK' }, ctx.engine);
     expect(output).toContain('CJK content');
   });
 
   it('should handle very long query (>1000 chars) by truncating to 10 terms', () => {
     const longQuery = 'TypeScript '.repeat(200);
-    const output = handleSearch({ query: longQuery }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: longQuery }, ctx.engine);
     expect(output).toContain('Found');
     expect(output).toContain('TypeScript overview');
   });
 
   it('should handle empty query without crashing', () => {
-    const output = handleSearch({ query: '' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: '' }, ctx.engine);
     expect(output).toMatch(/Found \d+ note|No matching notes found/);
   });
 
   it('should handle whitespace-only query without crashing', () => {
-    const output = handleSearch({ query: '   \t\n  ' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: '   \t\n  ' }, ctx.engine);
     expect(output).toMatch(/Found \d+ note|No matching notes found/);
   });
 
   it('should handle single-character query without crashing', () => {
-    const output = handleSearch({ query: 'a' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'a' }, ctx.engine);
     expect(output).toMatch(/Found \d+ note|No matching notes found/);
   });
 
   it('should handle query with only special characters without crashing', () => {
-    const output = handleSearch({ query: '***"""()(){}[]' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: '***"""()(){}[]' }, ctx.engine);
     expect(output).toMatch(/Found \d+ note|No matching notes found/);
   });
 
   it('should handle query with backslashes and colons', () => {
-    const output = handleSearch({ query: 'C:\\Users\\test:something' }, ctx.engine);
-    expect(output).toContain('No matching notes found');
+    const output = handleSearch({ project: 'test-project', query: 'C:\\Users\\test:something' }, ctx.engine);
+    expect(output).toMatch(/Found \d+ note|No matching notes found/);
   });
 });
 
@@ -135,7 +137,7 @@ describe('Input Validation', () => {
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should store a note with empty content', async () => {
-    const output = await handleStore({
+    const output = await handleStore({ project: 'test-project',
       title: 'Empty Content Note',
       content: '',
       kind: 'observation',
@@ -148,7 +150,7 @@ describe('Input Validation', () => {
 
   it('should reject a title exceeding the hard limit', async () => {
     const longTitle = 'A'.repeat(500);
-    const output = await handleStore({
+    const output = await handleStore({ project: 'test-project',
       title: longTitle,
       content: 'Some content',
       kind: 'reference',
@@ -161,7 +163,7 @@ describe('Input Validation', () => {
   });
 
   it('should warn on titles over 6 words', async () => {
-    const output = await handleStore({
+    const output = await handleStore({ project: 'test-project',
       title: 'This title has seven whole words here',
       content: 'Some content',
       kind: 'reference',
@@ -174,7 +176,7 @@ describe('Input Validation', () => {
   });
 
   it('should accept titles within the 3-6 word target', async () => {
-    const output = await handleStore({
+    const output = await handleStore({ project: 'test-project',
       title: 'Short valid title',
       content: 'Some content',
       kind: 'reference',
@@ -188,7 +190,7 @@ describe('Input Validation', () => {
   });
 
   it('should store a note with special characters in title', async () => {
-    const output = await handleStore({
+    const output = await handleStore({ project: 'test-project',
       title: 'Test / with < special > & "characters"',
       content: 'Content here',
       kind: 'observation',
@@ -200,7 +202,7 @@ describe('Input Validation', () => {
   });
 
   it('should handle search with kind filter that has no matches', async () => {
-    await handleStore({
+    await handleStore({ project: 'test-project',
       title: 'Only Observation',
       content: 'This is an observation',
       kind: 'observation',
@@ -208,7 +210,7 @@ describe('Input Validation', () => {
       guidance: 'Test kind filter',
     }, ctx.engine);
 
-    const output = handleSearch({ query: 'observation', kind: 'procedure' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'observation', kind: 'procedure' }, ctx.engine);
     expect(output).toBe('No matching notes found. Try broader keywords or remove filters.');
   });
 
@@ -237,7 +239,7 @@ describe('Input Validation', () => {
   });
 
   it('should handle store with duplicate tags', async () => {
-    await handleStore({
+    await handleStore({ project: 'test-project',
       title: 'Dup Tags',
       content: 'Note with duplicate tags',
       kind: 'reference',
@@ -253,7 +255,7 @@ describe('Input Validation', () => {
   });
 
   it('should handle store with empty tags array', async () => {
-    const output = await handleStore({
+    const output = await handleStore({ project: 'test-project',
       title: 'No Tags',
       content: 'Note without tags',
       kind: 'observation',
@@ -266,7 +268,7 @@ describe('Input Validation', () => {
   });
 
   it('should handle search with limit of 0', async () => {
-    await handleStore({
+    await handleStore({ project: 'test-project',
       title: 'Test Note',
       content: 'Searchable content',
       kind: 'reference',
@@ -274,12 +276,12 @@ describe('Input Validation', () => {
       guidance: 'Test',
     }, ctx.engine);
 
-    const output = handleSearch({ query: 'Searchable', limit: 0 }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'Searchable', limit: 0 }, ctx.engine);
     expect(output).toMatch(/Found \d+ note|No matching notes found/);
   });
 
   it('should handle search with very large limit', async () => {
-    await handleStore({
+    await handleStore({ project: 'test-project',
       title: 'Test Note',
       content: 'Searchable content',
       kind: 'reference',
@@ -287,7 +289,7 @@ describe('Input Validation', () => {
       guidance: 'Test',
     }, ctx.engine);
 
-    const output = handleSearch({ query: 'Searchable', limit: 99999 }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'Searchable', limit: 99999 }, ctx.engine);
     expect(output).toContain('Searchable content');
   });
 });
@@ -543,7 +545,7 @@ describe('handleStore embedding handling', () => {
   });
 
   it('should return successfully without embedding config', async () => {
-    const result = await handleStore({
+    const result = await handleStore({ project: 'test-project',
       title: 'Quick Note',
       content: 'This should return immediately',
       kind: 'observation',
@@ -558,7 +560,7 @@ describe('handleStore embedding handling', () => {
 
   it('should store note successfully even with embedding config', async () => {
     // Pass a dummy embedding config — embedding will fail but store should succeed
-    const result = await handleStore({
+    const result = await handleStore({ project: 'test-project',
       title: 'Note with embedding',
       content: 'Content that triggers embedding path',
       kind: 'reference',

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -138,9 +138,8 @@ describe('Knowledge Capture Integration Tests', () => {
       const stats = context.engine.getStats();
       expect(stats.total - stats.archived - context.engine.getScopedNoteCount()).toBe(1);
 
-      const output = handleContext({}, context.engine, context.config);
-      expect(output).toContain('Unscoped notes: 1');
-      expect(output).not.toContain('Unscoped notes: -');
+      const output = handleContext({ project: 'test-project' }, context.engine, context.config);
+      expect(output).toContain('No notes found for project "test-project"');
     });
 
     it('should exclude generated project index and log notes from global knowledge stats and recent notes', async () => {
@@ -177,9 +176,10 @@ describe('Knowledge Capture Integration Tests', () => {
         title: 'Related Target',
         kind: 'reference',
         status: 'permanent',
+        tags: ['project:test-project'],
       });
 
-      const output = await handleStore({
+      const output = await handleStore({ project: 'test-project',
         title: 'Related Source',
         content: 'Source content with an explicit related note',
         kind: 'observation',

--- a/tests/legacy-scope-maintenance.test.ts
+++ b/tests/legacy-scope-maintenance.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import * as fs from 'fs';
+import { handleMaintain } from '../src/tool-handlers.js';
+import { cleanupTestHarness, createTestHarness, type TestContext } from './harness.js';
+
+describe('legacy scope maintenance', () => {
+  let ctx: TestContext;
+  beforeEach(() => { ctx = createTestHarness(); });
+  afterEach(() => cleanupTestHarness(ctx));
+
+  it('inventories deterministic applicability evidence without mutation and reports strict readiness', async () => {
+    const legacy = ctx.engine.store('Legacy body.', { title: 'Legacy', kind: 'reference', tags: [] });
+    const before = fs.readFileSync(legacy.path, 'utf8');
+    const report = JSON.parse(await handleMaintain({ action: 'scope-inventory' }, ctx.engine, ctx.config));
+    expect(report).toMatchObject({ mutated: false, strictVisibility: { active: true, mode: 'fail-closed', unclassifiedExcluded: true }, counts: { activeUnclassified: 1, ready: false } });
+    expect(JSON.stringify(report.groups)).toContain(legacy.id);
+    expect(fs.readFileSync(legacy.path, 'utf8')).toBe(before);
+    expect(ctx.engine.search('Legacy', { visibility: { project: 'alpha' } })).toHaveLength(0);
+  });
+
+  it('requires confirmation then assigns, repairs path, tags, FTS, and visibility', async () => {
+    const legacy = ctx.engine.store('Repair keyword.', { title: 'Needs Repair', kind: 'reference', tags: ['project:old', 'project:other', 'scope:global', 'topic'] });
+    expect(await handleMaintain({ action: 'assign-project', noteId: legacy.id, project: 'alpha', dryRun: false }, ctx.engine, ctx.config)).toContain('confirm=true');
+    const preview = JSON.parse(await handleMaintain({ action: 'assign-project', noteId: legacy.id, project: 'alpha', dryRun: true }, ctx.engine, ctx.config));
+    const result = JSON.parse(await handleMaintain({ action: 'assign-project', noteId: legacy.id, project: 'alpha', dryRun: false, confirm: true, token: preview.confirmationToken }, ctx.engine, ctx.config));
+    const assigned = ctx.engine.getById(legacy.id);
+    expect(assigned).not.toBeNull();
+    if (!assigned) throw new Error('assigned note missing');
+    expect(result.mutated).toBe(true);
+    expect(assigned.tags).toEqual(['topic', 'project:alpha']);
+    expect(assigned.path).toContain('/projects/alpha/references/');
+    expect(fs.existsSync(legacy.path)).toBe(false);
+    expect(ctx.engine.search('Repair', { visibility: { project: 'alpha' } }).map(note => note.id)).toContain(legacy.id);
+    await handleMaintain({ action: 'rebuild' }, ctx.engine, ctx.config);
+    expect(ctx.engine.getById(legacy.id)?.path).toBe(assigned.path);
+  });
+
+  it('leaves note bytes and indexed metadata unchanged when the filesystem move fails', async () => {
+    const legacy = ctx.engine.store('Original bytes.', { title: 'Failed Assignment', kind: 'reference', tags: ['topic'] });
+    const beforeFile = fs.readFileSync(legacy.path, 'utf8');
+    const beforeNote = ctx.engine.getById(legacy.id);
+    const preview = JSON.parse(await handleMaintain({ action: 'assign-project', noteId: legacy.id, project: 'alpha', dryRun: true }, ctx.engine, ctx.config));
+    const rename = spyOn(fs, 'renameSync').mockImplementation(() => { throw new Error('forced rename failure'); });
+    try {
+      const result = await handleMaintain({ action: 'assign-project', noteId: legacy.id, project: 'alpha', dryRun: false, confirm: true, token: preview.confirmationToken }, ctx.engine, ctx.config);
+      expect(result).toContain('assignment failed');
+    } finally {
+      rename.mockRestore();
+    }
+
+    expect(fs.readFileSync(legacy.path, 'utf8')).toBe(beforeFile);
+    expect(ctx.engine.getById(legacy.id)).toMatchObject({
+      path: beforeNote?.path,
+      tags: beforeNote?.tags,
+      updated_at: beforeNote?.updated_at,
+    });
+    expect(ctx.engine.search('Original', { visibility: { project: 'alpha' } })).toHaveLength(0);
+  });
+
+  it('rejects stale assignment confirmations', async () => {
+    const legacy = ctx.engine.store('Original body.', { title: 'Stale Assignment', kind: 'reference', tags: [] });
+    const preview = JSON.parse(await handleMaintain({ action: 'assign-project', noteId: legacy.id, project: 'alpha', dryRun: true }, ctx.engine, ctx.config));
+    ctx.engine.store('Changed body.', { title: 'Stale Assignment', kind: 'reference', tags: [], existingId: legacy.id });
+    const result = await handleMaintain({ action: 'assign-project', noteId: legacy.id, project: 'alpha', dryRun: false, confirm: true, token: preview.confirmationToken }, ctx.engine, ctx.config);
+    expect(result).toContain('stale or does not match');
+    expect(ctx.engine.getById(legacy.id)?.tags).toEqual([]);
+  });
+
+  it('keeps assigned personalizations in the canonical preferences path', async () => {
+    const preference = ctx.engine.store('Use concise prose.', { title: 'Concise', kind: 'personalization', tags: [] });
+    const preview = JSON.parse(await handleMaintain({ action: 'assign-project', noteId: preference.id, project: 'alpha', dryRun: true }, ctx.engine, ctx.config));
+    await handleMaintain({ action: 'assign-project', noteId: preference.id, project: 'alpha', dryRun: false, confirm: true, token: preview.confirmationToken }, ctx.engine, ctx.config);
+    const assigned = ctx.engine.getById(preference.id);
+    expect(assigned).not.toBeNull();
+    if (!assigned) throw new Error('assigned preference missing');
+    expect(assigned.tags).toEqual(['project:alpha']);
+    expect(assigned.path).toContain('/preferences/');
+    expect(assigned.tags).not.toContain('scope:global');
+  });
+});

--- a/tests/mcp-protocol.test.ts
+++ b/tests/mcp-protocol.test.ts
@@ -403,5 +403,13 @@ describe('MCP Protocol E2E', () => {
     });
     const missingProjectText = (missingProject.content as Array<{ type: string; text: string }>)[0].text;
     expect(missingProjectText).toContain('a valid project is required');
+
+    const forwardedProject = await client!.callTool({
+      name: 'knowledge-maintain',
+      arguments: { action: 'assign-project', noteId: 'nonexistent-note', project: 'protocol', dryRun: true },
+    });
+    const forwardedProjectText = (forwardedProject.content as Array<{ type: string; text: string }>)[0].text;
+    expect(forwardedProjectText).toContain('Note not found: nonexistent-note');
+    expect(forwardedProjectText).not.toContain('a valid project is required');
   });
 });

--- a/tests/mcp-protocol.test.ts
+++ b/tests/mcp-protocol.test.ts
@@ -66,6 +66,8 @@ describe('MCP Protocol E2E', () => {
 
     expect(tools.tools.find(tool => tool.name === 'knowledge-overview')?.description).toContain('Deprecated alias');
     expect(tools.tools.find(tool => tool.name === 'knowledge-stats')?.description).toContain('Deprecated alias');
+    const healthSchema = tools.tools.find(tool => tool.name === 'knowledge-health')?.inputSchema as { properties?: Record<string, unknown> } | undefined;
+    expect(healthSchema?.properties).toHaveProperty('client');
   });
 
   it('knowledge-health and its deprecated alias return valid responses', async () => {
@@ -187,6 +189,19 @@ describe('MCP Protocol E2E', () => {
     });
     const allText = (allResult.content as Array<{ type: string; text: string }>)[0].text;
     expect(allText).toContain('This is only for Claude Code');
+  });
+
+  it('knowledge-health forwards client visibility through MCP', async () => {
+    const callHealth = async (clientName: string) => {
+      const result = await client!.callTool({
+        name: 'knowledge-health',
+        arguments: { project: 'protocol', client: clientName },
+      });
+      return (result.content as Array<{ type: string; text: string }>)[0].text;
+    };
+
+    expect(await callHealth('claude-code')).toContain('## Health (3 notes)');
+    expect(await callHealth('opencode')).toContain('## Health (1 notes)');
   });
 
   it('knowledge-context returns a structured matching preference capsule on request', async () => {

--- a/tests/mcp-protocol.test.ts
+++ b/tests/mcp-protocol.test.ts
@@ -342,6 +342,50 @@ describe('MCP Protocol E2E', () => {
     const minedText = (mined.content as Array<{ type: string; text: string }>)[0].text;
     expect(minedText).toContain('STORE');
     expect(minedText).not.toContain('Beta Boundary Note');
+  }, 15_000);
+
+  it('forwards knowledge-mine client scope through MCP', async () => {
+    // Seed an equivalent note in another client scope. If knowledge-mine fails
+    // to forward client to duplicate screening, this candidate is misclassified.
+    const cursorSeed = await client!.callTool({
+      name: 'knowledge-store',
+      arguments: {
+        project: 'protocol', client: 'cursor',
+        title: 'Cursor-only mining duplicate',
+        content: 'mcpclientisolationtoken duplicate screening content',
+        kind: 'reference',
+        summary: 'MCP client isolation duplicate screening content.',
+        guidance: 'Keep this note visible only to Cursor.',
+      },
+    });
+    expect((cursorSeed.content as Array<{ type: string; text: string }>)[0].text).toContain('Cursor-only mining duplicate');
+
+    const mined = await client!.callTool({
+      name: 'knowledge-mine',
+      arguments: {
+        project: 'protocol', client: 'pi', dry_run: false,
+        candidates: [{
+          title: 'Pi-only mining duplicate',
+          content: 'mcpclientisolationtoken duplicate screening content',
+          kind: 'reference',
+          summary: 'MCP client isolation duplicate screening content.',
+          guidance: 'Keep this candidate visible only to Pi.',
+        }],
+      },
+    });
+    expect((mined.content as Array<{ type: string; text: string }>)[0].text).toContain('Stored as');
+
+    const search = async (clientName: string) => {
+      const result = await client!.callTool({
+        name: 'knowledge-search',
+        arguments: { project: 'protocol', client: clientName, query: 'mcpclientisolationtoken' },
+      });
+      return (result.content as Array<{ type: string; text: string }>)[0].text;
+    };
+    expect(await search('pi')).toContain('Keep this candidate visible only to Pi.');
+    const cursorResults = await search('cursor');
+    expect(cursorResults).toContain('Keep this note visible only to Cursor.');
+    expect(cursorResults).not.toContain('Keep this candidate visible only to Pi.');
   });
 
   it('handles unknown tool gracefully', async () => {

--- a/tests/mcp-protocol.test.ts
+++ b/tests/mcp-protocol.test.ts
@@ -70,7 +70,7 @@ describe('MCP Protocol E2E', () => {
 
   it('knowledge-health and its deprecated alias return valid responses', async () => {
     for (const name of ['knowledge-health', 'knowledge-stats']) {
-      const result = await client!.callTool({ name, arguments: {} });
+      const result = await client!.callTool({ name, arguments: { project: 'protocol' } });
       const content = result.content as Array<{ type: string; text: string }>;
       expect(content).toHaveLength(1);
       expect(content[0].type).toBe('text');
@@ -82,6 +82,7 @@ describe('MCP Protocol E2E', () => {
     const result = await client!.callTool({
       name: 'knowledge-store',
       arguments: {
+        project: 'protocol',
         title: 'E2E Test Note',
         content: 'This is a test note from E2E tests.',
         kind: 'observation',
@@ -99,6 +100,7 @@ describe('MCP Protocol E2E', () => {
     const result = await client!.callTool({
       name: 'knowledge-search',
       arguments: {
+        project: 'protocol',
         query: 'E2E test',
       },
     });
@@ -123,6 +125,7 @@ describe('MCP Protocol E2E', () => {
     const result = await client!.callTool({
       name: 'knowledge-store',
       arguments: {
+        project: 'protocol',
         title: 'Client Param E2E Note',
         content: 'Configure .claude/skills directory for Claude Code.',
         kind: 'procedure',
@@ -151,6 +154,7 @@ describe('MCP Protocol E2E', () => {
     await client!.callTool({
       name: 'knowledge-store',
       arguments: {
+        project: 'protocol',
         title: 'Claude Filtered E2E Note',
         content: 'This is only for Claude Code clients to see.',
         kind: 'reference',
@@ -163,7 +167,7 @@ describe('MCP Protocol E2E', () => {
     // Search as opencode — should NOT see it
     const openCodeResult = await client!.callTool({
       name: 'knowledge-search',
-      arguments: { query: 'Claude Filtered E2E', client: 'opencode' },
+      arguments: { project: 'protocol', query: 'Claude Filtered E2E', client: 'opencode' },
     });
     const openCodeText = (openCodeResult.content as Array<{ type: string; text: string }>)[0].text;
     expect(openCodeText).not.toContain('This is only for Claude Code');
@@ -171,7 +175,7 @@ describe('MCP Protocol E2E', () => {
     // Search as claude-code — SHOULD see it
     const claudeResult = await client!.callTool({
       name: 'knowledge-search',
-      arguments: { query: 'Claude Filtered E2E', client: 'claude-code' },
+      arguments: { project: 'protocol', query: 'Claude Filtered E2E', client: 'claude-code' },
     });
     const claudeText = (claudeResult.content as Array<{ type: string; text: string }>)[0].text;
     expect(claudeText).toContain('This is only for Claude Code');
@@ -179,7 +183,7 @@ describe('MCP Protocol E2E', () => {
     // Search without client — SHOULD see it (backward compat)
     const allResult = await client!.callTool({
       name: 'knowledge-search',
-      arguments: { query: 'Claude Filtered E2E' },
+      arguments: { project: 'protocol', query: 'Claude Filtered E2E' },
     });
     const allText = (allResult.content as Array<{ type: string; text: string }>)[0].text;
     expect(allText).toContain('This is only for Claude Code');
@@ -194,6 +198,7 @@ describe('MCP Protocol E2E', () => {
     await client!.callTool({
       name: 'knowledge-store',
       arguments: {
+        project: 'protocol',
         title: 'Pi Protocol Preference',
         content: 'Keep Pi protocol output concise.',
         kind: 'personalization',
@@ -206,7 +211,7 @@ describe('MCP Protocol E2E', () => {
 
     const result = await client!.callTool({
       name: 'knowledge-context',
-      arguments: { client: 'pi', includePreferences: true },
+      arguments: { project: 'protocol', client: 'pi', includePreferences: true },
     });
     const structured = result.structuredContent as {
       preferenceCapsule?: {
@@ -218,13 +223,125 @@ describe('MCP Protocol E2E', () => {
 
     expect(structured?.preferenceCapsule?.selected).toBeGreaterThanOrEqual(1);
     expect(structured?.preferenceCapsule?.omitted).toBeGreaterThanOrEqual(0);
-    expect(structured?.preferenceCapsule?.text).toContain('[client:pi] Keep Pi protocol output concise.');
+    expect(structured?.preferenceCapsule?.text).toContain('[project:protocol, client:pi] Keep Pi protocol output concise.');
 
     const aliasResult = await client!.callTool({
       name: 'knowledge-overview',
-      arguments: { client: 'pi', includePreferences: true },
+      arguments: { project: 'protocol', client: 'pi', includePreferences: true },
     });
     expect(aliasResult.structuredContent).toEqual(result.structuredContent);
+  });
+
+  it('isolates project knowledge while sharing confirmed global derivatives', async () => {
+    const store = async (project: string, title: string, content: string) => {
+      const result = await client!.callTool({
+        name: 'knowledge-store',
+        arguments: {
+          project,
+          title,
+          content,
+          kind: 'reference',
+          summary: `${title} summary`,
+          guidance: `Use ${title.toLowerCase()} guidance.`,
+        },
+      });
+      const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+      const id = /→\s*(\d{12,16})\b/.exec(text)?.[1];
+      expect(id).toBeDefined();
+      return id as string;
+    };
+
+    const alphaId = await store('protocol-alpha', 'Alpha Boundary Note', 'isolationtoken alpha private detail');
+    const betaId = await store('protocol-beta', 'Beta Boundary Note', 'isolationtoken beta private detail');
+    const candidate = {
+      title: 'Shared Boundary Guidance',
+      content: 'isolationtoken shared reusable guidance',
+      kind: 'reference',
+      summary: 'Reusable isolation guidance applies broadly.',
+      guidance: 'Apply the reusable isolation guidance.',
+    };
+
+    const previewResult = await client!.callTool({
+      name: 'knowledge-maintain',
+      arguments: { action: 'publish-global', noteId: alphaId, candidate, dryRun: true },
+    });
+    const previewText = (previewResult.content as Array<{ type: string; text: string }>)[0].text;
+    const preview = JSON.parse(previewText) as { valid: boolean; confirmationToken: string };
+    expect(preview.valid).toBe(true);
+
+    const applyResult = await client!.callTool({
+      name: 'knowledge-maintain',
+      arguments: {
+        action: 'publish-global', noteId: alphaId, candidate,
+        dryRun: false, confirm: true, token: preview.confirmationToken,
+      },
+    });
+    expect((applyResult.content as Array<{ type: string; text: string }>)[0].text).toContain('"created"');
+
+    const search = async (project: string) => {
+      const result = await client!.callTool({
+        name: 'knowledge-search',
+        arguments: { project, query: 'isolationtoken' },
+      });
+      return (result.content as Array<{ type: string; text: string }>)[0].text;
+    };
+    const alphaSearch = await search('protocol-alpha');
+    expect(alphaSearch).toContain('Alpha Boundary Note');
+    expect(alphaSearch).toContain('Reusable isolation guidance applies broadly.');
+    expect(alphaSearch).not.toContain('Beta Boundary Note');
+
+    const betaSearch = await search('protocol-beta');
+    expect(betaSearch).toContain('Beta Boundary Note');
+    expect(betaSearch).toContain('Reusable isolation guidance applies broadly.');
+    expect(betaSearch).not.toContain('Alpha Boundary Note');
+
+    const deniedGet = await client!.callTool({
+      name: 'knowledge-get',
+      arguments: { project: 'protocol-alpha', noteId: betaId },
+    });
+    expect((deniedGet.content as Array<{ type: string; text: string }>)[0].text).toContain('Note not found');
+
+    const alphaContext = await client!.callTool({
+      name: 'knowledge-context',
+      arguments: { project: 'protocol-alpha' },
+    });
+    const alphaContextText = (alphaContext.content as Array<{ type: string; text: string }>)[0].text;
+    expect(alphaContextText).toContain('Alpha Boundary Note');
+    expect(alphaContextText).toContain('Shared Boundary Guidance');
+    expect(alphaContextText).not.toContain('Beta Boundary Note');
+
+    const relatedStore = await client!.callTool({
+      name: 'knowledge-store',
+      arguments: {
+        project: 'protocol-alpha',
+        title: 'Shared Boundary Guidance',
+        content: 'isolationtoken shared reusable guidance',
+        kind: 'reference',
+        summary: 'Reusable isolation guidance applies broadly.',
+        guidance: 'Keep related-note discovery within the visibility boundary.',
+        model: 'claude-opus-4',
+      },
+    });
+    const relatedStoreText = (relatedStore.content as Array<{ type: string; text: string }>)[0].text;
+    expect(relatedStoreText).toContain('Shared Boundary Guidance');
+    expect(relatedStoreText).not.toContain('Beta Boundary Note');
+
+    const mined = await client!.callTool({
+      name: 'knowledge-mine',
+      arguments: {
+        project: 'protocol-alpha', dry_run: true,
+        candidates: [{
+          title: 'Beta Private Candidate',
+          content: 'beta private detail unique candidate',
+          kind: 'reference',
+          summary: 'Beta private detail unique candidate.',
+          guidance: 'Use beta private detail only when visible.',
+        }],
+      },
+    });
+    const minedText = (mined.content as Array<{ type: string; text: string }>)[0].text;
+    expect(minedText).toContain('STORE');
+    expect(minedText).not.toContain('Beta Boundary Note');
   });
 
   it('handles unknown tool gracefully', async () => {
@@ -235,5 +352,56 @@ describe('MCP Protocol E2E', () => {
 
     // MCP SDK returns a result with isError flag for unknown tools
     expect(result.isError).toBe(true);
+  });
+
+  it('rejects knowledge-store without project', async () => {
+    const result = await client!.callTool({
+      name: 'knowledge-store',
+      arguments: {
+        title: 'Missing Project',
+        content: 'This should fail.',
+        kind: 'observation',
+        summary: 'Missing project test',
+        guidance: 'Test missing project rejection',
+      },
+    });
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(content[0].text).toContain('project');
+  });
+
+  it('knowledge-maintain scope-inventory returns a read-only report', async () => {
+    const result = await client!.callTool({
+      name: 'knowledge-maintain',
+      arguments: { action: 'scope-inventory' },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(content[0].text).toContain('scope-inventory');
+    expect(content[0].text).toContain('mutated');
+  });
+
+  it('knowledge-maintain publish-global requires noteId', async () => {
+    const result = await client!.callTool({
+      name: 'knowledge-maintain',
+      arguments: { action: 'publish-global', dryRun: true },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(content[0].text).toContain('noteId is required');
+  });
+
+  it('knowledge-maintain assign-project requires noteId and project', async () => {
+    const missingNoteId = await client!.callTool({
+      name: 'knowledge-maintain',
+      arguments: { action: 'assign-project', project: 'protocol' },
+    });
+    const missingNoteIdText = (missingNoteId.content as Array<{ type: string; text: string }>)[0].text;
+    expect(missingNoteIdText).toContain('noteId is required');
+
+    const missingProject = await client!.callTool({
+      name: 'knowledge-maintain',
+      arguments: { action: 'assign-project', noteId: 'nonexistent-note' },
+    });
+    const missingProjectText = (missingProject.content as Array<{ type: string; text: string }>)[0].text;
+    expect(missingProjectText).toContain('a valid project is required');
   });
 });

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -3509,6 +3509,25 @@ describe('Domain note kind', () => {
     expect(domainIndex).toBeLessThan(regularIndex);
   });
 
+  it('should not always-include a domain note hidden by client scope', async () => {
+    await handleStore({
+      title: 'Cursor Domain',
+      content: 'Canonical operating manual for .cursor/rules.',
+      kind: 'domain',
+      project: 'myapp',
+      client: 'cursor',
+      summary: 'Cursor-only operating manual',
+      guidance: 'Read only from Cursor.',
+    }, ctx.engine, null, ctx.config);
+
+    const config = { ...getConfig(), search: { alwaysIncludeDomainNote: true } };
+    const piOutput = handleSearch({ query: 'totally-unrelated-query', project: 'myapp', client: 'pi' }, ctx.engine, null, config);
+    const cursorOutput = handleSearch({ query: 'totally-unrelated-query', project: 'myapp', client: 'cursor' }, ctx.engine, null, config);
+
+    expect(piOutput).not.toContain('Cursor-only operating manual');
+    expect(cursorOutput).toContain('Cursor-only operating manual');
+  });
+
   it('should not inject the domain note into archived-only searches', async () => {
     await handleStore({
       title: 'MyApp Domain',
@@ -3903,6 +3922,25 @@ describe('Index and log note kinds', () => {
     expect(output).toContain('(showing 2 of 3 entries)');
   });
 
+  it('should omit unfilterable project logs from client-scoped context', async () => {
+    const config = makeConfig();
+    await handleStore({
+      project: 'myapp', client: 'cursor', title: 'Cursor Private Event',
+      content: 'Cursor-only context.', kind: 'reference',
+      summary: 'Cursor-only context', guidance: 'Use only in Cursor.',
+    }, ctx.engine, null, config);
+    await handleStore({
+      project: 'myapp', client: 'pi', title: 'Pi Visible Event',
+      content: 'Pi-visible context.', kind: 'reference',
+      summary: 'Pi-visible context', guidance: 'Use only in Pi.',
+    }, ctx.engine, null, config);
+
+    const output = handleContext({ project: 'myapp', client: 'pi' }, ctx.engine, config);
+    expect(output).toContain('Pi Visible Event');
+    expect(output).not.toContain('Cursor Private Event');
+    expect(output).not.toContain('### Recent Activity');
+  });
+
   it('should work when only domain note exists', async () => {
     const config = makeConfig({ navigation: { enableProjectIndex: false, enableProjectLog: false } });
     await storeProjectNote('Partial Domain', 'partial', config, 'domain');
@@ -4267,6 +4305,32 @@ describe('MCP Tool: knowledge-health', () => {
     expect(output).toContain('## Health (1 notes)');
     expect(output).toContain('## Growth');
     expect(output).toContain('Notes created: 1');
+  });
+
+  it('should apply client visibility to all scoped note metrics', async () => {
+    const fixtures = [
+      { title: 'Alpha Universal', tags: ['project:alpha'] },
+      { title: 'Alpha Pi', tags: ['project:alpha', 'client:pi'] },
+      { title: 'Alpha Cursor', tags: ['project:alpha', 'client:cursor'] },
+      { title: 'Global Universal', tags: ['scope:global'] },
+      { title: 'Global Pi', tags: ['scope:global', 'client:pi'] },
+      { title: 'Global Cursor', tags: ['scope:global', 'client:cursor'] },
+      { title: 'Beta Pi', tags: ['project:beta', 'client:pi'] },
+    ];
+    for (const fixture of fixtures) {
+      const note = ctx.engine.store(fixture.title, {
+        title: fixture.title, kind: 'reference', tags: fixture.tags,
+      });
+      ctx.engine.storeEmbedding(note.id, [0.1], 'test-model');
+    }
+
+    const output = await handleHealth({ project: 'alpha', client: 'pi', period: '7d' }, ctx.engine, ctx.config);
+
+    expect(output).toContain('## Health (4 notes)');
+    expect(output).toContain('- Embedded: 4/4 notes');
+    expect(output).toContain('- 0–7d: 4');
+    expect(output).toContain('- Notes created: 4');
+    expect(output).toContain('- Issues: 4 unlinked');
   });
 
   it('should exclude generated navigation notes from scoped embedding stats', async () => {

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -3478,6 +3478,22 @@ describe('Domain note kind', () => {
     expect(domainIndex).toBeLessThan(regularIndex);
   });
 
+  it('should not inject the domain note into archived-only searches', async () => {
+    await handleStore({
+      title: 'MyApp Domain',
+      content: 'Canonical operating manual for MyApp.',
+      kind: 'domain',
+      project: 'myapp',
+      summary: 'MyApp operating manual',
+      guidance: 'Read first',
+    }, ctx.engine, null, ctx.config);
+
+    const config = { ...getConfig(), search: { alwaysIncludeDomainNote: true } };
+    const output = handleSearch({ query: 'totally-unrelated-query', project: 'myapp', status: 'archived' }, ctx.engine, null, config);
+
+    expect(output).toBe('No matching notes found. Try broader keywords or remove filters.');
+  });
+
   it('should return domain note even with zero FTS matches', async () => {
     await handleStore({
       title: 'MyApp Domain',

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -25,6 +25,7 @@ describe('MCP Tool: knowledge-store', () => {
 
   it('should store a note with kind-based default status', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Test Preference',
       content: 'I prefer dark mode',
       kind: 'personalization',
@@ -40,6 +41,7 @@ describe('MCP Tool: knowledge-store', () => {
 
   it('should store with explicit status override', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Fleeting Pref',
       content: 'Maybe I like light mode',
       kind: 'personalization',
@@ -62,7 +64,7 @@ describe('MCP Tool: knowledge-store', () => {
       guidance: 'Use PostgreSQL for all database needs in myapp',
     }, ctx.engine);
 
-    const notes = ctx.engine.getByKind('decision');
+    const notes = ctx.engine.getByKind('decision').filter(note => !note.tags.includes('generated'));
     expect(notes.length).toBe(1);
     expect(notes[0].tags).toContain('project:myapp');
   });
@@ -72,7 +74,7 @@ describe('MCP Tool: knowledge-store', () => {
       content: 'This decision belongs to the replacement project.',
       kind: 'decision',
       project: 'replacement-project',
-      tags: ['project:original-project', 'client:cursor'],
+      tags: ['client:cursor'],
       summary: 'Decision moved to replacement project',
       guidance: 'Use for replacement project work',
     }, ctx.engine);
@@ -85,13 +87,14 @@ describe('MCP Tool: knowledge-store', () => {
 
   it('should append related notes as wikilinks', async () => {
     // Store a first note
-    const _result1 = ctx.engine.store('Base concept', {
+    const _result1 = ctx.engine.store('Base concept', { tags: ['project:test-project'],
       title: 'Base Note',
       kind: 'reference',
       existingId: '202602081000',
     });
 
     const output = await handleStore({
+      project: 'test-project',
       title: 'Follow-up',
       content: 'This builds on the base',
       kind: 'reference',
@@ -108,6 +111,7 @@ describe('MCP Tool: knowledge-store', () => {
 
   it('should store with summary and guidance', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Prefers Tailwind',
       content: 'The user prefers Tailwind CSS utility classes over Bootstrap for styling.',
       kind: 'personalization',
@@ -118,7 +122,7 @@ describe('MCP Tool: knowledge-store', () => {
     expect(output).toContain('Stored ');
 
     // Verify summary/guidance persisted in DB
-    const notes = ctx.engine.search('Tailwind');
+    const notes = ctx.engine.getByKind('personalization');
     expect(notes.length).toBe(1);
     expect(notes[0].summary).toBe('User prefers Tailwind CSS over Bootstrap for styling');
     expect(notes[0].guidance).toBe('Use Tailwind when suggesting CSS frameworks or reviewing CSS code');
@@ -127,6 +131,7 @@ describe('MCP Tool: knowledge-store', () => {
   it('should warn when note exceeds kind word threshold', async () => {
     const longContent = Array(100).fill('word').join(' '); // 100 words
     const output = await handleStore({
+      project: 'test-project',
       title: 'Oversized Personalization',
       content: longContent,
       kind: 'personalization', // warn threshold: 80
@@ -143,6 +148,7 @@ describe('MCP Tool: knowledge-store', () => {
   it('should warn when note exceeds absolute threshold', async () => {
     const hugeContent = Array(350).fill('word').join(' '); // 350 words
     const output = await handleStore({
+      project: 'test-project',
       title: 'Huge Decision',
       content: hugeContent,
       kind: 'decision', // warn threshold: 250, absolute: 300
@@ -158,6 +164,7 @@ describe('MCP Tool: knowledge-store', () => {
   it('should not warn when note is within target', async () => {
     const shortContent = 'This is a concise observation about a specific behavior.';
     const output = await handleStore({
+      project: 'test-project',
       title: 'Good Note',
       content: shortContent,
       kind: 'observation',
@@ -173,6 +180,7 @@ describe('MCP Tool: knowledge-store', () => {
     // personalization warn threshold is 80 words — exactly 80 should NOT warn
     const exactContent = Array(80).fill('word').join(' ');
     const output = await handleStore({
+      project: 'test-project',
       title: 'Boundary Personalization',
       content: exactContent,
       kind: 'personalization',
@@ -187,6 +195,7 @@ describe('MCP Tool: knowledge-store', () => {
     // 210 words for reference (warn: 200, absolute: 300) — kind-level warning
     const content = Array(210).fill('word').join(' ');
     const output = await handleStore({
+      project: 'test-project',
       title: 'Long Reference',
       content,
       kind: 'reference',
@@ -203,6 +212,7 @@ describe('MCP Tool: knowledge-store', () => {
     // 310 words for reference — absolute-level warning
     const content = Array(310).fill('word').join(' ');
     const output = await handleStore({
+      project: 'test-project',
       title: 'Huge Reference',
       content,
       kind: 'reference',
@@ -218,6 +228,7 @@ describe('MCP Tool: knowledge-store', () => {
     // resource warn threshold: 100
     const content = Array(110).fill('word').join(' ');
     const output = await handleStore({
+      project: 'test-project',
       title: 'Long Resource',
       content,
       kind: 'resource',
@@ -237,7 +248,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should surface FTS5-matched related notes in response', async () => {
-    ctx.engine.store('React hooks provide a way to use state in functional components', {
+    ctx.engine.store('React hooks provide a way to use state in functional components', { tags: ['project:test-project'],
       title: 'React Hooks Guide',
       kind: 'reference',
       status: 'permanent',
@@ -246,6 +257,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
     });
 
     const output = await handleStore({
+      project: 'test-project',
       title: 'React State Management',
       content: 'React hooks are the preferred way to manage state',
       kind: 'reference',
@@ -296,7 +308,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
       guidance: 'Read first',
     }, ctx.engine, null, ctx.config);
 
-    ctx.engine.store('Task management workflows and sprint planning', {
+    ctx.engine.store('Task management workflows and sprint planning', { tags: ['project:myapp'],
       title: 'Task Workflows',
       kind: 'reference',
       status: 'permanent',
@@ -319,7 +331,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
   });
 
   it('should exclude archived notes from related notes', async () => {
-    const storeResult = ctx.engine.store('Archived note about PostgreSQL databases', {
+    const storeResult = ctx.engine.store('Archived note about PostgreSQL databases', { tags: ['project:test-project'],
       title: 'Old DB Reference',
       kind: 'reference',
       status: 'permanent',
@@ -328,7 +340,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
     });
     ctx.engine.archive(storeResult.id);
 
-    ctx.engine.store('Current guide to PostgreSQL databases', {
+    ctx.engine.store('Current guide to PostgreSQL databases', { tags: ['project:test-project'],
       title: 'Current DB Guide',
       kind: 'reference',
       status: 'permanent',
@@ -337,6 +349,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
     });
 
     const output = await handleStore({
+      project: 'test-project',
       title: 'PostgreSQL Best Practices',
       content: 'PostgreSQL database best practices and patterns',
       kind: 'reference',
@@ -350,7 +363,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
   });
 
   it('should not show related notes when disabled', async () => {
-    ctx.engine.store('Existing note about testing', {
+    ctx.engine.store('Existing note about testing', { tags: ['project:test-project'],
       title: 'Testing Guide',
       kind: 'reference',
       status: 'permanent',
@@ -364,6 +377,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
     };
 
     const output = await handleStore({
+      project: 'test-project',
       title: 'Testing Best Practices',
       content: 'Testing is essential for code quality',
       kind: 'reference',
@@ -376,6 +390,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
 
   it('should not show related notes when no matches exist', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'First Note Ever',
       content: 'This is the very first note in an empty vault',
       kind: 'observation',
@@ -388,7 +403,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
 
   it('should respect maxResults config', async () => {
     for (let i = 0; i < 8; i++) {
-      ctx.engine.store(`TypeScript pattern number ${i} for advanced usage`, {
+      ctx.engine.store(`TypeScript pattern number ${i} for advanced usage`, { tags: ['project:test-project'],
         title: `TypeScript Pattern ${i}`,
         kind: 'reference',
         status: 'permanent',
@@ -403,6 +418,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
     };
 
     const output = await handleStore({
+      project: 'test-project',
       title: 'TypeScript Advanced Patterns',
       content: 'Advanced TypeScript patterns for type-safe development',
       kind: 'reference',
@@ -416,7 +432,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
   });
 
   it('should not include the stored note itself in related notes', async () => {
-    ctx.engine.store('Existing reference about databases', {
+    ctx.engine.store('Existing reference about databases', { tags: ['project:test-project'],
       title: 'Database Reference',
       kind: 'reference',
       status: 'permanent',
@@ -425,6 +441,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
     });
 
     const output = await handleStore({
+      project: 'test-project',
       title: 'Database Patterns',
       content: 'Common database patterns and references',
       kind: 'reference',
@@ -438,14 +455,14 @@ describe('MCP Tool: knowledge-store — related notes', () => {
   });
 
   it('should apply minSimilarity threshold and render similarity scores via vector path', () => {
-    const r1 = ctx.engine.store('Very similar content about React hooks', {
+    const r1 = ctx.engine.store('Very similar content about React hooks', { tags: ['project:test-project'],
       title: 'React Hooks Deep Dive',
       kind: 'reference',
       status: 'permanent',
       summary: 'Deep dive into React hooks',
       guidance: 'Use hooks',
     });
-    const r2 = ctx.engine.store('Completely unrelated cooking content', {
+    const r2 = ctx.engine.store('Completely unrelated cooking content', { tags: ['project:test-project'],
       title: 'Pasta Recipes',
       kind: 'reference',
       status: 'permanent',
@@ -460,7 +477,7 @@ describe('MCP Tool: knowledge-store — related notes', () => {
       guidance: 'Read first',
       tags: ['project:myapp'],
     });
-    const r4 = ctx.engine.store('Archived old hooks guide', {
+    const r4 = ctx.engine.store('Archived old hooks guide', { tags: ['project:test-project'],
       title: 'Old Hooks Guide',
       kind: 'reference',
       status: 'permanent',
@@ -500,21 +517,21 @@ describe('MCP Tool: knowledge-search', () => {
 
   beforeEach(() => {
     ctx = createTestHarness();
-    ctx.engine.store('I prefer TypeScript', { title: 'TS Pref', kind: 'personalization', status: 'permanent' });
-    ctx.engine.store('API endpoint is /api/v2', { title: 'API Ref', kind: 'reference', status: 'fleeting' });
+    ctx.engine.store('I prefer TypeScript', { tags: ['project:test-project'], title: 'TS Pref', kind: 'personalization', status: 'permanent' });
+    ctx.engine.store('API endpoint is /api/v2', { tags: ['project:test-project'], title: 'API Ref', kind: 'reference', status: 'fleeting' });
     ctx.engine.store('Use PostgreSQL', { title: 'DB Decision', kind: 'decision', status: 'permanent', tags: ['project:myapp'] });
   });
 
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should find notes by text query', () => {
-    const output = handleSearch({ query: 'TypeScript' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'TypeScript' }, ctx.engine);
     expect(output).toContain('TS Pref');
     expect(output).not.toContain('No matching notes');
   });
 
   it('should render notes as XML with summary and guidance', () => {
-    const output = handleSearch({ query: 'TypeScript' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'TypeScript' }, ctx.engine);
     expect(output).toContain('<note ');
     expect(output).toContain('<summary>');
     expect(output).toContain('<guidance>');
@@ -522,7 +539,7 @@ describe('MCP Tool: knowledge-search', () => {
   });
 
   it('should filter by kind', () => {
-    const output = handleSearch({ query: 'TypeScript API PostgreSQL', kind: 'personalization' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'TypeScript API PostgreSQL', kind: 'personalization' }, ctx.engine);
     expect(output).toContain('personalization');
     expect(output).not.toContain('kind="decision"');
   });
@@ -553,13 +570,13 @@ describe('MCP Tool: knowledge-search', () => {
     const output = handleSearch({ query: 'Scoped', project: 'app' }, ctx.engine);
 
     expect(output).toContain('App Exact');
-    expect(output).toContain('App Feature');
+    expect(output).not.toContain('App Feature');
     expect(output).not.toContain('Apple Sibling');
   });
 
   it('should overfetch before applying project filter', () => {
     for (let i = 0; i < 12; i++) {
-      ctx.engine.store('Shared scoped overfetch keyword', {
+      ctx.engine.store('Shared scoped overfetch keyword', { tags: ['project:test-project'],
         title: `Non Project Overfetch ${i}`,
         kind: 'reference',
       });
@@ -592,19 +609,19 @@ describe('MCP Tool: knowledge-search', () => {
         tags: [`project:generated-${i}`],
       });
     }
-    ctx.engine.store(query, { title: 'Real Search Result', kind: 'reference' });
+    ctx.engine.store(query, { tags: ['project:test-project'], title: 'Real Search Result', kind: 'reference' });
 
     const ranked = ctx.engine.search(query, { limit: 10 });
     expect(ranked).toHaveLength(10);
     expect(ranked.every(note => note.kind === 'index' || note.kind === 'log')).toBe(true);
 
-    const output = handleSearch({ query, limit: 10 }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query, limit: 10 }, ctx.engine);
     expect(output).toContain('Real Search Result');
     expect(output).not.toContain('Generated Crowding');
   });
 
   it('should return no results message with hint', () => {
-    const output = handleSearch({ query: 'xyznonexistent' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'xyznonexistent' }, ctx.engine);
     expect(output).toBe('No matching notes found. Try broader keywords or remove filters.');
   });
 });
@@ -614,14 +631,14 @@ describe('MCP Tool: knowledge-get', () => {
 
   beforeEach(() => {
     ctx = createTestHarness();
-    ctx.engine.store('API endpoint is /api/v2', { title: 'API Ref', kind: 'reference', status: 'permanent' });
+    ctx.engine.store('API endpoint is /api/v2', { tags: ['project:test-project'], title: 'API Ref', kind: 'reference', status: 'permanent' });
   });
 
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should retrieve a note by exact ID', () => {
-    const result = ctx.engine.store('Full API docs here', { title: 'Full API Ref', kind: 'reference', status: 'permanent' });
-    const output = handleGet({ noteId: result.id }, ctx.engine);
+    const result = ctx.engine.store('Full API docs here', { tags: ['project:test-project'], title: 'Full API Ref', kind: 'reference', status: 'permanent' });
+    const output = handleGet({ project: 'test-project', noteId: result.id }, ctx.engine);
     expect(output).toContain('Full API Ref');
     expect(output).toContain('kind="reference"');
     expect(output).toContain('<content>');
@@ -629,7 +646,7 @@ describe('MCP Tool: knowledge-get', () => {
   });
 
   it('should return error for nonexistent ID', () => {
-    const output = handleGet({ noteId: '9999999999999999' }, ctx.engine);
+    const output = handleGet({ project: 'test-project', noteId: '9999999999999999' }, ctx.engine);
     expect(output).toBe('Note not found: 9999999999999999');
   });
 });
@@ -644,9 +661,9 @@ describe('MCP Tool: knowledge-maintain', () => {
 
   beforeEach(() => {
     ctx = createTestHarness({ telemetryEnabled: true });
-    ctx.engine.store('Pref 1', { title: 'P1', kind: 'personalization', status: 'permanent' });
-    ctx.engine.store('Ref 1', { title: 'R1', kind: 'reference', status: 'fleeting' });
-    ctx.engine.store('Dec 1', { title: 'D1', kind: 'decision', status: 'permanent' });
+    ctx.engine.store('Pref 1', { tags: ['project:test-project'], title: 'P1', kind: 'personalization', status: 'permanent' });
+    ctx.engine.store('Ref 1', { tags: ['project:test-project'], title: 'R1', kind: 'reference', status: 'fleeting' });
+    ctx.engine.store('Dec 1', { tags: ['project:test-project'], title: 'D1', kind: 'decision', status: 'permanent' });
   });
 
   afterEach(() => { cleanupTestHarness(ctx); });
@@ -683,11 +700,11 @@ describe('MCP Tool: knowledge-maintain', () => {
   });
 
   it('should preserve Related sections when formatting notes', async () => {
-    const related = ctx.engine.store('Related note content', {
+    const related = ctx.engine.store('Related note content', { tags: ['project:test-project'],
       title: 'Related Format Target',
       kind: 'reference',
     });
-    const source = ctx.engine.store('Source note content', {
+    const source = ctx.engine.store('Source note content', { tags: ['project:test-project'],
       title: 'Related Format Source',
       kind: 'reference',
     });
@@ -709,7 +726,7 @@ describe('MCP Tool: knowledge-maintain', () => {
   it('should backfill embeddings in bounded batches', async () => {
     ctx.engine.clearAll();
     for (let i = 0; i < 51; i++) {
-      ctx.engine.store(`Batch content ${i}`, {
+      ctx.engine.store(`Batch content ${i}`, { tags: ['project:test-project'],
         title: `Batch Note ${i}`,
         kind: 'reference',
         summary: `Batch summary ${i}`,
@@ -747,7 +764,7 @@ describe('MCP Tool: knowledge-maintain', () => {
     ctx.engine.clearAll();
     // Create 60 notes — more than the old default of 50
     for (let i = 0; i < 60; i++) {
-      ctx.engine.store(`Content ${i}`, {
+      ctx.engine.store(`Content ${i}`, { tags: ['project:test-project'],
         title: `Note ${i}`,
         kind: 'reference',
         summary: `Summary ${i}`,
@@ -781,7 +798,7 @@ describe('MCP Tool: knowledge-maintain', () => {
   it('should include remaining count in embed response when partial', async () => {
     ctx.engine.clearAll();
     for (let i = 0; i < 10; i++) {
-      ctx.engine.store(`Content ${i}`, {
+      ctx.engine.store(`Content ${i}`, { tags: ['project:test-project'],
         title: `Note ${i}`,
         kind: 'reference',
         summary: `Summary ${i}`,
@@ -818,7 +835,7 @@ describe('MCP Tool: knowledge-maintain', () => {
   it('should not show remaining count when all notes are embedded', async () => {
     ctx.engine.clearAll();
     for (let i = 0; i < 3; i++) {
-      ctx.engine.store(`Content ${i}`, {
+      ctx.engine.store(`Content ${i}`, { tags: ['project:test-project'],
         title: `Note ${i}`,
         kind: 'reference',
         summary: `Summary ${i}`,
@@ -987,7 +1004,7 @@ describe('MCP Tool: knowledge-maintain', () => {
 
   it('should report all upgraded when fields are present', async () => {
     ctx.engine.clearAll();
-    ctx.engine.store('Content', {
+    ctx.engine.store('Content', { tags: ['project:test-project'],
       title: 'Complete Note',
       kind: 'personalization',
       status: 'permanent',
@@ -1002,12 +1019,12 @@ describe('MCP Tool: knowledge-maintain', () => {
   it('should return review output with proper formatting and counts', async () => {
     ctx.engine.clearAll();
 
-    const fleeting = ctx.engine.store('Old fleeting item', {
+    const fleeting = ctx.engine.store('Old fleeting item', { tags: ['project:test-project'],
       title: 'Review Fleeting',
       kind: 'observation',
       status: 'fleeting',
     });
-    const permanent = ctx.engine.store('Old permanent item', {
+    const permanent = ctx.engine.store('Old permanent item', { tags: ['project:test-project'],
       title: 'Review Permanent',
       kind: 'reference',
       status: 'permanent',
@@ -1031,17 +1048,17 @@ describe('MCP Tool: knowledge-maintain', () => {
   it('should include archive/review/promote recommendations', async () => {
     ctx.engine.clearAll();
 
-    const promoteCandidate = ctx.engine.store('Promote candidate', {
+    const promoteCandidate = ctx.engine.store('Promote candidate', { tags: ['project:test-project'],
       title: 'Promote Candidate',
       kind: 'observation',
       status: 'fleeting',
     });
-    const archiveCandidate = ctx.engine.store('Archive candidate', {
+    const archiveCandidate = ctx.engine.store('Archive candidate', { tags: ['project:test-project'],
       title: 'Archive Candidate',
       kind: 'observation',
       status: 'fleeting',
     });
-    const reviewCandidate = ctx.engine.store('Review candidate', {
+    const reviewCandidate = ctx.engine.store('Review candidate', { tags: ['project:test-project'],
       title: 'Review Candidate',
       kind: 'observation',
       status: 'fleeting',
@@ -1074,12 +1091,12 @@ describe('MCP Tool: knowledge-maintain', () => {
   it('should respect review filter in handleMaintain review action', async () => {
     ctx.engine.clearAll();
 
-    const fleeting = ctx.engine.store('Filter fleeting', {
+    const fleeting = ctx.engine.store('Filter fleeting', { tags: ['project:test-project'],
       title: 'Filter Fleeting',
       kind: 'observation',
       status: 'fleeting',
     });
-    const permanent = ctx.engine.store('Filter permanent', {
+    const permanent = ctx.engine.store('Filter permanent', { tags: ['project:test-project'],
       title: 'Filter Permanent',
       kind: 'reference',
       status: 'permanent',
@@ -1112,14 +1129,14 @@ describe('MCP Tool: knowledge-maintain', () => {
 
     // Store a note that exceeds the personalization warn threshold (80 words)
     const longContent = Array(120).fill('word').join(' ');
-    ctx.engine.store(longContent, {
+    ctx.engine.store(longContent, { tags: ['project:test-project'],
       title: 'Bloated Personalization',
       kind: 'personalization',
       status: 'fleeting',
     });
 
     // Store a small note that should NOT appear in oversized
-    ctx.engine.store('Short content', {
+    ctx.engine.store('Short content', { tags: ['project:test-project'],
       title: 'Good Note',
       kind: 'observation',
       status: 'fleeting',
@@ -1147,12 +1164,12 @@ describe('MCP Tool: knowledge-maintain', () => {
   it('dedupe shows permanent notes as protected and never recommends archiving them', async () => {
     ctx.engine.clearAll();
 
-    const permanent = ctx.engine.store('Canonical decision content', {
+    const permanent = ctx.engine.store('Canonical decision content', { tags: ['project:test-project'],
       title: 'Test Decision',
       kind: 'decision',
       status: 'permanent',
     });
-    const duplicate = ctx.engine.store('Older duplicate decision content', {
+    const duplicate = ctx.engine.store('Older duplicate decision content', { tags: ['project:test-project'],
       title: 'Test Decision',
       kind: 'decision',
       status: 'fleeting',
@@ -1172,12 +1189,12 @@ describe('MCP Tool: knowledge-maintain', () => {
   it('dedupe backfills missing hashes and reports SimHash near-duplicates', async () => {
     ctx.engine.clearAll();
 
-    ctx.engine.store('Use PostgreSQL for ACID transactions and reliability', {
+    ctx.engine.store('Use PostgreSQL for ACID transactions and reliability', { tags: ['project:test-project'],
       title: 'Database Decision A',
       kind: 'decision',
       status: 'fleeting',
     });
-    ctx.engine.store('Use PostgreSQL for ACID transactions and reliability', {
+    ctx.engine.store('Use PostgreSQL for ACID transactions and reliability', { tags: ['project:test-project'],
       title: 'Database Decision B',
       kind: 'decision',
       status: 'fleeting',
@@ -1444,8 +1461,8 @@ describe('Data Migrations: upgrade action', () => {
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should list pending migrations with correct counts', () => {
-    ctx.engine.store('Content A', { title: 'Note A', kind: 'reference', status: 'fleeting' });
-    ctx.engine.store('Content B', { title: 'Note B', kind: 'observation', status: 'fleeting' });
+    ctx.engine.store('Content A', { tags: ['project:test-project'], title: 'Note A', kind: 'reference', status: 'fleeting' });
+    ctx.engine.store('Content B', { tags: ['project:test-project'], title: 'Note B', kind: 'observation', status: 'fleeting' });
 
     const pending = getPendingMigrations(ctx.engine);
     expect(pending.length).toBe(1);
@@ -1455,7 +1472,7 @@ describe('Data Migrations: upgrade action', () => {
   });
 
   it('should report no pending when all notes have summary and guidance', () => {
-    ctx.engine.store('Content', {
+    ctx.engine.store('Content', { tags: ['project:test-project'],
       title: 'Complete Note',
       kind: 'personalization',
       status: 'permanent',
@@ -1477,7 +1494,7 @@ describe('Data Migrations: upgrade-read', () => {
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should return full content in XML with instructions', () => {
-    ctx.engine.store('This is my preference content', {
+    ctx.engine.store('This is my preference content', { tags: ['project:test-project'],
       title: 'Dark Mode Pref',
       kind: 'personalization',
       status: 'permanent',
@@ -1499,7 +1516,7 @@ describe('Data Migrations: upgrade-read', () => {
   it('should support pagination via detect + slice', () => {
     // Store 5 notes without summary/guidance
     for (let i = 0; i < 5; i++) {
-      ctx.engine.store(`Content ${i}`, { title: `Note ${i}`, kind: 'reference', status: 'fleeting' });
+      ctx.engine.store(`Content ${i}`, { tags: ['project:test-project'], title: `Note ${i}`, kind: 'reference', status: 'fleeting' });
     }
 
     const migration = getMigrationById('v3-summary-guidance')!;
@@ -1517,9 +1534,9 @@ describe('Data Migrations: upgrade-read', () => {
   });
 
   it('should support fetching specific noteIds via getByIds', () => {
-    const r1 = ctx.engine.store('Content A', { title: 'Note A', kind: 'reference', status: 'fleeting' });
-    const r2 = ctx.engine.store('Content B', { title: 'Note B', kind: 'reference', status: 'fleeting' });
-    ctx.engine.store('Content C', { title: 'Note C', kind: 'reference', status: 'fleeting' });
+    const r1 = ctx.engine.store('Content A', { tags: ['project:test-project'], title: 'Note A', kind: 'reference', status: 'fleeting' });
+    const r2 = ctx.engine.store('Content B', { tags: ['project:test-project'], title: 'Note B', kind: 'reference', status: 'fleeting' });
+    ctx.engine.store('Content C', { tags: ['project:test-project'], title: 'Note C', kind: 'reference', status: 'fleeting' });
 
     const fetched = ctx.engine.getByIds([r1.id, r2.id]);
     expect(fetched.length).toBe(2);
@@ -1538,7 +1555,7 @@ describe('Data Migrations: upgrade-apply', () => {
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should update summary and guidance correctly', () => {
-    const result = ctx.engine.store('I prefer dark mode in all editors', {
+    const result = ctx.engine.store('I prefer dark mode in all editors', { tags: ['project:test-project'],
       title: 'Dark Mode Pref',
       kind: 'personalization',
       status: 'permanent',
@@ -1566,8 +1583,8 @@ describe('Data Migrations: upgrade-apply', () => {
   });
 
   it('should remove migration from pending after all notes are upgraded', () => {
-    const r1 = ctx.engine.store('Content A', { title: 'Note A', kind: 'reference', status: 'fleeting' });
-    const r2 = ctx.engine.store('Content B', { title: 'Note B', kind: 'observation', status: 'fleeting' });
+    const r1 = ctx.engine.store('Content A', { tags: ['project:test-project'], title: 'Note A', kind: 'reference', status: 'fleeting' });
+    const r2 = ctx.engine.store('Content B', { tags: ['project:test-project'], title: 'Note B', kind: 'observation', status: 'fleeting' });
 
     let pending = getPendingMigrations(ctx.engine);
     expect(pending.length).toBe(1);
@@ -1582,7 +1599,7 @@ describe('Data Migrations: upgrade-apply', () => {
   });
 
   it('should update markdown frontmatter when applying', () => {
-    const result = ctx.engine.store('Some content here', {
+    const result = ctx.engine.store('Some content here', { tags: ['project:test-project'],
       title: 'Frontmatter Test',
       kind: 'reference',
       status: 'fleeting',
@@ -1614,7 +1631,7 @@ describe('Data Migrations: NoteRepository.getByIds', () => {
   });
 
   it('should return only existing notes', () => {
-    const r1 = ctx.engine.store('Content', { title: 'Exists', kind: 'reference', status: 'fleeting' });
+    const r1 = ctx.engine.store('Content', { tags: ['project:test-project'], title: 'Exists', kind: 'reference', status: 'fleeting' });
     const results = ctx.engine.getByIds([r1.id, 'nonexistent']);
     expect(results.length).toBe(1);
     expect(results[0].id).toBe(r1.id);
@@ -1780,7 +1797,7 @@ describe('MCP Tool: knowledge-health version check', () => {
     )) as any;
 
     const output = await handleHealth(
-      {}, ctx.engine, ctx.config, null, '0.1.0',
+      { project: 'test-project' }, ctx.engine, ctx.config, null, '0.1.0',
     );
     expect(output).toContain('## Version');
     expect(output).toContain('Server: 0.1.0');
@@ -1795,7 +1812,7 @@ describe('MCP Tool: knowledge-health version check', () => {
     )) as any;
 
     const output = await handleHealth(
-      {}, ctx.engine, ctx.config, null, '0.1.0',
+      { project: 'test-project' }, ctx.engine, ctx.config, null, '0.1.0',
     );
     expect(output).not.toContain('Update Available');
   });
@@ -1804,7 +1821,7 @@ describe('MCP Tool: knowledge-health version check', () => {
     globalThis.fetch = (async () => { throw new Error('offline'); }) as any;
 
     const output = await handleHealth(
-      {}, ctx.engine, ctx.config, null, '0.1.0',
+      { project: 'test-project' }, ctx.engine, ctx.config, null, '0.1.0',
     );
     expect(output).not.toContain('Update Available');
   });
@@ -1816,7 +1833,7 @@ describe('MCP Tool: knowledge-health version check', () => {
     )) as any;
 
     const output = await handleHealth(
-      {}, ctx.engine, ctx.config, null, '0.2.0',
+      { project: 'test-project' }, ctx.engine, ctx.config, null, '0.2.0',
     );
     expect(output).not.toContain('Update Available');
   });
@@ -1828,7 +1845,7 @@ describe('MCP Tool: knowledge-health version check', () => {
     )) as any;
 
     const output = await handleHealth(
-      {}, ctx.engine, ctx.config,
+      { project: 'test-project' }, ctx.engine, ctx.config,
     );
     expect(output).not.toContain('Update Available');
   });
@@ -1844,6 +1861,7 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
 
   it('should add client tag when client param provided', async () => {
     await handleStore({
+      project: 'test-project',
       title: 'Claude Code Workflow',
       content: 'Use skills directory for prompts',
       kind: 'procedure',
@@ -1859,6 +1877,7 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
 
   it('should auto-detect client from .opencode/ in content', async () => {
     await handleStore({
+      project: 'test-project',
       title: 'OpenCode Config',
       content: 'Edit .opencode/config.json to change settings',
       kind: 'reference',
@@ -1872,6 +1891,7 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
 
   it('should auto-detect client from .claude/ in guidance', async () => {
     await handleStore({
+      project: 'test-project',
       title: 'Claude Instructions',
       content: 'Project instructions go in the root',
       kind: 'reference',
@@ -1885,6 +1905,7 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
 
   it('should NOT auto-tag universal content', async () => {
     await handleStore({
+      project: 'test-project',
       title: 'General Preference',
       content: 'User prefers TypeScript',
       kind: 'personalization',
@@ -1899,6 +1920,7 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
 
   it('should warn on unrecognized client name', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Unknown Client Note',
       content: 'Some content',
       kind: 'reference',
@@ -1913,6 +1935,7 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
 
   it('should NOT warn on recognized client name', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Known Client Note',
       content: 'Some content',
       kind: 'reference',
@@ -1926,6 +1949,7 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
 
   it('should use explicit client over auto-detection', async () => {
     await handleStore({
+      project: 'test-project',
       title: 'Cross-Client Note',
       content: 'Edit .opencode/config for opencode',
       kind: 'reference',
@@ -1941,6 +1965,7 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
 
   it('should not auto-tag when multiple clients detected (ambiguous)', async () => {
     await handleStore({
+      project: 'test-project',
       title: 'Client Comparison',
       content: 'Compare .opencode/config.json vs .claude/settings.json',
       kind: 'reference',
@@ -1978,29 +2003,29 @@ describe('MCP Tool: knowledge-search (client filtering)', () => {
     ctx.engine.store('Universal knowledge about TypeScript', {
       title: 'Universal Note',
       kind: 'reference',
-      tags: [],
+      tags: ['scope:global'],
     });
     ctx.engine.store('Claude-specific knowledge about skills', {
       title: 'Claude Only',
       kind: 'reference',
-      tags: ['client:claude-code'],
+      tags: ['scope:global', 'client:claude-code'],
     });
     ctx.engine.store('OpenCode-specific knowledge about agents', {
       title: 'OpenCode Only',
       kind: 'reference',
-      tags: ['client:opencode'],
+      tags: ['scope:global', 'client:opencode'],
     });
     ctx.engine.store('Explicitly universal knowledge for all clients', {
       title: 'All Clients',
       kind: 'reference',
-      tags: ['client:all'],
+      tags: ['scope:global', 'client:all'],
     });
   });
 
   afterEach(() => { cleanupTestHarness(ctx); });
 
-  it('should return all notes when no client param (backward compat)', () => {
-    const output = handleSearch({ query: 'knowledge' }, ctx.engine);
+  it('should search global client fixtures within the current project contract', () => {
+    const output = handleSearch({ project: 'test-project', query: 'knowledge' }, ctx.engine);
     expect(output).toContain('Universal Note');
     expect(output).toContain('Claude Only');
     expect(output).toContain('OpenCode Only');
@@ -2008,7 +2033,7 @@ describe('MCP Tool: knowledge-search (client filtering)', () => {
   });
 
   it('should exclude other-client notes when client param set', () => {
-    const output = handleSearch({ query: 'knowledge', client: 'claude-code' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'knowledge', client: 'claude-code' }, ctx.engine);
     expect(output).toContain('Universal Note');
     expect(output).toContain('Claude Only');
     expect(output).toContain('All Clients');
@@ -2016,7 +2041,7 @@ describe('MCP Tool: knowledge-search (client filtering)', () => {
   });
 
   it('should show only universal notes to a client with no scoped notes', () => {
-    const output = handleSearch({ query: 'knowledge', client: 'cursor' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'knowledge', client: 'cursor' }, ctx.engine);
     expect(output).toContain('Universal Note');
     expect(output).toContain('All Clients');
     expect(output).not.toContain('Claude Only');
@@ -2038,17 +2063,17 @@ describe('MCP Tool: knowledge-search (client filtering)', () => {
     const output = handleSearch({ query: 'knowledge', client: 'claude-code', project: 'myapp' }, ctx.engine);
     expect(output).toContain('Claude Project Note');
     expect(output).not.toContain('OpenCode Project Note');
-    // Universal notes without project tag are excluded by project filter
-    expect(output).not.toContain('Universal Note');
+    // Explicitly global notes remain visible within a project search.
+    expect(output).toContain('Universal Note');
   });
 
   it('should warn on unrecognized client name in search', () => {
-    const output = handleSearch({ query: 'knowledge', client: 'vscode' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'knowledge', client: 'vscode' }, ctx.engine);
     expect(output).toContain('⚠ Unrecognized client "vscode"');
   });
 
   it('should NOT warn on recognized client name in search', () => {
-    const output = handleSearch({ query: 'knowledge', client: 'opencode' }, ctx.engine);
+    const output = handleSearch({ project: 'test-project', query: 'knowledge', client: 'opencode' }, ctx.engine);
     expect(output).not.toContain('Unrecognized client');
   });
 });
@@ -2230,7 +2255,7 @@ describe('MCP Tool: knowledge-maintain scope-audit', () => {
     const _result = ctx.engine.store('Edit .opencode/config.json for settings', {
       title: 'Already Tagged',
       kind: 'reference',
-      tags: ['client:opencode'],
+      tags: ['scope:global', 'client:opencode'],
       guidance: 'Configure settings',
     });
 
@@ -2258,12 +2283,12 @@ describe('MCP Tool: knowledge-maintain scope-audit', () => {
     ctx.engine.store('Claude knowledge', {
       title: 'Claude Note',
       kind: 'reference',
-      tags: ['client:claude-code'],
+      tags: ['scope:global', 'client:claude-code'],
     });
     ctx.engine.store('OpenCode knowledge', {
       title: 'OpenCode Note',
       kind: 'reference',
-      tags: ['client:opencode'],
+      tags: ['scope:global', 'client:opencode'],
     });
 
     const output = await handleMaintain(
@@ -2277,7 +2302,7 @@ describe('MCP Tool: knowledge-maintain scope-audit', () => {
     ctx.engine.store('Unknown client knowledge', {
       title: 'Unknown Client Note',
       kind: 'reference',
-      tags: ['client:vscode'],
+      tags: ['scope:global', 'client:vscode'],
     });
 
     const output = await handleMaintain(
@@ -2292,12 +2317,12 @@ describe('MCP Tool: knowledge-maintain scope-audit', () => {
     ctx.engine.store('Unknown client knowledge', {
       title: 'Unknown Client Note',
       kind: 'reference',
-      tags: ['client:vscode'],
+      tags: ['scope:global', 'client:vscode'],
     });
     ctx.engine.store('Known client knowledge', {
       title: 'Known Client Note',
       kind: 'reference',
-      tags: ['client:opencode'],
+      tags: ['scope:global', 'client:opencode'],
     });
 
     const output = await handleMaintain(
@@ -2316,6 +2341,7 @@ describe('MCP Tool: knowledge-store (model capability)', () => {
 
   it('should append model hint when model param is absent', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'No Model',
       content: 'Test content',
       kind: 'observation',
@@ -2329,6 +2355,7 @@ describe('MCP Tool: knowledge-store (model capability)', () => {
 
   it('should not append model hint when model param is provided', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'With Model',
       content: 'Test content',
       kind: 'observation',
@@ -2342,6 +2369,7 @@ describe('MCP Tool: knowledge-store (model capability)', () => {
 
   it('should show capability tier for high-tier models', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'High Tier',
       content: 'Test content',
       kind: 'observation',
@@ -2355,6 +2383,7 @@ describe('MCP Tool: knowledge-store (model capability)', () => {
 
   it('should not show capability tier for medium-tier models', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Medium Tier',
       content: 'Test content',
       kind: 'observation',
@@ -2368,6 +2397,7 @@ describe('MCP Tool: knowledge-store (model capability)', () => {
 
   it('should not show capability tier for low-tier models', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Low Tier',
       content: 'Test content',
       kind: 'observation',
@@ -2381,6 +2411,7 @@ describe('MCP Tool: knowledge-store (model capability)', () => {
 
   it('should still store the note correctly regardless of model param', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Model Store Test',
       content: 'Important knowledge',
       kind: 'reference',
@@ -2392,7 +2423,7 @@ describe('MCP Tool: knowledge-store (model capability)', () => {
     expect(output).toContain('Stored ');
     expect(output).toContain('reference:');
 
-    const notes = ctx.engine.search('Important knowledge');
+    const notes = ctx.engine.search('Important knowledge').filter(note => note.title === 'Model Store Test');
     expect(notes.length).toBe(1);
     expect(notes[0].title).toBe('Model Store Test');
   });
@@ -2405,8 +2436,8 @@ describe('MCP Tool: knowledge-maintain unlinked', () => {
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should detect unlinked notes with no links', async () => {
-    ctx.engine.store('Standalone note', { title: 'Unlinked A', kind: 'reference' });
-    ctx.engine.store('Another standalone', { title: 'Unlinked B', kind: 'observation' });
+    ctx.engine.store('Standalone note', { tags: ['project:test-project'], title: 'Unlinked A', kind: 'reference' });
+    ctx.engine.store('Another standalone', { tags: ['project:test-project'], title: 'Unlinked B', kind: 'observation' });
 
     const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
     expect(output).toContain('Unlinked Notes (2)');
@@ -2415,8 +2446,8 @@ describe('MCP Tool: knowledge-maintain unlinked', () => {
   });
 
   it('should exclude archived notes from unlinked detection', async () => {
-    ctx.engine.store('Archived note', { title: 'Old Note', kind: 'reference', status: 'archived' });
-    ctx.engine.store('Active unlinked', { title: 'Active Note', kind: 'observation' });
+    ctx.engine.store('Archived note', { tags: ['project:test-project'], title: 'Old Note', kind: 'reference', status: 'archived' });
+    ctx.engine.store('Active unlinked', { tags: ['project:test-project'], title: 'Active Note', kind: 'observation' });
 
     const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
     expect(output).toContain('Active Note');
@@ -2424,8 +2455,8 @@ describe('MCP Tool: knowledge-maintain unlinked', () => {
   });
 
   it('should exclude generated index and log notes from unlinked detection', async () => {
-    ctx.engine.store('Generated navigation', { title: 'Project Index', kind: 'index' });
-    ctx.engine.store('Generated activity', { title: 'Project Log', kind: 'log' });
+    ctx.engine.store('Generated navigation', { tags: ['project:test-project'], title: 'Project Index', kind: 'index' });
+    ctx.engine.store('Generated activity', { tags: ['project:test-project'], title: 'Project Log', kind: 'log' });
 
     const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
     expect(output).toContain('No unlinked notes found');
@@ -2434,39 +2465,39 @@ describe('MCP Tool: knowledge-maintain unlinked', () => {
   });
 
   it('should not list notes that have outgoing links', async () => {
-    const target = ctx.engine.store('Target note', { title: 'Target', kind: 'reference' });
-    ctx.engine.store(`Links to [[${target.id}]]`, { title: 'Linker', kind: 'observation' });
+    const target = ctx.engine.store('Target note', { tags: ['project:test-project'], title: 'Target', kind: 'reference' });
+    ctx.engine.store(`Links to [[${target.id}]]`, { tags: ['project:test-project'], title: 'Linker', kind: 'observation' });
 
     const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
     expect(output).not.toContain('Linker');
   });
 
   it('should not list notes that have incoming links', async () => {
-    const target = ctx.engine.store('Target content', { title: 'Target', kind: 'reference' });
-    ctx.engine.store(`See also [[${target.id}]]`, { title: 'Source', kind: 'observation' });
+    const target = ctx.engine.store('Target content', { tags: ['project:test-project'], title: 'Target', kind: 'reference' });
+    ctx.engine.store(`See also [[${target.id}]]`, { tags: ['project:test-project'], title: 'Source', kind: 'observation' });
 
     const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
     expect(output).not.toContain('Target');
   });
 
   it('should return clean message when no unlinked notes', async () => {
-    const noteA = ctx.engine.store('Note A content', { title: 'Note A', kind: 'reference' });
-    ctx.engine.store(`References [[${noteA.id}]]`, { title: 'Note B', kind: 'observation' });
+    const noteA = ctx.engine.store('Note A content', { tags: ['project:test-project'], title: 'Note A', kind: 'reference' });
+    ctx.engine.store(`References [[${noteA.id}]]`, { tags: ['project:test-project'], title: 'Note B', kind: 'observation' });
 
     const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
     expect(output).toContain('No unlinked notes found');
   });
 
   it('should not flag notes with broken wikilinks as unlinked', async () => {
-    ctx.engine.store('See [[9999999999999999-nonexistent]]', { title: 'Has Broken Link', kind: 'reference' });
+    ctx.engine.store('See [[9999999999999999-nonexistent]]', { tags: ['project:test-project'], title: 'Has Broken Link', kind: 'reference' });
 
     const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
     expect(output).not.toContain('Has Broken Link');
   });
 
   it('should not flag as unlinked when note has wikilink syntax to archived target', async () => {
-    const target = ctx.engine.store('Target content', { title: 'Target', kind: 'reference' });
-    ctx.engine.store(`Links to [[${target.id}]]`, { title: 'Linker To Archived', kind: 'observation' });
+    const target = ctx.engine.store('Target content', { tags: ['project:test-project'], title: 'Target', kind: 'reference' });
+    ctx.engine.store(`Links to [[${target.id}]]`, { tags: ['project:test-project'], title: 'Linker To Archived', kind: 'observation' });
     ctx.engine.archive(target.id);
 
     const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
@@ -2477,12 +2508,11 @@ describe('MCP Tool: knowledge-maintain unlinked', () => {
     ctx.engine.store('Alpha content', { title: 'Alpha', kind: 'reference', tags: ['project:proj-a'] });
     ctx.engine.store('Beta content', { title: 'Beta', kind: 'decision', tags: ['project:proj-a'] });
     ctx.engine.store('Gamma content', { title: 'Gamma', kind: 'observation', tags: ['project:proj-b'] });
-    ctx.engine.store('Delta content', { title: 'Delta', kind: 'reference' }); // no project
+    ctx.engine.store('Delta content', { tags: ['scope:global'], title: 'Delta', kind: 'reference' }); // no project
 
     const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
     expect(output).toContain('Unlinked Notes (4)');
-    expect(output).toContain('3 in 2 projects');
-    expect(output).toContain('1 unscoped');
+    expect(output).toContain('3 in 2 projects, 1 unscoped');
     expect(output).toContain('### proj-a (2)');
     expect(output).toContain('### proj-b (1)');
     expect(output).toContain('### (no project) (1)');
@@ -2492,7 +2522,7 @@ describe('MCP Tool: knowledge-maintain unlinked', () => {
 
   it('should cap unlinked display at 20 with overflow message', async () => {
     for (let i = 0; i < 25; i++) {
-      ctx.engine.store(`Content ${i}`, { title: `Note ${i}`, kind: 'reference' });
+      ctx.engine.store(`Content ${i}`, { tags: ['project:test-project'], title: `Note ${i}`, kind: 'reference' });
     }
 
     const output = await handleMaintain({ action: 'unlinked' }, ctx.engine, ctx.config);
@@ -2508,7 +2538,7 @@ describe('MCP Tool: knowledge-maintain broken-links', () => {
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should detect broken wikilinks with line numbers', async () => {
-    ctx.engine.store('See [[9999999999999999-nonexistent]]', { title: 'Has Broken Link', kind: 'reference' });
+    ctx.engine.store('See [[9999999999999999-nonexistent]]', { tags: ['project:test-project'], title: 'Has Broken Link', kind: 'reference' });
 
     const output = await handleMaintain({ action: 'broken-links' }, ctx.engine, ctx.config);
     expect(output).toContain('Broken Wikilinks');
@@ -2518,15 +2548,15 @@ describe('MCP Tool: knowledge-maintain broken-links', () => {
   });
 
   it('should not flag valid wikilinks', async () => {
-    const target = ctx.engine.store('Valid target', { title: 'Target Note', kind: 'reference' });
-    ctx.engine.store(`See [[${target.id}]]`, { title: 'Linker', kind: 'observation' });
+    const target = ctx.engine.store('Valid target', { tags: ['project:test-project'], title: 'Target Note', kind: 'reference' });
+    ctx.engine.store(`See [[${target.id}]]`, { tags: ['project:test-project'], title: 'Linker', kind: 'observation' });
 
     const output = await handleMaintain({ action: 'broken-links' }, ctx.engine, ctx.config);
     expect(output).toContain('No broken wikilinks found');
   });
 
   it('should exclude archived notes from broken link check', async () => {
-    ctx.engine.store('See [[9999999999999999-fake]]', {
+    ctx.engine.store('See [[9999999999999999-fake]]', { tags: ['project:test-project'],
       title: 'Archived With Broken',
       kind: 'reference',
       status: 'archived',
@@ -2537,7 +2567,7 @@ describe('MCP Tool: knowledge-maintain broken-links', () => {
   });
 
   it('should return clean message when no broken links', async () => {
-    ctx.engine.store('No links here', { title: 'Plain Note', kind: 'observation' });
+    ctx.engine.store('No links here', { tags: ['project:test-project'], title: 'Plain Note', kind: 'observation' });
 
     const output = await handleMaintain({ action: 'broken-links' }, ctx.engine, ctx.config);
     expect(output).toContain('No broken wikilinks found');
@@ -2551,18 +2581,18 @@ describe('MCP Tool: knowledge-maintain link-health', () => {
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should return clean message when no issues', async () => {
-    const noteA = ctx.engine.store('Note A content', { title: 'Note A', kind: 'reference' });
-    const noteB = ctx.engine.store(`References [[${noteA.id}]]`, { title: 'Note B', kind: 'reference' });
+    const noteA = ctx.engine.store('Note A content', { tags: ['project:test-project'], title: 'Note A', kind: 'reference' });
+    const noteB = ctx.engine.store(`References [[${noteA.id}]]`, { tags: ['project:test-project'], title: 'Note B', kind: 'reference' });
     // Make bidirectional
-    ctx.engine.store(`Links back to [[${noteB.id}]]`, { title: 'Note A', kind: 'reference', existingId: noteA.id });
+    ctx.engine.store(`Links back to [[${noteB.id}]]`, { tags: ['project:test-project'], title: 'Note A', kind: 'reference', existingId: noteA.id });
 
     const output = await handleMaintain({ action: 'link-health' }, ctx.engine, ctx.config);
     expect(output).toContain('all clear');
   });
 
   it('should detect one-way links', async () => {
-    const target = ctx.engine.store('Target content', { title: 'Target Note', kind: 'reference' });
-    ctx.engine.store(`Links to [[${target.id}]]`, { title: 'Source Note', kind: 'observation' });
+    const target = ctx.engine.store('Target content', { tags: ['project:test-project'], title: 'Target Note', kind: 'reference' });
+    ctx.engine.store(`Links to [[${target.id}]]`, { tags: ['project:test-project'], title: 'Source Note', kind: 'observation' });
 
     const output = await handleMaintain({ action: 'link-health' }, ctx.engine, ctx.config);
     expect(output).toContain('One-Way Links (1)');
@@ -2572,10 +2602,10 @@ describe('MCP Tool: knowledge-maintain link-health', () => {
   });
 
   it('should not flag bidirectional links as one-way', async () => {
-    const noteA = ctx.engine.store('Note A content', { title: 'Note A', kind: 'reference' });
-    const noteB = ctx.engine.store(`Links to [[${noteA.id}]]`, { title: 'Note B', kind: 'reference' });
+    const noteA = ctx.engine.store('Note A content', { tags: ['project:test-project'], title: 'Note A', kind: 'reference' });
+    const noteB = ctx.engine.store(`Links to [[${noteA.id}]]`, { tags: ['project:test-project'], title: 'Note B', kind: 'reference' });
     // Update A to link back to B
-    ctx.engine.store(`Updated to link back [[${noteB.id}]]`, { title: 'Note A', kind: 'reference', existingId: noteA.id });
+    ctx.engine.store(`Updated to link back [[${noteB.id}]]`, { tags: ['project:test-project'], title: 'Note A', kind: 'reference', existingId: noteA.id });
 
     const output = await handleMaintain({ action: 'link-health' }, ctx.engine, ctx.config);
     expect(output).not.toContain('One-Way Links');
@@ -2583,12 +2613,12 @@ describe('MCP Tool: knowledge-maintain link-health', () => {
 
   it('should combine unlinked notes, broken links, and one-way links', async () => {
     // Unlinked
-    ctx.engine.store('Standalone note', { title: 'Lonely Note', kind: 'reference' });
+    ctx.engine.store('Standalone note', { tags: ['project:test-project'], title: 'Lonely Note', kind: 'reference' });
     // Broken link
-    ctx.engine.store('See [[9999999999999999-nonexistent]]', { title: 'Broken Linker', kind: 'reference' });
+    ctx.engine.store('See [[9999999999999999-nonexistent]]', { tags: ['project:test-project'], title: 'Broken Linker', kind: 'reference' });
     // One-way link
-    const target = ctx.engine.store('Target only', { title: 'One Way Target', kind: 'reference' });
-    ctx.engine.store(`See [[${target.id}]]`, { title: 'One Way Source', kind: 'observation' });
+    const target = ctx.engine.store('Target only', { tags: ['project:test-project'], title: 'One Way Target', kind: 'reference' });
+    ctx.engine.store(`See [[${target.id}]]`, { tags: ['project:test-project'], title: 'One Way Source', kind: 'observation' });
 
     const output = await handleMaintain({ action: 'link-health' }, ctx.engine, ctx.config);
     expect(output).toContain('Link Health Report');
@@ -2602,8 +2632,8 @@ describe('MCP Tool: knowledge-maintain link-health', () => {
   });
 
   it('should exclude archived notes from one-way link detection', async () => {
-    const target = ctx.engine.store('Target content', { title: 'Archived Target', kind: 'reference' });
-    ctx.engine.store(`Links to [[${target.id}]]`, { title: 'Active Source', kind: 'observation' });
+    const target = ctx.engine.store('Target content', { tags: ['project:test-project'], title: 'Archived Target', kind: 'reference' });
+    ctx.engine.store(`Links to [[${target.id}]]`, { tags: ['project:test-project'], title: 'Active Source', kind: 'observation' });
     ctx.engine.archive(target.id);
 
     const output = await handleMaintain({ action: 'link-health' }, ctx.engine, ctx.config);
@@ -2611,8 +2641,8 @@ describe('MCP Tool: knowledge-maintain link-health', () => {
   });
 
   it('should show summary counts', async () => {
-    const target = ctx.engine.store('Target content', { title: 'Target', kind: 'reference' });
-    ctx.engine.store(`Links to [[${target.id}]]`, { title: 'Source', kind: 'observation' });
+    const target = ctx.engine.store('Target content', { tags: ['project:test-project'], title: 'Target', kind: 'reference' });
+    ctx.engine.store(`Links to [[${target.id}]]`, { tags: ['project:test-project'], title: 'Source', kind: 'observation' });
 
     const output = await handleMaintain({ action: 'link-health' }, ctx.engine, ctx.config);
     expect(output).toContain('Unlinked: 0');
@@ -2646,7 +2676,7 @@ describe('MCP Tool: knowledge-maintain full with link-health', () => {
 
   it('should run link-health step in full composite', async () => {
     // Create an unlinked note — survives rebuild regardless of file ordering
-    ctx.engine.store('Standalone content', { title: 'Standalone', kind: 'reference' });
+    ctx.engine.store('Standalone content', { tags: ['project:test-project'], title: 'Standalone', kind: 'reference' });
 
     globalThis.fetch = (async () => { throw new Error('offline'); }) as any;
     const output = await handleMaintain({ action: 'full' }, ctx.engine, ctx.config);
@@ -2668,7 +2698,7 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should surface stale fleeting notes older than autoArchiveFleetingDays', async () => {
-    const result = ctx.engine.store('Old fleeting', { title: 'Ancient Note', kind: 'observation' });
+    const result = ctx.engine.store('Old fleeting', { tags: ['project:test-project'], title: 'Ancient Note', kind: 'observation' });
     setCreatedAt(result.id, daysAgo(100));
 
     const output = await handleMaintain({ action: 'review' }, ctx.engine, ctx.config);
@@ -2678,7 +2708,7 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   });
 
   it('should not surface fleeting notes younger than threshold', async () => {
-    const result = ctx.engine.store('Recent fleeting', { title: 'Fresh Note', kind: 'observation' });
+    const result = ctx.engine.store('Recent fleeting', { tags: ['project:test-project'], title: 'Fresh Note', kind: 'observation' });
     setCreatedAt(result.id, daysAgo(30));
 
     const output = await handleMaintain({ action: 'review' }, ctx.engine, ctx.config);
@@ -2686,7 +2716,7 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   });
 
   it('should not duplicate stale notes in the fleeting review section', async () => {
-    const result = ctx.engine.store('Very old note', { title: 'Stale Duplicate Check', kind: 'observation' });
+    const result = ctx.engine.store('Very old note', { tags: ['project:test-project'], title: 'Stale Duplicate Check', kind: 'observation' });
     setCreatedAt(result.id, daysAgo(100));
 
     const output = await handleMaintain({ action: 'review' }, ctx.engine, ctx.config);
@@ -2702,7 +2732,7 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   });
 
   it('should surface old unaccessed permanent notes as review candidates', async () => {
-    const result = ctx.engine.store('Old permanent', { title: 'Old Perm', kind: 'reference', status: 'permanent' });
+    const result = ctx.engine.store('Old permanent', { tags: ['project:test-project'], title: 'Old Perm', kind: 'reference', status: 'permanent' });
     setCreatedAt(result.id, daysAgo(200));
 
     const output = await handleMaintain({ action: 'review' }, ctx.engine, ctx.config);
@@ -2711,7 +2741,7 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   });
 
   it('should not surface archived notes', async () => {
-    const result = ctx.engine.store('Old archived', { title: 'Already Archived', kind: 'observation', status: 'archived' });
+    const result = ctx.engine.store('Old archived', { tags: ['project:test-project'], title: 'Already Archived', kind: 'observation', status: 'archived' });
     setCreatedAt(result.id, daysAgo(200));
 
     const output = await handleMaintain({ action: 'review' }, ctx.engine, ctx.config);
@@ -2719,7 +2749,7 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   });
 
   it('should not flag recently accessed notes as stale even if created long ago', async () => {
-    const result = ctx.engine.store('Old but active', { title: 'Recently Accessed', kind: 'observation' });
+    const result = ctx.engine.store('Old but active', { tags: ['project:test-project'], title: 'Recently Accessed', kind: 'observation' });
     setCreatedAt(result.id, daysAgo(200));
     const recentAccess = Date.now() - (2 * 24 * 60 * 60 * 1000);
     (ctx.engine as any).db.prepare('UPDATE notes SET last_accessed_at = ? WHERE id = ?').run(recentAccess, result.id);
@@ -2729,7 +2759,7 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   });
 
   it('should respect custom autoArchiveFleetingDays config', async () => {
-    const result = ctx.engine.store('Borderline fleeting', { title: 'Borderline', kind: 'observation' });
+    const result = ctx.engine.store('Borderline fleeting', { tags: ['project:test-project'], title: 'Borderline', kind: 'observation' });
     setCreatedAt(result.id, daysAgo(45));
 
     const customConfig = { ...ctx.config, lifecycle: { ...ctx.config.lifecycle, autoArchiveFleetingDays: 30 } };
@@ -2739,7 +2769,7 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   });
 
   it('should not flag note just under the threshold', async () => {
-    const result = ctx.engine.store('Boundary note', { title: 'Just Under 90', kind: 'observation' });
+    const result = ctx.engine.store('Boundary note', { tags: ['project:test-project'], title: 'Just Under 90', kind: 'observation' });
     setCreatedAt(result.id, daysAgo(89));
 
     const output = await handleMaintain({ action: 'review' }, ctx.engine, ctx.config);
@@ -2747,7 +2777,7 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   });
 
   it('should flag note just over the threshold', async () => {
-    const result = ctx.engine.store('Over boundary', { title: 'Just Over 90', kind: 'observation' });
+    const result = ctx.engine.store('Over boundary', { tags: ['project:test-project'], title: 'Just Over 90', kind: 'observation' });
     setCreatedAt(result.id, daysAgo(91));
 
     const output = await handleMaintain({ action: 'review' }, ctx.engine, ctx.config);
@@ -2756,7 +2786,7 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   });
 
   it('should guard against zero autoArchiveFleetingDays config', async () => {
-    ctx.engine.store('Fresh note', { title: 'Should Not Be Stale', kind: 'observation' });
+    ctx.engine.store('Fresh note', { tags: ['project:test-project'], title: 'Should Not Be Stale', kind: 'observation' });
 
     const zeroConfig = { ...ctx.config, lifecycle: { ...ctx.config.lifecycle, autoArchiveFleetingDays: 0 } };
     const output = await handleMaintain({ action: 'review' }, ctx.engine, zeroConfig);
@@ -2764,7 +2794,7 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   });
 
   it('should guard against negative autoArchiveFleetingDays config', async () => {
-    ctx.engine.store('Fresh note', { title: 'Not Stale Either', kind: 'observation' });
+    ctx.engine.store('Fresh note', { tags: ['project:test-project'], title: 'Not Stale Either', kind: 'observation' });
 
     const negConfig = { ...ctx.config, lifecycle: { ...ctx.config.lifecycle, autoArchiveFleetingDays: -10 } };
     const output = await handleMaintain({ action: 'review' }, ctx.engine, negConfig);
@@ -2772,8 +2802,8 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   });
 
   it('should handle all fleeting notes being stale', async () => {
-    const r1 = ctx.engine.store('Old one', { title: 'All Stale A', kind: 'observation' });
-    const r2 = ctx.engine.store('Old two', { title: 'All Stale B', kind: 'reference' });
+    const r1 = ctx.engine.store('Old one', { tags: ['project:test-project'], title: 'All Stale A', kind: 'observation' });
+    const r2 = ctx.engine.store('Old two', { tags: ['project:test-project'], title: 'All Stale B', kind: 'reference' });
     setCreatedAt(r1.id, daysAgo(120));
     setCreatedAt(r2.id, daysAgo(100));
 
@@ -2786,8 +2816,8 @@ describe('MCP Tool: knowledge-maintain review (stale fleeting archive)', () => {
   });
 
   it('should separate stale notes from review candidates when mixed ages', async () => {
-    const old = ctx.engine.store('Old note', { title: 'Stale One', kind: 'observation' });
-    const recent = ctx.engine.store('Recent note', { title: 'Review One', kind: 'observation' });
+    const old = ctx.engine.store('Old note', { tags: ['project:test-project'], title: 'Stale One', kind: 'observation' });
+    const recent = ctx.engine.store('Recent note', { tags: ['project:test-project'], title: 'Review One', kind: 'observation' });
     setCreatedAt(old.id, daysAgo(100));
     setCreatedAt(recent.id, daysAgo(20));
 
@@ -2827,8 +2857,8 @@ describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should show backlink signals in review output', async () => {
-    const noteA = ctx.engine.store('Links to another note', { title: 'Source Note', kind: 'observation' });
-    const noteB = ctx.engine.store('Linked note', { title: 'Target Note', kind: 'observation' });
+    const noteA = ctx.engine.store('Links to another note', { tags: ['project:test-project'], title: 'Source Note', kind: 'observation' });
+    const noteB = ctx.engine.store('Linked note', { tags: ['project:test-project'], title: 'Target Note', kind: 'observation' });
     ctx.engine.syncLinks(noteA.id, `[[${noteB.id}|test]]`);
     setCreatedAt(noteA.id, daysAgo(20));
     setCreatedAt(noteB.id, daysAgo(20));
@@ -2840,7 +2870,7 @@ describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
   });
 
   it('should recommend promote when accesses meet the threshold', async () => {
-    const note = ctx.engine.store('Accessed note', { title: 'Promotion Candidate', kind: 'observation' });
+    const note = ctx.engine.store('Accessed note', { tags: ['project:test-project'], title: 'Promotion Candidate', kind: 'observation' });
     setCreatedAt(note.id, daysAgo(50));
     for (let i = 0; i < ctx.config.lifecycle.promotionThreshold; i++) {
       ctx.engine.recordAccess(note.id);
@@ -2853,7 +2883,7 @@ describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
   });
 
   it('should recommend archive for zero-access old unlinked notes', async () => {
-    const note = ctx.engine.store('Stale note', { title: 'Unlinked Archive Candidate', kind: 'observation' });
+    const note = ctx.engine.store('Stale note', { tags: ['project:test-project'], title: 'Unlinked Archive Candidate', kind: 'observation' });
     setCreatedAt(note.id, daysAgo(50));
 
     const output = await handleMaintain({ action: 'review', limit: 10 }, ctx.engine, ctx.config);
@@ -2863,8 +2893,8 @@ describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
   });
 
   it('should recommend review (not archive) when backlinks exist', async () => {
-    const noteA = ctx.engine.store('Source content', { title: 'Backlink Source', kind: 'observation' });
-    const noteB = ctx.engine.store('Target content', { title: 'Backlinked Review Candidate', kind: 'observation' });
+    const noteA = ctx.engine.store('Source content', { tags: ['project:test-project'], title: 'Backlink Source', kind: 'observation' });
+    const noteB = ctx.engine.store('Target content', { tags: ['project:test-project'], title: 'Backlinked Review Candidate', kind: 'observation' });
     ctx.engine.syncLinks(noteA.id, `[[${noteB.id}|test]]`);
     setCreatedAt(noteA.id, daysAgo(10));
     setCreatedAt(noteB.id, daysAgo(50));
@@ -2879,7 +2909,7 @@ describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
   });
 
   it('should recommend review for young notes', async () => {
-    const note = ctx.engine.store('Needs judgment', { title: 'Manual Review Candidate', kind: 'observation' });
+    const note = ctx.engine.store('Needs judgment', { tags: ['project:test-project'], title: 'Manual Review Candidate', kind: 'observation' });
     setCreatedAt(note.id, daysAgo(16));
     ctx.engine.recordAccess(note.id);
 
@@ -2890,8 +2920,8 @@ describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
   });
 
   it('should use numbered candidate format', async () => {
-    const first = ctx.engine.store('First note', { title: 'Numbered One', kind: 'observation' });
-    const second = ctx.engine.store('Second note', { title: 'Numbered Two', kind: 'reference' });
+    const first = ctx.engine.store('First note', { tags: ['project:test-project'], title: 'Numbered One', kind: 'observation' });
+    const second = ctx.engine.store('Second note', { tags: ['project:test-project'], title: 'Numbered Two', kind: 'reference' });
     setCreatedAt(first.id, daysAgo(20));
     setCreatedAt(second.id, daysAgo(20));
 
@@ -2904,7 +2934,7 @@ describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
 
   it('should show oversized signal inline', async () => {
     const content = Array(120).fill('word').join(' ');
-    const note = ctx.engine.store(content, { title: 'Inline Oversized', kind: 'personalization' });
+    const note = ctx.engine.store(content, { tags: ['project:test-project'], title: 'Inline Oversized', kind: 'personalization' });
     setCreatedAt(note.id, daysAgo(20));
 
     const customConfig = { ...ctx.config, lifecycle: { ...ctx.config.lifecycle, exemptKinds: [] } };
@@ -2915,8 +2945,8 @@ describe('MCP Tool: knowledge-maintain review (enhanced curation)', () => {
   });
 
   it('should combine fleeting and permanent candidates in one numbered list', async () => {
-    const fleeting = ctx.engine.store('Fleeting content', { title: 'Combined Fleeting', kind: 'observation' });
-    const permanent = ctx.engine.store('Permanent content', { title: 'Combined Permanent', kind: 'reference', status: 'permanent' });
+    const fleeting = ctx.engine.store('Fleeting content', { tags: ['project:test-project'], title: 'Combined Fleeting', kind: 'observation' });
+    const permanent = ctx.engine.store('Permanent content', { tags: ['project:test-project'], title: 'Combined Permanent', kind: 'reference', status: 'permanent' });
     setCreatedAt(fleeting.id, daysAgo(20));
     setCreatedAt(permanent.id, daysAgo(20));
 
@@ -2936,6 +2966,7 @@ describe('MCP Tool: lifecycle field', () => {
 
   it('should default lifecycle based on kind', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'A Decision',
       content: 'We chose X',
       kind: 'decision',
@@ -2949,6 +2980,7 @@ describe('MCP Tool: lifecycle field', () => {
 
   it('should default to living for personalization', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Dark Mode',
       content: 'I prefer dark mode',
       kind: 'personalization',
@@ -2962,6 +2994,7 @@ describe('MCP Tool: lifecycle field', () => {
 
   it('should accept explicit lifecycle override', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Living Decision',
       content: 'An evolving decision',
       kind: 'decision',
@@ -2976,6 +3009,7 @@ describe('MCP Tool: lifecycle field', () => {
 
   it('should auto-detect snapshot from date in title', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Analysis 2025-04-25',
       content: 'Point-in-time analysis',
       kind: 'observation',
@@ -2989,6 +3023,7 @@ describe('MCP Tool: lifecycle field', () => {
 
   it('should not auto-detect snapshot when explicit lifecycle given', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Log 2025-04-25',
       content: 'Append-only log',
       kind: 'observation',
@@ -3002,7 +3037,7 @@ describe('MCP Tool: lifecycle field', () => {
   });
 
   it('should reject updates to snapshot notes', () => {
-    const result = ctx.engine.store('Immutable content', {
+    const result = ctx.engine.store('Immutable content', { tags: ['project:test-project'],
       title: 'Frozen Decision',
       kind: 'decision',
       lifecycle: 'snapshot',
@@ -3011,7 +3046,7 @@ describe('MCP Tool: lifecycle field', () => {
     });
 
     expect(() => {
-      ctx.engine.store('Changed content', {
+      ctx.engine.store('Changed content', { tags: ['project:test-project'],
         title: 'Frozen Decision',
         kind: 'decision',
         existingId: result.id,
@@ -3020,7 +3055,7 @@ describe('MCP Tool: lifecycle field', () => {
   });
 
   it('should reject non-extending updates to append-only notes', () => {
-    const result = ctx.engine.store('Entry 1: started project', {
+    const result = ctx.engine.store('Entry 1: started project', { tags: ['project:test-project'],
       title: 'Ops Log',
       kind: 'observation',
       lifecycle: 'append-only',
@@ -3029,7 +3064,7 @@ describe('MCP Tool: lifecycle field', () => {
     });
 
     expect(() => {
-      ctx.engine.store('Completely different content', {
+      ctx.engine.store('Completely different content', { tags: ['project:test-project'],
         title: 'Ops Log',
         kind: 'observation',
         existingId: result.id,
@@ -3038,7 +3073,7 @@ describe('MCP Tool: lifecycle field', () => {
   });
 
   it('should allow extending append-only notes', () => {
-    const result = ctx.engine.store('Entry 1: started', {
+    const result = ctx.engine.store('Entry 1: started', { tags: ['project:test-project'],
       title: 'Ops Log',
       kind: 'observation',
       lifecycle: 'append-only',
@@ -3046,7 +3081,7 @@ describe('MCP Tool: lifecycle field', () => {
       guidance: 'Append only',
     });
 
-    const updated = ctx.engine.store('Entry 1: started\nEntry 2: continued', {
+    const updated = ctx.engine.store('Entry 1: started\nEntry 2: continued', { tags: ['project:test-project'],
       title: 'Ops Log',
       kind: 'observation',
       existingId: result.id,
@@ -3057,6 +3092,7 @@ describe('MCP Tool: lifecycle field', () => {
 
   it('should persist lifecycle in frontmatter', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Snapshot Note',
       content: 'Frozen content',
       kind: 'decision',
@@ -3076,6 +3112,7 @@ describe('MCP Tool: lifecycle field', () => {
 
   it('should persist lifecycle in DB and read back', async () => {
     await handleStore({
+      project: 'test-project',
       title: 'Append Log',
       content: 'Log entry',
       kind: 'observation',
@@ -3095,6 +3132,7 @@ describe('MCP Tool: lifecycle field', () => {
       lifecycleDefaults: { ...ctx.config.lifecycleDefaults, detectSnapshotFromSlug: false },
     };
     const output = await handleStore({
+      project: 'test-project',
       title: 'Procedure 2025-04-25',
       content: 'Dated procedure',
       kind: 'procedure',
@@ -3108,6 +3146,7 @@ describe('MCP Tool: lifecycle field', () => {
 
   it('should slug-detect snapshot for kind that defaults to living', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Procedure 2025-04-25',
       content: 'Dated procedure',
       kind: 'procedure',
@@ -3121,6 +3160,7 @@ describe('MCP Tool: lifecycle field', () => {
 
   it('should fall back to kind default for invalid lifecycle value', async () => {
     const output = await handleStore({
+      project: 'test-project',
       title: 'Bad Lifecycle',
       content: 'Invalid lifecycle value',
       kind: 'decision',
@@ -3135,6 +3175,7 @@ describe('MCP Tool: lifecycle field', () => {
 
   it('should filter search results by lifecycle', async () => {
     await handleStore({
+      project: 'test-project',
       title: 'Living Reference',
       content: 'A living reference note about search',
       kind: 'reference',
@@ -3144,6 +3185,7 @@ describe('MCP Tool: lifecycle field', () => {
     }, ctx.engine, null, ctx.config);
 
     await handleStore({
+      project: 'test-project',
       title: 'Snapshot Reference',
       content: 'A snapshot reference note about search',
       kind: 'reference',
@@ -3152,8 +3194,8 @@ describe('MCP Tool: lifecycle field', () => {
       guidance: 'Frozen',
     }, ctx.engine, null, ctx.config);
 
-    const living = handleSearch({ query: 'reference note search', lifecycle: 'living' }, ctx.engine);
-    const snapshot = handleSearch({ query: 'reference note search', lifecycle: 'snapshot' }, ctx.engine);
+    const living = handleSearch({ project: 'test-project', query: 'reference note search', lifecycle: 'living' }, ctx.engine);
+    const snapshot = handleSearch({ project: 'test-project', query: 'reference note search', lifecycle: 'snapshot' }, ctx.engine);
 
     expect(living).toContain('Living ref');
     expect(living).not.toContain('Snapshot ref');
@@ -3162,13 +3204,13 @@ describe('MCP Tool: lifecycle field', () => {
   });
 
   it('should allow updating living notes freely', () => {
-    const result = ctx.engine.store('Original content', {
+    const result = ctx.engine.store('Original content', { tags: ['project:test-project'],
       title: 'Mutable Note',
       kind: 'procedure',
       lifecycle: 'living',
     });
 
-    const updated = ctx.engine.store('Completely rewritten content', {
+    const updated = ctx.engine.store('Completely rewritten content', { tags: ['project:test-project'],
       title: 'Mutable Note',
       kind: 'procedure',
       existingId: result.id,
@@ -3178,13 +3220,13 @@ describe('MCP Tool: lifecycle field', () => {
   });
 
   it('should normalize trailing whitespace in append-only validation', () => {
-    const result = ctx.engine.store('Entry 1\n', {
+    const result = ctx.engine.store('Entry 1\n', { tags: ['project:test-project'],
       title: 'Whitespace Log',
       kind: 'observation',
       lifecycle: 'append-only',
     });
 
-    const updated = ctx.engine.store('Entry 1\nEntry 2', {
+    const updated = ctx.engine.store('Entry 1\nEntry 2', { tags: ['project:test-project'],
       title: 'Whitespace Log',
       kind: 'observation',
       existingId: result.id,
@@ -3194,27 +3236,28 @@ describe('MCP Tool: lifecycle field', () => {
   });
 
   it('should include note title and ID in LifecycleViolationError', () => {
-    const result = ctx.engine.store('Frozen', {
+    const result = ctx.engine.store('Frozen', { tags: ['project:test-project'],
       title: 'My Snapshot',
       kind: 'decision',
       lifecycle: 'snapshot',
     });
 
     expect(() =>
-      ctx.engine.store('Changed', { title: 'My Snapshot', kind: 'decision', existingId: result.id }),
+      ctx.engine.store('Changed', { tags: ['project:test-project'], title: 'My Snapshot', kind: 'decision', existingId: result.id }),
     ).toThrow(LifecycleViolationError);
 
     expect(() =>
-      ctx.engine.store('Changed', { title: 'My Snapshot', kind: 'decision', existingId: result.id }),
+      ctx.engine.store('Changed', { tags: ['project:test-project'], title: 'My Snapshot', kind: 'decision', existingId: result.id }),
     ).toThrow(/My Snapshot/);
 
     expect(() =>
-      ctx.engine.store('Changed', { title: 'My Snapshot', kind: 'decision', existingId: result.id }),
+      ctx.engine.store('Changed', { tags: ['project:test-project'], title: 'My Snapshot', kind: 'decision', existingId: result.id }),
     ).toThrow(new RegExp(result.id));
   });
 
   it('should render lifecycle attribute in XML only for non-living notes', async () => {
     await handleStore({
+      project: 'test-project',
       title: 'Snapshot for Render',
       content: 'Frozen for rendering test',
       kind: 'decision',
@@ -3224,6 +3267,7 @@ describe('MCP Tool: lifecycle field', () => {
     }, ctx.engine, null, ctx.config);
 
     await handleStore({
+      project: 'test-project',
       title: 'Living for Render',
       content: 'Living for rendering test',
       kind: 'procedure',
@@ -3246,13 +3290,13 @@ describe('MCP Tool: lifecycle field', () => {
   });
 
   it('should preserve append-only lifecycle on update without explicit lifecycle param', () => {
-    const result = ctx.engine.store('Entry 1', {
+    const result = ctx.engine.store('Entry 1', { tags: ['project:test-project'],
       title: 'Preserved Log',
       kind: 'observation',
       lifecycle: 'append-only',
     });
 
-    ctx.engine.store('Entry 1\nEntry 2', {
+    ctx.engine.store('Entry 1\nEntry 2', { tags: ['project:test-project'],
       title: 'Preserved Log',
       kind: 'observation',
       existingId: result.id,
@@ -3263,7 +3307,7 @@ describe('MCP Tool: lifecycle field', () => {
     expect(note!.lifecycle).toBe('append-only');
 
     expect(() =>
-      ctx.engine.store('Completely rewritten', {
+      ctx.engine.store('Completely rewritten', { tags: ['project:test-project'],
         title: 'Preserved Log',
         kind: 'observation',
         existingId: result.id,
@@ -3273,6 +3317,7 @@ describe('MCP Tool: lifecycle field', () => {
 
   it('should preserve lifecycle through rebuildFromFiles', async () => {
     await handleStore({
+      project: 'test-project',
       title: 'Rebuild Test Note',
       content: 'Content for rebuild lifecycle test',
       kind: 'observation',
@@ -3336,7 +3381,7 @@ describe('Domain note kind', () => {
       guidance: 'Always provide a project',
     }, ctx.engine, null, ctx.config);
 
-    expect(output).toContain('require a project');
+    expect(output).toContain('A valid project is required');
   });
 
   it('should reject duplicate domain note for same project', async () => {
@@ -3478,7 +3523,7 @@ describe('Domain note kind', () => {
     }, ctx.engine, null, ctx.config);
 
     const config = { ...getConfig(), search: { alwaysIncludeDomainNote: true } };
-    const output = handleSearch({ query: 'totally-unrelated-query' }, ctx.engine, null, config);
+    const output = handleSearch({ project: 'test-project', query: 'totally-unrelated-query' }, ctx.engine, null, config);
 
     expect(output).toBe('No matching notes found. Try broader keywords or remove filters.');
   });
@@ -3577,7 +3622,7 @@ describe('Index and log note kinds', () => {
     project: string = 'myapp',
     config = makeConfig(),
     kind: 'observation' | 'domain' = 'observation',
-   ) => await handleStore({
+  ) => await handleStore({
     title,
     content: `${title} content for ${project}`,
     kind,
@@ -3600,7 +3645,7 @@ describe('Index and log note kinds', () => {
     expect(indexNote!.kind).toBe('index');
   });
 
-  it('should reject traversal in a raw project argument before navigation', async () => {
+  it('should fail closed for traversal in a raw project argument', async () => {
     const project = '../../etc';
     const outsidePath = path.resolve(ctx.tempDir, 'projects', project);
 
@@ -3613,7 +3658,7 @@ describe('Index and log note kinds', () => {
       guidance: 'Reject invalid project paths.',
     }, ctx.engine, null, makeConfig());
 
-    expect(output).toBe(`Error: Invalid project name: "${project}"`);
+    expect(output).toBe('Error: A valid project is required for routine knowledge storage.');
     expect(ctx.engine.getByKind('observation')).toHaveLength(0);
     expect(fs.existsSync(outsidePath)).toBe(false);
   });
@@ -3630,14 +3675,14 @@ describe('Index and log note kinds', () => {
   it('should exclude index notes from default search results', async () => {
     await storeProjectNote('Index Search Hidden');
 
-    const output = handleSearch({ query: 'Index Search Hidden' }, ctx.engine, null, makeConfig());
+    const output = handleSearch({ project: 'test-project', query: 'Index Search Hidden' }, ctx.engine, null, makeConfig());
     expect(output).not.toContain('myapp Index');
   });
 
   it('should return index notes when explicitly filtered by kind', async () => {
     await storeProjectNote('Index Search Visible');
 
-    const output = handleSearch({ query: 'myapp', kind: 'index' }, ctx.engine, null, makeConfig());
+    const output = handleSearch({ project: 'myapp', query: 'myapp', kind: 'index' }, ctx.engine, null, makeConfig());
     expect(output).toContain('# Myapp');
   });
 
@@ -3696,14 +3741,14 @@ describe('Index and log note kinds', () => {
   it('should exclude log notes from default search results', async () => {
     await storeProjectNote('Log Search Hidden');
 
-    const output = handleSearch({ query: 'Log Search Hidden' }, ctx.engine, null, makeConfig());
+    const output = handleSearch({ project: 'test-project', query: 'Log Search Hidden' }, ctx.engine, null, makeConfig());
     expect(output).not.toContain('Operations Log');
   });
 
   it('should return log notes when explicitly filtered by kind', async () => {
     await storeProjectNote('Log Search Visible');
 
-    const output = handleSearch({ query: 'Log Search Visible', kind: 'log' }, ctx.engine, null, makeConfig());
+    const output = handleSearch({ project: 'myapp', query: 'Log Search Visible', kind: 'log' }, ctx.engine, null, makeConfig());
     expect(output).toContain('# Myapp Operations Log');
   });
 
@@ -3760,6 +3805,7 @@ describe('Index and log note kinds', () => {
 
   it('should reject manual creation of structural kinds', async () => {
     const indexOutput = await handleStore({
+      project: 'test-project',
       title: 'Manual Index',
       content: 'Should fail',
       kind: 'index',
@@ -3768,6 +3814,7 @@ describe('Index and log note kinds', () => {
     }, ctx.engine, null, makeConfig());
 
     const logOutput = await handleStore({
+      project: 'test-project',
       title: 'Manual Log',
       content: 'Should fail',
       kind: 'log',
@@ -3836,7 +3883,7 @@ describe('Index and log note kinds', () => {
     const config = makeConfig({ search: { excludeLogFromSearch: false } });
     await storeProjectNote('Structural Search Visible', 'myapp', config);
 
-    const output = handleSearch({ query: 'Structural Search Visible' }, ctx.engine, null, config);
+    const output = handleSearch({ project: 'myapp', query: 'Structural Search Visible' }, ctx.engine, null, config);
     expect(output).toContain('Structural Search Visible');
     expect(output).toContain('Myapp Operations Log');
   });
@@ -3923,6 +3970,7 @@ describe('MCP Tool: knowledge-mine protocol surface', () => {
       const mineResult = await client.callTool({
         name: 'knowledge-mine',
         arguments: {
+          project: 'candidate-only',
           dry_run: false,
           candidates: [{
             title: 'Candidate Scoped Domain',
@@ -3968,7 +4016,7 @@ describe('MCP Tool: compact preference capsule', () => {
       title,
       kind: 'personalization',
       status,
-      tags,
+      tags: tags.some(tag => tag.startsWith('project:')) ? tags : ['scope:global', ...tags],
       summary: `${title} summary`,
       guidance,
     });
@@ -4016,13 +4064,14 @@ describe('MCP Tool: compact preference capsule', () => {
 
   it('orders same-day rebuilt preferences by newest ID', () => {
     const older = ctx.engine.store({
+      tags: ['scope:global'],
       title: 'Older rebuilt preference',
       kind: 'personalization',
       status: 'permanent',
       summary: 'Older rebuilt preference summary',
       guidance: 'Use the older rebuilt preference.',
     });
-    const newer = ctx.engine.store({
+    const newer = ctx.engine.store({ tags: ['scope:global'],
       title: 'Newer rebuilt preference',
       kind: 'personalization',
       status: 'permanent',
@@ -4067,6 +4116,7 @@ describe('MCP Tool: compact preference capsule', () => {
     try {
       for (let index = 0; index < 10; index++) {
         longContext.engine.store(`Long ${index}`, {
+          tags: ['scope:global'],
           title: `Long ${index}`,
           kind: 'personalization',
           status: 'permanent',
@@ -4127,10 +4177,10 @@ describe('MCP Tool: knowledge-health', () => {
   afterEach(() => { cleanupTestHarness(ctx); });
 
   it('should return health indicators and staleness', async () => {
-    ctx.engine.store('Note A', { title: 'A', kind: 'reference' });
-    ctx.engine.store('Note B', { title: 'B', kind: 'decision', status: 'permanent' });
+    ctx.engine.store('Note A', { tags: ['project:test-project'], title: 'A', kind: 'reference' });
+    ctx.engine.store('Note B', { tags: ['project:test-project'], title: 'B', kind: 'decision', status: 'permanent' });
 
-    const output = await handleHealth({}, ctx.engine, ctx.config);
+    const output = await handleHealth({ project: 'test-project',}, ctx.engine, ctx.config);
     expect(output).toContain('# Knowledge Base Stats');
     expect(output).toContain('## Health (2 notes)');
     expect(output).toContain('Fleeting: 1');
@@ -4140,23 +4190,23 @@ describe('MCP Tool: knowledge-health', () => {
   });
 
   it('should include growth rate section with period', async () => {
-    ctx.engine.store('Recent note', { title: 'Recent', kind: 'observation' });
+    ctx.engine.store('Recent note', { tags: ['project:test-project'], title: 'Recent', kind: 'observation' });
 
-    const output = await handleHealth({ period: '7d' }, ctx.engine, ctx.config);
+    const output = await handleHealth({ project: 'test-project', period: '7d' }, ctx.engine, ctx.config);
     expect(output).toContain('## Growth (last 7d)');
     expect(output).toContain('Notes created: 1');
     expect(output).toContain('observation: 1');
   });
 
   it('should default period to 30d', async () => {
-    const output = await handleHealth({}, ctx.engine, ctx.config);
+    const output = await handleHealth({ project: 'test-project',}, ctx.engine, ctx.config);
     expect(output).toContain('## Growth (last 30d)');
   });
 
   it('should include link health section', async () => {
-    ctx.engine.store('Standalone', { title: 'Orphan', kind: 'reference' });
+    ctx.engine.store('Standalone', { tags: ['project:test-project'], title: 'Orphan', kind: 'reference' });
 
-    const output = await handleHealth({}, ctx.engine, ctx.config);
+    const output = await handleHealth({ project: 'test-project',}, ctx.engine, ctx.config);
     expect(output).toContain('## Link Health');
     expect(output).toContain('1 unlinked');
   });
@@ -4185,59 +4235,57 @@ describe('MCP Tool: knowledge-health', () => {
   });
 
   it('should clamp 0d period to 30d default', async () => {
-    ctx.engine.store('A note', { title: 'A', kind: 'reference' });
+    ctx.engine.store('A note', { tags: ['project:test-project'], title: 'A', kind: 'reference' });
 
-    const output = await handleHealth({ period: '0d' }, ctx.engine, ctx.config);
+    const output = await handleHealth({ project: 'test-project', period: '0d' }, ctx.engine, ctx.config);
     expect(output).toContain('## Growth (last 30d)');
     expect(output).not.toContain('Infinity');
   });
   it('should scope link health to project when project specified', async () => {
     ctx.engine.store('Alpha note', { title: 'Alpha', kind: 'reference', tags: ['project:alpha'] });
     ctx.engine.store('Beta standalone', { title: 'Beta', kind: 'reference', tags: ['project:beta'] });
-    ctx.engine.store('Global standalone', { title: 'Global', kind: 'reference' });
+    ctx.engine.store('Global standalone', { tags: ['project:test-project'], title: 'Global', kind: 'reference' });
 
     // Alpha has one note with no links — should show 1 unlinked when scoped to alpha
     const alphaOutput = await handleHealth({ project: 'alpha' }, ctx.engine, ctx.config);
     expect(alphaOutput).toContain('## Link Health');
     expect(alphaOutput).toContain('1 unlinked');
 
-    // Global stats should show 3 unlinked (alpha + beta + global)
+    // Calls without a current project fail closed.
     const globalOutput = await handleHealth({}, ctx.engine, ctx.config);
-    expect(globalOutput).toContain('3 unlinked');
+    expect(globalOutput).toBe('Error: A valid project is required for knowledge health metrics.');
   });
 });
 
-describe('MCP Tool: knowledge-context global', () => {
+describe('MCP Tool: knowledge-context without project', () => {
   let ctx: TestContext;
 
   beforeEach(() => { ctx = createTestHarness(); });
   afterEach(() => { cleanupTestHarness(ctx); });
 
-  it('should return global overview when no project specified', async () => {
+  it('should fail closed when no project is specified', async () => {
     await handleStore({
       title: 'Proj Note', content: 'Stuff', kind: 'reference',
       summary: 'Sum', guidance: 'Guide', tags: ['project:alpha'],
     }, ctx.engine, null, ctx.config);
     await handleStore({
+      project: 'test-project',
       title: 'Loose Note', content: 'Unscoped stuff', kind: 'observation',
       summary: 'Sum', guidance: 'Guide',
     }, ctx.engine, null, ctx.config);
 
     const output = handleContext({}, ctx.engine, ctx.config);
-    expect(output).toContain('## Knowledge Base Overview');
-    expect(output).toContain('### Projects');
-    expect(output).toContain('**alpha**');
-    expect(output).toContain('### Inventory');
-    expect(output).toContain('### Recent Notes');
+    expect(output).toBe('Error: A valid project is required for knowledge context.');
   });
 
-  it('should show unscoped note count', async () => {
+  it('should not expose unscoped note counts without a project', async () => {
     await handleStore({
+      project: 'test-project',
       title: 'Unscoped', content: 'Content', kind: 'reference',
       summary: 'Sum', guidance: 'Guide',
     }, ctx.engine, null, ctx.config);
 
     const output = handleContext({}, ctx.engine, ctx.config);
-    expect(output).toContain('Unscoped notes:');
+    expect(output).toBe('Error: A valid project is required for knowledge context.');
   });
 });

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -1889,6 +1889,37 @@ describe('MCP Tool: knowledge-store (client filtering)', () => {
     expect(notes[0].tags).toContain('client:opencode');
   });
 
+  it('should use an auto-detected client for explicit and suggested related-note visibility', async () => {
+    const cursor = ctx.engine.store('Private routing details.', {
+      title: 'Cursor Private Routing', kind: 'reference', status: 'permanent',
+      tags: ['project:test-project', 'client:cursor'],
+      summary: 'Private routing configuration', guidance: 'Keep private to Cursor.',
+    });
+
+    const explicit = await handleStore({
+      project: 'test-project',
+      title: 'Pi Explicit Relation',
+      content: 'Configure .pi/settings.json for this workflow.',
+      kind: 'reference',
+      summary: 'Pi explicit relation test',
+      guidance: 'Use .pi/settings.json.',
+      related: [cursor.id],
+    }, ctx.engine, null, ctx.config);
+    expect(explicit).toContain('not found or not visible');
+
+    const suggested = await handleStore({
+      project: 'test-project',
+      title: 'Private Routing Probe',
+      content: 'Configure .pi/settings.json with private routing.',
+      kind: 'reference',
+      summary: 'Private routing configuration',
+      guidance: 'Use .pi/settings.json.',
+    }, ctx.engine, null, ctx.config);
+    expect(suggested).not.toContain('Cursor Private Routing');
+    expect(ctx.engine.getByKind('reference').find(note => note.title === 'Private Routing Probe')?.tags)
+      .toContain('client:pi');
+  });
+
   it('should auto-detect client from .claude/ in guidance', async () => {
     await handleStore({
       project: 'test-project',

--- a/tests/mine.test.ts
+++ b/tests/mine.test.ts
@@ -28,7 +28,7 @@ describe('knowledge-mine: validation', () => {
   });
 
   it('empty candidates array', async () => {
-    const output = await handleMine({ candidates: [] }, ctx.engine, null, ctx.config);
+    const output = await handleMine({ project: 'test-project', candidates: [] }, ctx.engine, null, ctx.config);
 
     expect(output).toContain('No mining candidates provided');
     expect(output).toContain('at least one candidate');
@@ -38,54 +38,53 @@ describe('knowledge-mine: validation', () => {
   it('over 50 candidates', async () => {
     const candidates = Array.from({ length: 51 }, (_, index) => makeCandidate({ title: `Candidate ${index}` }));
 
-    const output = await handleMine({ candidates }, ctx.engine, null, ctx.config);
+    const output = await handleMine({ project: 'test-project', candidates }, ctx.engine, null, ctx.config);
 
     expect(output).toContain('Error: knowledge-mine accepts at most 50 candidates per batch');
     expect(output).toContain('received 51');
   });
 
   it('missing required field (title)', async () => {
-    const output = await handleMine({ candidates: [makeCandidate({ title: '' })] }, ctx.engine, null, ctx.config);
+    const output = await handleMine({ project: 'test-project', candidates: [makeCandidate({ title: '' })] }, ctx.engine, null, ctx.config);
 
     expect(output).toContain('Error: Candidate 1');
     expect(output).toContain('missing required field "title"');
   });
 
   it('missing required field (summary)', async () => {
-    const output = await handleMine({ candidates: [makeCandidate({ summary: '   ' })] }, ctx.engine, null, ctx.config);
+    const output = await handleMine({ project: 'test-project', candidates: [makeCandidate({ summary: '   ' })] }, ctx.engine, null, ctx.config);
 
     expect(output).toContain('Error: Candidate 1');
     expect(output).toContain('missing required field "summary"');
   });
 
   it('structural kind (index)', async () => {
-    const output = await handleMine({ candidates: [makeCandidate({ kind: 'index' })] }, ctx.engine, null, ctx.config);
+    const output = await handleMine({ project: 'test-project', candidates: [makeCandidate({ kind: 'index' })] }, ctx.engine, null, ctx.config);
 
     expect(output).toContain('Error: Candidate 1');
     expect(output).toContain('index notes are structural and auto-generated');
   });
 
   it('structural kind (log)', async () => {
-    const output = await handleMine({ candidates: [makeCandidate({ kind: 'log' })] }, ctx.engine, null, ctx.config);
+    const output = await handleMine({ project: 'test-project', candidates: [makeCandidate({ kind: 'log' })] }, ctx.engine, null, ctx.config);
 
     expect(output).toContain('Error: Candidate 1');
     expect(output).toContain('log notes are structural and auto-generated');
   });
 
-  it('domain kind without project', async () => {
-    const output = await handleMine({ candidates: [makeCandidate({ kind: 'domain' })] }, ctx.engine, null, ctx.config);
-
-    expect(output).toContain('Error: Candidate 1');
-    expect(output).toContain('domain notes require a project parameter');
-  });
-
-  it('domain kind accepts per-candidate project', async () => {
-    const output = await handleMine({
-      candidates: [makeCandidate({ kind: 'domain', project: 'alpha' })],
-    }, ctx.engine, null, ctx.config);
+  it('domain kind uses the current project', async () => {
+    const output = await handleMine({ project: 'test-project', candidates: [makeCandidate({ kind: 'domain' })] }, ctx.engine, null, ctx.config);
 
     expect(output).not.toContain('Error:');
     expect(output).toContain('⮕ STORE');
+  });
+
+  it('domain kind rejects a conflicting candidate project', async () => {
+    const output = await handleMine({ project: 'test-project',
+      candidates: [makeCandidate({ kind: 'domain', project: 'alpha' })],
+    }, ctx.engine, null, ctx.config);
+
+    expect(output).toContain('candidate project conflicts with project:test-project');
   });
 });
 
@@ -101,7 +100,7 @@ describe('knowledge-mine: dry-run classification', () => {
   });
 
   it('single candidate, empty KB', async () => {
-    const output = await handleMine({ candidates: [makeCandidate()] }, ctx.engine, null, ctx.config);
+    const output = await handleMine({ project: 'test-project', candidates: [makeCandidate()] }, ctx.engine, null, ctx.config);
 
     expect(output).toContain('⮕ STORE — No similar notes found');
     expect(output).not.toContain('↳ [');
@@ -109,7 +108,7 @@ describe('knowledge-mine: dry-run classification', () => {
   });
 
   it('dry_run defaults to true', async () => {
-    await handleMine({ candidates: [makeCandidate({ title: 'Default Dry Run Note' })] }, ctx.engine, null, ctx.config);
+    await handleMine({ project: 'test-project', candidates: [makeCandidate({ title: 'Default Dry Run Note' })] }, ctx.engine, null, ctx.config);
 
     const stats = ctx.engine.getStats();
     const results = ctx.engine.search('Default Dry Run Note', { limit: 10 });
@@ -119,7 +118,7 @@ describe('knowledge-mine: dry-run classification', () => {
   });
 
   it('candidate matching existing note', async () => {
-    await handleStore({
+    await handleStore({ project: 'test-project',
       title: 'Session Context Capture',
       content: 'Capture durable session context before ending work.',
       kind: 'observation',
@@ -127,7 +126,7 @@ describe('knowledge-mine: dry-run classification', () => {
       guidance: 'Store durable session context before handoff.',
     }, ctx.engine, null, ctx.config);
 
-    const output = await handleMine({
+    const output = await handleMine({ project: 'test-project',
       candidates: [makeCandidate({
         title: 'Session Context Capture',
         content: 'Capture durable session context before ending work with a concise handoff.',
@@ -143,7 +142,7 @@ describe('knowledge-mine: dry-run classification', () => {
   });
 
   it('candidate partially matching existing note', async () => {
-    await handleStore({
+    await handleStore({ project: 'test-project',
       title: 'Release Checklist',
       content: 'Run build, tests, and changelog checks before release.',
       kind: 'procedure',
@@ -151,7 +150,7 @@ describe('knowledge-mine: dry-run classification', () => {
       guidance: 'Use this before publishing releases.',
     }, ctx.engine, null, ctx.config);
 
-    const output = await handleMine({
+    const output = await handleMine({ project: 'test-project',
       candidates: [makeCandidate({
         title: 'Release Checklist Followup',
         content: 'Document deployment rollback ownership after a production incident.',
@@ -167,7 +166,7 @@ describe('knowledge-mine: dry-run classification', () => {
   });
 
   it('intra-batch duplicate', async () => {
-    const output = await handleMine({
+    const output = await handleMine({ project: 'test-project',
       candidates: [
         makeCandidate({
           title: 'Duplicate Candidate A',
@@ -200,7 +199,7 @@ describe('knowledge-mine: store mode', () => {
   });
 
   it('dry_run=false stores STORE candidates', async () => {
-    const output = await handleMine({
+    const output = await handleMine({ project: 'test-project',
       dry_run: false,
       candidates: [makeCandidate({ title: 'Stored Mining Candidate', summary: 'Unique stored mining candidate summary' })],
     }, ctx.engine, null, ctx.config);
@@ -213,7 +212,7 @@ describe('knowledge-mine: store mode', () => {
   });
 
   it('extracts the real stored id when a mined title contains an arrow', async () => {
-    const output = await handleMine({
+    const output = await handleMine({ project: 'test-project',
       dry_run: false,
       candidates: [makeCandidate({ title: 'Cause → Effect Mapping', summary: 'Unique arrow-title mining candidate summary' })],
     }, ctx.engine, null, ctx.config);
@@ -229,7 +228,7 @@ describe('knowledge-mine: store mode', () => {
   });
 
   it('dry_run=false skips SKIP candidates', async () => {
-    await handleStore({
+    await handleStore({ project: 'test-project',
       title: 'Existing Duplicate Seed',
       content: 'Do not duplicate this already captured note.',
       kind: 'observation',
@@ -237,7 +236,7 @@ describe('knowledge-mine: store mode', () => {
       guidance: 'Prefer the existing duplicate seed.',
     }, ctx.engine, null, ctx.config);
 
-    await handleMine({
+    await handleMine({ project: 'test-project',
       dry_run: false,
       candidates: [makeCandidate({
         title: 'New Duplicate Candidate',
@@ -253,7 +252,7 @@ describe('knowledge-mine: store mode', () => {
   });
 
   it('source tag stored as mined:{source}', async () => {
-    await handleMine({
+    await handleMine({ project: 'test-project',
       dry_run: false,
       candidates: [makeCandidate({
         title: 'Mined Source Candidate',
@@ -288,44 +287,18 @@ describe('knowledge-mine: store mode', () => {
     expect(second?.tags).toContain('project:myapp');
   });
 
-  it('per-candidate project overrides support mixed-project batches', async () => {
-    await handleMine({
-      dry_run: false,
+  it('fails closed for mixed-project batches', async () => {
+    const output = await handleMine({
       project: 'fallback',
+      dry_run: false,
       candidates: [
-        makeCandidate({
-          title: 'Alpha Mixed Candidate',
-          summary: 'Unique alpha mixed candidate summary',
-          project: 'alpha',
-        }),
-        makeCandidate({
-          title: 'Beta Mixed Candidate',
-          summary: 'Unique beta mixed candidate summary',
-          project: 'beta',
-        }),
-        makeCandidate({
-          title: 'Gamma Mixed Domain',
-          kind: 'domain',
-          content: 'Gamma project operating context',
-          summary: 'Unique gamma mixed domain summary',
-          guidance: 'Use for gamma project context',
-          project: 'gamma',
-        }),
+        makeCandidate({ title: 'Alpha Mixed Candidate', project: 'alpha' }),
+        makeCandidate({ title: 'Beta Mixed Candidate', project: 'beta' }),
       ],
     }, ctx.engine, null, ctx.config);
 
-    const alpha = ctx.engine.search('Alpha Mixed Candidate', { limit: 10 })
-      .find(result => result.title === 'Alpha Mixed Candidate');
-    const beta = ctx.engine.search('Beta Mixed Candidate', { limit: 10 })
-      .find(result => result.title === 'Beta Mixed Candidate');
-    const gamma = ctx.engine.getDomainNote('gamma');
-
-    expect(alpha?.tags).toContain('project:alpha');
-    expect(alpha?.tags).not.toContain('project:fallback');
-    expect(beta?.tags).toContain('project:beta');
-    expect(beta?.tags).not.toContain('project:fallback');
-    expect(gamma?.tags).toContain('project:gamma');
-    expect(gamma?.tags).not.toContain('project:fallback');
+    expect(output).toContain('candidate project conflicts with project:fallback');
+    expect(ctx.engine.search('Mixed Candidate', { limit: 10 })).toHaveLength(0);
   });
 
   it('commits mined stores through the path-scoped versioning flow', async () => {
@@ -334,7 +307,7 @@ describe('knowledge-mine: store mode', () => {
     await versioning.init();
 
     try {
-      const output = await handleMine({
+      const output = await handleMine({ project: 'test-project',
         dry_run: false,
         candidates: [makeCandidate({
           title: 'Versioned Mining Candidate',
@@ -378,19 +351,19 @@ describe('knowledge-mine: output format', () => {
   });
 
   it('includes summary line with counts', async () => {
-    const output = await handleMine({ candidates: [makeCandidate()] }, ctx.engine, null, ctx.config);
+    const output = await handleMine({ project: 'test-project', candidates: [makeCandidate()] }, ctx.engine, null, ctx.config);
 
     expect(output).toContain('Summary: 1 STORE, 0 SKIP, 0 REVIEW');
   });
 
   it('dry-run shows store instruction', async () => {
-    const output = await handleMine({ candidates: [makeCandidate()] }, ctx.engine, null, ctx.config);
+    const output = await handleMine({ project: 'test-project', candidates: [makeCandidate()] }, ctx.engine, null, ctx.config);
 
     expect(output).toContain('call again with dry_run=false');
   });
 
   it('store mode omits dry-run instruction', async () => {
-    const output = await handleMine({
+    const output = await handleMine({ project: 'test-project',
       dry_run: false,
       candidates: [makeCandidate({ title: 'Instruction Omitted Candidate', summary: 'Instruction omitted candidate summary' })],
     }, ctx.engine, null, ctx.config);
@@ -399,7 +372,7 @@ describe('knowledge-mine: output format', () => {
   });
 
   it('shows embeddings disabled warning when no embedding config', async () => {
-    const output = await handleMine({ candidates: [makeCandidate()] }, ctx.engine, null, ctx.config);
+    const output = await handleMine({ project: 'test-project', candidates: [makeCandidate()] }, ctx.engine, null, ctx.config);
 
     expect(output).toContain('Embeddings disabled');
     expect(output).toContain('SimHash + FTS5 only');
@@ -407,7 +380,7 @@ describe('knowledge-mine: output format', () => {
 
   it('word count warning for oversized notes', async () => {
     const content = Array.from({ length: 401 }, (_, index) => `word${index}`).join(' ');
-    const output = await handleMine({
+    const output = await handleMine({ project: 'test-project',
       candidates: [makeCandidate({
         title: 'Oversized Mining Candidate',
         content,

--- a/tests/mine.test.ts
+++ b/tests/mine.test.ts
@@ -141,6 +141,31 @@ describe('knowledge-mine: dry-run classification', () => {
     expect(output).toContain('Summary: 0 STORE, 1 SKIP, 0 REVIEW');
   });
 
+  it('does not classify against notes hidden from the mining client', async () => {
+    await handleStore({
+      project: 'test-project', client: 'cursor',
+      title: 'Cursor Private Duplicate',
+      content: 'Capture this exact private duplicate phrase for one client.',
+      kind: 'observation',
+      summary: 'Capture this exact private duplicate phrase',
+      guidance: 'Keep this duplicate private to Cursor.',
+    }, ctx.engine, null, ctx.config);
+
+    const candidate = makeCandidate({
+      title: 'Candidate Duplicate Mirror',
+      content: 'Capture this exact private duplicate phrase for one client.',
+      summary: 'Capture this exact private duplicate phrase',
+      guidance: 'Keep this duplicate private to the matching client.',
+    });
+    const hidden = await handleMine({ project: 'test-project', client: 'pi', candidates: [candidate] }, ctx.engine, null, ctx.config);
+    const visible = await handleMine({ project: 'test-project', client: 'cursor', candidates: [candidate] }, ctx.engine, null, ctx.config);
+
+    expect(hidden).not.toContain('"Cursor Private Duplicate"');
+    expect(hidden).not.toContain('⮕ SKIP');
+    expect(visible).toContain('⮕ SKIP');
+    expect(visible).toContain('"Cursor Private Duplicate"');
+  });
+
   it('candidate partially matching existing note', async () => {
     await handleStore({ project: 'test-project',
       title: 'Release Checklist',
@@ -209,6 +234,22 @@ describe('knowledge-mine: store mode', () => {
     expect(output).toContain('⮕ STORE — No similar notes found');
     expect(output).toContain('✅ Stored as');
     expect(results.some(note => note.title === 'Stored Mining Candidate')).toBe(true);
+  });
+
+  it('stores mined notes with the supplied client applicability', async () => {
+    await handleMine({
+      project: 'test-project', client: 'pi', dry_run: false,
+      candidates: [makeCandidate({ title: 'Pi Scoped Mining Note', summary: 'Unique Pi scoped mining note' })],
+    }, ctx.engine, null, ctx.config);
+
+    const stored = ctx.engine.search('Pi Scoped Mining Note', {
+      kind: 'observation', visibility: { project: 'test-project', client: 'pi' },
+    })[0];
+    expect(stored.tags).toContain('project:test-project');
+    expect(stored.tags).toContain('client:pi');
+    expect(ctx.engine.search('Pi Scoped Mining Note', {
+      kind: 'observation', visibility: { project: 'test-project', client: 'cursor' },
+    })).toEqual([]);
   });
 
   it('extracts the real stored id when a mined title contains an arrow', async () => {

--- a/tests/obsidian-scaffold.test.ts
+++ b/tests/obsidian-scaffold.test.ts
@@ -161,14 +161,12 @@ describe('Obsidian scaffold', () => {
     });
 
     const quickAddData = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'plugins', 'quickadd', 'data.json'), 'utf-8'));
-    const nestedChoices = quickAddData.choices[0].choices;
     const projectChoices = quickAddData.choices.filter((choice: { name: string }) => choice.name.startsWith('Project '));
     expect(quickAddData.macros).toBeUndefined();
-    expect(nestedChoices.every((choice: { folder: { folders: string[] } }) => !choice.folder.folders[0].includes('_staging'))).toBe(true);
-    expect(nestedChoices.some((choice: { fileNameFormat: { format: string } }) => choice.fileNameFormat.format === '{{DATE:YYYYMMDDHHmmss}}00-new-note')).toBe(true);
-    expect(nestedChoices.some((choice: { fileNameFormat: { format: string } }) => choice.fileNameFormat.format === 'domain')).toBe(true);
+    expect(quickAddData.choices).toHaveLength(6);
     expect(projectChoices).toHaveLength(6);
     expect(projectChoices.every((choice: { command: boolean; templatePath: string }) => choice.command === false && choice.templatePath.endsWith('-project.md'))).toBe(true);
+    expect(quickAddData.choices.some((choice: { name: string }) => choice.name === 'New Note')).toBe(false);
     expect(quickAddData.choices.filter((choice: { type: string }) => choice.type === 'Macro')).toHaveLength(0);
 
     const templaterData = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'plugins', 'templater-obsidian', 'data.json'), 'utf-8'));

--- a/tests/obsidian-scaffold.test.ts
+++ b/tests/obsidian-scaffold.test.ts
@@ -168,6 +168,22 @@ describe('Obsidian scaffold', () => {
     expect(projectChoices.every((choice: { command: boolean; templatePath: string }) => choice.command === false && choice.templatePath.endsWith('-project.md'))).toBe(true);
     expect(quickAddData.choices.some((choice: { name: string }) => choice.name === 'New Note')).toBe(false);
     expect(quickAddData.choices.filter((choice: { type: string }) => choice.type === 'Macro')).toHaveLength(0);
+    expect(projectChoices.map((choice: { folder: { folders: string[] } }) => choice.folder.folders[0])).toEqual([
+      'projects/{{VALUE:project}}/decisions',
+      'projects/{{VALUE:project}}/observations',
+      'projects/{{VALUE:project}}/procedures',
+      'projects/{{VALUE:project}}/references',
+      'projects/{{VALUE:project}}/resources',
+      'projects/{{VALUE:project}}/preferences',
+    ]);
+
+    const commanderData = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'plugins', 'cmdr', 'data.json'), 'utf-8'));
+    const quickAddChoiceIds = new Set(quickAddData.choices.map((choice: { id: string }) => `quickadd:choice:${choice.id}`));
+    const commanderQuickAddIds = commanderData.leftRibbon
+      .map((button: { id: string }) => button.id)
+      .filter((id: string) => id.startsWith('quickadd:choice:'));
+    expect(commanderQuickAddIds.every((id: string) => quickAddChoiceIds.has(id))).toBe(true);
+    expect(commanderData.leftRibbon).toEqual([]);
 
     const templaterData = JSON.parse(fs.readFileSync(path.join(obsidianDir, 'plugins', 'templater-obsidian', 'data.json'), 'utf-8'));
     expect(templaterData.auto_jump_to_cursor).toBe(true);

--- a/tests/pi-extension.test.ts
+++ b/tests/pi-extension.test.ts
@@ -191,6 +191,16 @@ describe('Pi extension', () => {
       await promptHandler?.({ systemPrompt: 'Base prompt' });
       expect(fs.readFileSync(callsPath, 'utf8').match(/knowledge-context/g)).toHaveLength(5);
 
+      const search = registered.find((candidate) => candidate.name === 'knowledge-search');
+      const searchResult = await search?.execute('search', { query: 'runtime', project: 'wrong-project', client: 'wrong-client' });
+      expect(searchResult?.content[0]?.text).toContain(
+        'called knowledge-search with {"query":"runtime","project":"example-project","client":"pi"}',
+      );
+
+      const maintenance = registered.find((candidate) => candidate.name === 'knowledge-maintain');
+      const maintenanceResult = await maintenance?.execute('maintenance', { action: 'review' });
+      expect(maintenanceResult?.content[0]?.text).toContain('called knowledge-maintain with {"action":"review"}');
+
       const tool = registered.find((candidate) => candidate.name === 'knowledge-template');
       expect(tool).toBeDefined();
       const result = await tool?.execute('tool-call-1', { kind: 'decision' });

--- a/tests/pi-extension.test.ts
+++ b/tests/pi-extension.test.ts
@@ -147,6 +147,14 @@ describe('Pi extension', () => {
       expect(promptHandler).toBeDefined();
 
       expect(preferenceRenderer).toBeDefined();
+      const preSessionSearch = registered.find((candidate) => candidate.name === 'knowledge-search');
+      const preSessionResult = await preSessionSearch?.execute('pre-session', {
+        query: 'runtime', project: 'model-project', client: 'model-client',
+      });
+      expect(preSessionResult?.content[0]?.text).toContain('called knowledge-search with {"query":"runtime","client":"pi"}');
+      expect(preSessionResult?.content[0]?.text).not.toContain('model-project');
+      expect(preSessionResult?.content[0]?.text).not.toContain('model-client');
+
       const sessionManager = { getEntries: () => sessionEntries };
       await sessionStartHandler?.({}, { cwd: '/work/example-project', mode: 'tui', sessionManager });
       expect(appendedEntries).toHaveLength(1);

--- a/tests/pi-personalization.integration.test.ts
+++ b/tests/pi-personalization.integration.test.ts
@@ -32,8 +32,8 @@ describe('Pi personalization scope integration', () => {
     fs.mkdirSync(path.join(configHome, 'open-zk-kb'), { recursive: true });
     fs.mkdirSync(home, { recursive: true });
     fs.writeFileSync(path.join(configHome, 'open-zk-kb', 'config.yaml'), `vault: ${JSON.stringify(vault)}\nembeddings:\n  enabled: false\ntelemetry:\n  enabled: false\n`);
-    fs.writeFileSync(path.join(preferences, '2026030100000001-universal.md'), note('2026030100000001', 'Universal concise answers', 'permanent', ['writing'], 'Keep answers concise.'));
-    fs.writeFileSync(path.join(preferences, '2026030100000002-pi.md'), note('2026030100000002', 'Pi TypeScript setup', 'fleeting', ['client:pi'], 'For now configure TypeScript output for Pi.'));
+    fs.writeFileSync(path.join(preferences, '2026030100000001-universal.md'), note('2026030100000001', 'Universal concise answers', 'permanent', ['scope:global', 'writing'], 'Keep answers concise.'));
+    fs.writeFileSync(path.join(preferences, '2026030100000002-pi.md'), note('2026030100000002', 'Pi TypeScript setup', 'fleeting', ['scope:global', 'client:pi'], 'For now configure TypeScript output for Pi.'));
     fs.writeFileSync(path.join(preferences, '2026030100000003-project.md'), note('2026030100000003', 'Project Python setup', 'permanent', ['project:atlas'], 'Install Python tooling for Atlas.'));
     const archivedPath = path.join(preferences, '2026030100000004-archived.md');
     fs.writeFileSync(archivedPath, note('2026030100000004', 'Archived Cursor routing', 'archived', [], 'Currently route Cursor to gpt-4.'));
@@ -77,13 +77,11 @@ describe('Pi personalization scope integration', () => {
       const harness = section('## Harness Preferences');
       const project = section('## Project Preferences');
       for (const block of [universal, harness, project]) expect(block).toContain(".where(p => p.status !== 'archived')");
-      expect(universal).toContain("p => !tagsFor(p).some(t => t.startsWith('project:') || t.startsWith('#project:') || t.startsWith('client:') || t.startsWith('#client:'))");
-      const harnessPredicate = ".where(p => tagsFor(p).some(t => t.startsWith('client:') || t.startsWith('#client:')))";
-      const projectPredicate = ".where(p => tagsFor(p).some(t => t.startsWith('project:') || t.startsWith('#project:')))";
+      expect(universal).toContain("p => tagsFor(p).some(t => t === 'scope:global' || t === '#scope:global') && !tagsFor(p).some(t => t.startsWith('project:') || t.startsWith('#project:') || t.startsWith('client:') || t.startsWith('#client:'))");
+      const harnessPredicate = ".where(p => tagsFor(p).some(t => t.startsWith('client:') || t.startsWith('#client:')) && ((tagsFor(p).some(t => t === 'scope:global' || t === '#scope:global')";
+      const projectPredicate = ".where(p => !tagsFor(p).some(t => t === 'scope:global' || t === '#scope:global') && tagsFor(p).filter(t => t.startsWith('project:') || t.startsWith('#project:')).length === 1)";
       expect(harness).toContain(harnessPredicate);
-      expect(harness).not.toContain(projectPredicate);
       expect(project).toContain(projectPredicate);
-      expect(project).not.toContain(harnessPredicate);
       for (const [name, before] of sourceBefore) expect(fs.readFileSync(path.join(preferences, name), 'utf8')).toBe(before);
     } finally {
       clearTimeout(timeout);

--- a/tests/project-knowledge-boundaries.test.ts
+++ b/tests/project-knowledge-boundaries.test.ts
@@ -31,6 +31,21 @@ describe('repository project knowledge boundaries', () => {
     expect(context.engine.search('boundary', { limit: 1, visibility: { project: 'alpha' } })).toHaveLength(1);
   });
 
+  it('excludes archived notes before default FTS and vector ranking', () => {
+    const archived = store('Archived Alpha', ['project:alpha'], 'archived boundary keyword');
+    context.engine.storeEmbedding(archived.id, [1, 0], 'test');
+    context.engine.archive(archived.id);
+
+    expect(context.engine.search('archived boundary', { visibility: { project: 'alpha' } })).toEqual([]);
+    expect(context.engine.searchVector([1, 0], { visibility: { project: 'alpha' } })).toEqual([]);
+    expect(context.engine.search('archived boundary', {
+      status: 'archived', visibility: { project: 'alpha' },
+    }).map(note => note.id)).toEqual([archived.id]);
+    expect(context.engine.searchVector([1, 0], {
+      status: 'archived', visibility: { project: 'alpha' },
+    }).map(note => note.id)).toEqual([archived.id]);
+  });
+
   it('prefilters vector candidates and applies client compatibility', () => {
     const alpha = store('Alpha Pi', ['project:alpha', 'client:pi']);
     const beta = store('Beta', ['project:beta']);

--- a/tests/project-knowledge-boundaries.test.ts
+++ b/tests/project-knowledge-boundaries.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { cleanupTestHarness, createTestHarness, type TestContext } from './harness.js';
+import { parseKnowledgeApplicability } from '../src/knowledge-scope.js';
+
+describe('repository project knowledge boundaries', () => {
+  let context: TestContext;
+
+  beforeEach(() => { context = createTestHarness(); });
+  afterEach(() => { cleanupTestHarness(context); });
+
+  function store(title: string, tags: string[], content = 'shared boundary keyword') {
+    return context.engine.store(content, { title, kind: 'reference', tags });
+  }
+
+  it('classifies explicit applicability and conflicts', () => {
+    expect(parseKnowledgeApplicability(['project:alpha'])).toEqual({ type: 'project-local', project: 'alpha' });
+    expect(parseKnowledgeApplicability(['scope:global'])).toEqual({ type: 'global' });
+    expect(parseKnowledgeApplicability([])).toEqual({ type: 'unclassified', reason: 'missing' });
+    expect(parseKnowledgeApplicability(['project:a', 'project:b'])).toEqual({ type: 'unclassified', reason: 'multiple-projects' });
+    expect(parseKnowledgeApplicability(['project:a', 'scope:global'])).toEqual({ type: 'unclassified', reason: 'conflict' });
+  });
+
+  it('excludes unrelated and unclassified notes before FTS limits', () => {
+    for (let index = 0; index < 4; index++) store(`Beta ${index}`, ['project:beta'], `boundary boundary boundary ${index}`);
+    const alpha = store('Alpha', ['project:alpha'], 'boundary');
+    const global = store('Global', ['scope:global'], 'boundary');
+    store('Legacy', [], 'boundary boundary');
+
+    const results = context.engine.search('boundary', { limit: 10, visibility: { project: 'alpha' } });
+    expect(results.map(note => note.id).sort()).toEqual([alpha.id, global.id].sort());
+    expect(context.engine.search('boundary', { limit: 1, visibility: { project: 'alpha' } })).toHaveLength(1);
+  });
+
+  it('prefilters vector candidates and applies client compatibility', () => {
+    const alpha = store('Alpha Pi', ['project:alpha', 'client:pi']);
+    const beta = store('Beta', ['project:beta']);
+    const global = store('Global all', ['scope:global', 'client:all']);
+    context.engine.storeEmbedding(alpha.id, [0.8, 0.2], 'test');
+    context.engine.storeEmbedding(beta.id, [1, 0], 'test');
+    context.engine.storeEmbedding(global.id, [0.7, 0.3], 'test');
+
+    const results = context.engine.searchVector([1, 0], { limit: 5, visibility: { project: 'alpha', client: 'pi' } });
+    expect(results.map(note => note.id)).toEqual([alpha.id, global.id]);
+    expect(context.engine.searchVector([1, 0], { visibility: { project: 'alpha', client: 'cursor' } }).map(note => note.id)).toEqual([global.id]);
+  });
+
+  it('uses project-plus-global visibility for health aggregates', () => {
+    const alpha = store('Alpha health', ['project:alpha']);
+    const global = store('Global health', ['scope:global']);
+    store('Beta health', ['project:beta']);
+    store('Legacy health', []);
+    store('Conflicted health', ['project:alpha', 'scope:global']);
+    context.engine.storeEmbedding(alpha.id, [1, 0], 'test-model');
+
+    expect(context.engine.getStats('alpha')).toMatchObject({ total: 2, fleeting: 2 });
+    expect(context.engine.getEmbeddingStats('alpha')).toEqual({
+      total: 2,
+      withEmbedding: 1,
+      withoutEmbedding: 1,
+      models: { 'test-model': 1 },
+    });
+    expect(context.engine.getGrowthByKind(Date.now() - 60_000, 'alpha')).toEqual({ reference: 2 });
+    const staleness = context.engine.getStalenessDistribution('alpha');
+    expect(staleness.fresh + staleness.recent + staleness.aging + staleness.stale).toBe(2);
+    expect(context.engine.getByIdVisible(global.id, { project: 'alpha' })?.id).toBe(global.id);
+  });
+
+  it('scopes exact IDs, duplicate candidates, and link queries', () => {
+    const alpha = store('Alpha', ['project:alpha']);
+    const beta = store('Beta', ['project:beta']);
+    const global = store('Global', ['scope:global']);
+    context.engine.updateContentHash(alpha.id, '0000000000000001');
+    context.engine.updateContentHash(beta.id, '0000000000000001');
+    context.engine.updateContentHash(global.id, '0000000000000001');
+
+    const visibility = { project: 'alpha' };
+    expect(context.engine.getByIdVisible(beta.id, visibility)).toBeNull();
+    expect(context.engine.getByIdVisible(global.id, visibility)?.id).toBe(global.id);
+    expect(context.engine.findNearDuplicates('0000000000000001', 0, visibility).map(note => note.id).sort())
+      .toEqual([alpha.id, global.id].sort());
+
+    context.engine.store(`Links [[${beta.id}]] and [[${global.id}]]`, {
+      title: 'Source', kind: 'reference', tags: ['project:alpha'],
+    });
+    const source = context.engine.search('Links', { visibility })[0];
+    expect(context.engine.getOutgoingLinks(source.id, visibility).map(link => link.note.id)).toEqual([global.id]);
+  });
+});

--- a/tests/publish-global.test.ts
+++ b/tests/publish-global.test.ts
@@ -95,6 +95,55 @@ describe('publish-global maintenance', () => {
     expect(rejected.outboundLinks).toContain('unresolved:[[missing-note]]');
   });
 
+  it('validates links in every rendered field and rejects archived global targets', async () => {
+    const local = source();
+    const privateTarget = ctx.engine.store('Private target.', {
+      title: 'Private Target', kind: 'reference', status: 'permanent', tags: ['project:alpha'],
+      summary: 'Private.', guidance: 'Keep private.',
+    });
+    for (const field of ['title', 'summary', 'guidance'] as const) {
+      const proposed = { ...candidate, [field]: `Use [[${privateTarget.id}|Private Target]].` };
+      const preview = JSON.parse(await handleMaintain({
+        action: 'publish-global', noteId: local.id, candidate: proposed, dryRun: true,
+      }, ctx.engine, ctx.config));
+      expect(preview.valid).toBe(false);
+      expect(preview.outboundLinks.join('\n')).toContain(`${field}:project-local:`);
+    }
+
+    const archivedGlobal = ctx.engine.store('Inactive reusable target.', {
+      title: 'Archived Global Target', kind: 'reference', status: 'permanent', tags: ['scope:global'],
+      summary: 'Inactive.', guidance: 'Do not use.',
+    });
+    ctx.engine.archive(archivedGlobal.id);
+    const archivedPreview = JSON.parse(await handleMaintain({
+      action: 'publish-global', noteId: local.id,
+      candidate: { ...candidate, content: `Use [[${archivedGlobal.id}|Archived Global Target]].` },
+      dryRun: true,
+    }, ctx.engine, ctx.config));
+    expect(archivedPreview.valid).toBe(false);
+    expect(archivedPreview.outboundLinks.join('\n')).toContain('archived:');
+    expect(archivedPreview.errors.join('\n')).toContain('not active global');
+  });
+
+  it('does not revive a used confirmation token after rebuild', async () => {
+    const local = source();
+    ctx.engine.rebuildFromFiles();
+    const preview = JSON.parse(await handleMaintain({
+      action: 'publish-global', noteId: local.id, candidate, dryRun: true,
+    }, ctx.engine, ctx.config));
+    await handleMaintain({
+      action: 'publish-global', noteId: local.id, candidate, dryRun: false,
+      confirm: true, token: preview.confirmationToken,
+    }, ctx.engine, ctx.config);
+    ctx.engine.rebuildFromFiles();
+
+    const replay = await handleMaintain({
+      action: 'publish-global', noteId: local.id, candidate, dryRun: false,
+      confirm: true, token: preview.confirmationToken,
+    }, ctx.engine, ctx.config);
+    expect(replay).toContain('stale or does not match');
+  });
+
   it('audits global violations deterministically without mutation', async () => {
     const local = source();
     const global = ctx.engine.store(`References [[${local.id}|Local Source]].`, {
@@ -107,6 +156,10 @@ describe('publish-global maintenance', () => {
     expect(first).toBe(second);
     expect(JSON.parse(first)).toMatchObject({ mutated: false, scanned: 1, findings: [{ id: global.id }] });
     expect(first).toContain('project-local:');
+    expect(ctx.engine.getOutgoingLinks(global.id)).toEqual([]);
+    ctx.engine.rebuildFromFiles();
+    expect(ctx.engine.getOutgoingLinks(global.id)).toEqual([]);
+    expect(await handleMaintain({ action: 'global-reference-audit' }, ctx.engine, ctx.config)).toContain('project-local:');
     expect(fs.readFileSync(global.path, 'utf8')).toBe(before);
   });
 

--- a/tests/publish-global.test.ts
+++ b/tests/publish-global.test.ts
@@ -95,6 +95,50 @@ describe('publish-global maintenance', () => {
     expect(rejected.outboundLinks).toContain('unresolved:[[missing-note]]');
   });
 
+  it('rejects raw unclassified IDs and withholds tokens from invalid previews', async () => {
+    const local = source();
+    const unclassified = ctx.engine.store('Legacy unclassified target.', {
+      title: 'Legacy Unclassified Target', kind: 'reference', status: 'permanent', tags: [],
+      summary: 'Legacy target.', guidance: 'Classify before use.',
+    });
+    const rawIdPreview = JSON.parse(await handleMaintain({
+      action: 'publish-global', noteId: local.id,
+      candidate: { ...candidate, content: `Internal reference ${unclassified.id} must not escape.` },
+      dryRun: true,
+    }, ctx.engine, ctx.config));
+    expect(rawIdPreview.valid).toBe(false);
+    expect(rawIdPreview.projectReferences).toContain(`content:unclassified-id:${unclassified.id}`);
+    expect(rawIdPreview).not.toHaveProperty('confirmationToken');
+
+    const archivedUnclassified = ctx.engine.store('Archived unclassified target.', {
+      title: 'Archived Unclassified Target', kind: 'reference', status: 'permanent', tags: [],
+      summary: 'Archived legacy target.', guidance: 'Classify before use.',
+    });
+    ctx.engine.archive(archivedUnclassified.id);
+    const archivedRawIdPreview = JSON.parse(await handleMaintain({
+      action: 'publish-global', noteId: local.id,
+      candidate: { ...candidate, content: `Archived internal reference ${archivedUnclassified.id} must not escape.` },
+      dryRun: true,
+    }, ctx.engine, ctx.config));
+    expect(archivedRawIdPreview.valid).toBe(false);
+    expect(archivedRawIdPreview.projectReferences).toContain(`content:unclassified-id:${archivedUnclassified.id}`);
+    expect(archivedRawIdPreview).not.toHaveProperty('confirmationToken');
+
+    const archived = source();
+    ctx.engine.archive(archived.id);
+    const globalSource = ctx.engine.store('Already global.', {
+      title: 'Already Global Source', kind: 'reference', status: 'permanent', tags: ['scope:global'],
+      summary: 'Global.', guidance: 'Keep global.',
+    });
+    for (const noteId of [archived.id, globalSource.id, unclassified.id]) {
+      const preview = JSON.parse(await handleMaintain({
+        action: 'publish-global', noteId, candidate, dryRun: true,
+      }, ctx.engine, ctx.config));
+      expect(preview.valid).toBe(false);
+      expect(preview).not.toHaveProperty('confirmationToken');
+    }
+  });
+
   it('validates links in every rendered field and rejects archived global targets', async () => {
     const local = source();
     const privateTarget = ctx.engine.store('Private target.', {

--- a/tests/publish-global.test.ts
+++ b/tests/publish-global.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { handleMaintain, type PublishGlobalCandidate } from '../src/tool-handlers.js';
+import { cleanupTestHarness, createTestHarness, type TestContext } from './harness.js';
+
+const candidate: PublishGlobalCandidate = {
+  title: 'Prefer Deterministic Tokens',
+  content: 'Canonical inputs make confirmation reproducible.',
+  kind: 'reference',
+  summary: 'Canonical inputs produce stable confirmation tokens.',
+  guidance: 'Canonicalize inputs before generating confirmation tokens.',
+  tags: ['security'],
+};
+
+describe('publish-global maintenance', () => {
+  let ctx: TestContext;
+  beforeEach(() => { ctx = createTestHarness(); });
+  afterEach(() => cleanupTestHarness(ctx));
+
+  function source(lifecycle: 'living' | 'snapshot' = 'living') {
+    return ctx.engine.store('Project-only source body.', {
+      title: 'Local Source', kind: 'observation', status: 'permanent', lifecycle,
+      tags: ['project:alpha', 'client:pi'], summary: 'Local summary', guidance: 'Keep local guidance.',
+    });
+  }
+
+  it('previews deterministically without mutation and reports evidence', async () => {
+    const local = source();
+    const before = fs.readFileSync(local.path, 'utf8');
+    const first = await handleMaintain({ action: 'publish-global', noteId: local.id, candidate, dryRun: true }, ctx.engine, ctx.config);
+    const second = await handleMaintain({ action: 'publish-global', noteId: local.id, candidate, dryRun: true }, ctx.engine, ctx.config);
+    expect(first).toBe(second);
+    expect(JSON.parse(first)).toMatchObject({ valid: true, duplicates: [], projectReferences: [], outboundLinks: [] });
+    expect(fs.readFileSync(local.path, 'utf8')).toBe(before);
+    expect(ctx.engine.getAllGlobalNotes()).toHaveLength(0);
+  });
+
+  it('requires confirmation and rejects mismatched or stale tokens', async () => {
+    const local = source();
+    const preview = JSON.parse(await handleMaintain({ action: 'publish-global', noteId: local.id, candidate, dryRun: true }, ctx.engine, ctx.config));
+    expect(await handleMaintain({ action: 'publish-global', noteId: local.id, candidate, dryRun: false, token: preview.confirmationToken }, ctx.engine, ctx.config)).toContain('confirm=true');
+    expect(await handleMaintain({ action: 'publish-global', noteId: local.id, candidate: { ...candidate, title: 'Different Candidate' }, dryRun: false, confirm: true, token: preview.confirmationToken }, ctx.engine, ctx.config)).toContain('stale or does not match');
+    ctx.engine.store('Changed source.', { existingId: local.id, title: 'Local Source', kind: 'observation', tags: ['project:alpha', 'client:pi'] });
+    expect(await handleMaintain({ action: 'publish-global', noteId: local.id, candidate, dryRun: false, confirm: true, token: preview.confirmationToken }, ctx.engine, ctx.config)).toContain('stale or does not match');
+  });
+
+  it('creates a separate derivative and preserves source semantics', async () => {
+    const local = source();
+    ctx.engine.store('Legacy hidden body.', { title: 'Legacy Hidden Note', kind: 'reference', tags: [] });
+    const before = ctx.engine.getById(local.id)!;
+    const preview = JSON.parse(await handleMaintain({ action: 'publish-global', noteId: local.id, candidate, dryRun: true }, ctx.engine, ctx.config));
+    await handleMaintain({ action: 'publish-global', noteId: local.id, candidate, dryRun: false, confirm: true, token: preview.confirmationToken }, ctx.engine, ctx.config);
+    const after = ctx.engine.getById(local.id)!;
+    expect({ title: after.title, content: after.content, summary: after.summary, guidance: after.guidance, tags: after.tags, lifecycle: after.lifecycle, status: after.status })
+      .toEqual({ title: before.title, content: before.content, summary: before.summary, guidance: before.guidance, tags: before.tags, lifecycle: before.lifecycle, status: before.status });
+    const global = ctx.engine.getAllGlobalNotes()[0];
+    expect(global.tags).toEqual(['security', 'scope:global']);
+    expect(fs.readFileSync(global.path, 'utf8')).not.toContain(local.id);
+    expect(fs.readFileSync(global.path, 'utf8')).not.toContain('project:alpha');
+    const generalIndex = fs.readFileSync(path.join(ctx.tempDir, 'general', 'general.md'), 'utf8');
+    expect(generalIndex).toContain('includes("scope:global")');
+    expect(generalIndex).not.toContain('obsidian://quickadd');
+    expect(generalIndex).not.toContain('Legacy Hidden Note');
+    expect(generalIndex).not.toContain(local.id);
+    expect(generalIndex).not.toContain('project:alpha');
+    expect(fs.existsSync(path.join(ctx.tempDir, 'log.md'))).toBe(false);
+  });
+
+  it('rejects exact project evidence and non-global links while allowing global links', async () => {
+    const local = source();
+    const otherLocal = ctx.engine.store('Private target.', {
+      title: 'Alpha Secret', kind: 'reference', status: 'permanent', tags: ['project:alpha'],
+      summary: 'Private.', guidance: 'Keep private.',
+    });
+    const global = ctx.engine.store('Reusable target.', {
+      title: 'Reusable Target', kind: 'reference', status: 'permanent', tags: ['scope:global'],
+      summary: 'Reusable.', guidance: 'Reuse.',
+    });
+    const accepted = JSON.parse(await handleMaintain({ action: 'publish-global', noteId: local.id, candidate: {
+      ...candidate, content: `Use [[${global.id}|Reusable Target]].`,
+    }, dryRun: true }, ctx.engine, ctx.config));
+    expect(accepted.valid).toBe(true);
+    const rejected = JSON.parse(await handleMaintain({ action: 'publish-global', noteId: local.id, candidate: {
+      ...candidate,
+      title: 'Alpha deployment',
+      content: `See projects/alpha and [[${otherLocal.id}|Alpha Secret]] and [[missing-note]].`,
+      tags: ['security', 'project:alpha'],
+    }, dryRun: true }, ctx.engine, ctx.config));
+    expect(rejected.valid).toBe(false);
+    expect(rejected.projectReferences.join('\n')).toContain('project-name:alpha');
+    expect(rejected.projectReferences.join('\n')).toContain('project-path:projects/alpha');
+    expect(rejected.projectReferences).toContain('tag:project:alpha');
+    expect(rejected.outboundLinks.join('\n')).toContain('project-local:');
+    expect(rejected.outboundLinks).toContain('unresolved:[[missing-note]]');
+  });
+
+  it('audits global violations deterministically without mutation', async () => {
+    const local = source();
+    const global = ctx.engine.store(`References [[${local.id}|Local Source]].`, {
+      title: 'Legacy Global', kind: 'reference', status: 'permanent', tags: ['scope:global'],
+      summary: 'Legacy.', guidance: 'Review.',
+    });
+    const before = fs.readFileSync(global.path, 'utf8');
+    const first = await handleMaintain({ action: 'global-reference-audit' }, ctx.engine, ctx.config);
+    const second = await handleMaintain({ action: 'global-reference-audit' }, ctx.engine, ctx.config);
+    expect(first).toBe(second);
+    expect(JSON.parse(first)).toMatchObject({ mutated: false, scanned: 1, findings: [{ id: global.id }] });
+    expect(first).toContain('project-local:');
+    expect(fs.readFileSync(global.path, 'utf8')).toBe(before);
+  });
+
+  it('hides local incoming provenance from global backlink surfaces', () => {
+    const local = source();
+    const global = ctx.engine.store('Reusable.', {
+      title: 'Global', kind: 'reference', status: 'permanent', tags: ['scope:global'], summary: 'Reusable.', guidance: 'Reuse.',
+    });
+    ctx.engine.addLocalToGlobalRelation(local.id, global.id);
+    expect(ctx.engine.getOutgoingLinks(local.id).map(({ note }) => note.id)).toContain(global.id);
+    expect(ctx.engine.getGlobalBacklinks(global.id)).toEqual([]);
+  });
+
+  it('adds and rebuilds the one-way relation on a snapshot source', async () => {
+    const local = source('snapshot');
+    const original = fs.readFileSync(local.path, 'utf8');
+    const customized = original.replace('\n---\n\n', '\ncustom_field: preserve-verbatim\n---\n\n');
+    fs.writeFileSync(local.path, customized, 'utf8');
+    ctx.engine.rebuildFromFiles();
+    const beforePublication = fs.readFileSync(local.path, 'utf8');
+    const preview = JSON.parse(await handleMaintain({ action: 'publish-global', noteId: local.id, candidate, dryRun: true }, ctx.engine, ctx.config));
+    await handleMaintain({ action: 'publish-global', noteId: local.id, candidate, dryRun: false, confirm: true, token: preview.confirmationToken }, ctx.engine, ctx.config);
+    const publishedSource = fs.readFileSync(local.path, 'utf8');
+    expect(publishedSource.startsWith(beforePublication)).toBe(true);
+    expect(publishedSource).toContain('custom_field: preserve-verbatim');
+    const global = ctx.engine.getAllGlobalNotes()[0];
+    expect(ctx.engine.getOutgoingLinks(local.id).map(({ note }) => note.id)).toContain(global.id);
+    expect(ctx.engine.getOutgoingLinks(global.id)).toHaveLength(0);
+    ctx.engine.rebuildFromFiles();
+    expect(ctx.engine.getOutgoingLinks(local.id).map(({ note }) => note.id)).toContain(global.id);
+    expect(fs.readFileSync(ctx.engine.getLogNote('alpha')!.path, 'utf8')).toContain('Published global derivative');
+  });
+});

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -137,19 +137,22 @@ function expectSlimAgentDocsBlock(content: string, usesOmpSkill = false): void {
   expect(block.split('\n')).toHaveLength(MANAGED_BLOCK_LINE_COUNT);
   expect(block).toContain('Persistent cross-session memory via `knowledge-*` MCP tools.');
   expect(block).toContain('`knowledge-search` for relevant context.');
-  expect(block).toContain("Filter by `project` and `kind`; follow each note's `<guidance>`.");
+  expect(block).toContain("Pass the current project explicitly on every routine stored-knowledge call; follow each note's `<guidance>`.");
+  expect(block).toContain('Routine capture is project-local; never create global knowledge with `knowledge-store` or `knowledge-mine`.');
+  expect(block).toContain('preview `publish-global`');
+  expect(block).toContain('Maintenance remains full-vault and must classify legacy unscoped notes');
   expect(block).toContain('`knowledge-store` immediately, never defer:');
   expect(block).toContain('useful URL → resource (`knowledge-ingest` first).');
   expect(block).toContain('**Each note:** one concept only.');
   expect(block).toContain('Include a `summary` and imperative `guidance`.');
-  expect(block).toContain('**Project session start:** `knowledge-context`.');
+  expect(block).toContain('**Project session start:** `knowledge-context` with the current project.');
   expect(block).toContain(
     usesOmpSkill
       ? '`skill://open-zk-kb`.'
       : '`knowledge-template --kind {kind}` and the `open-zk-kb` skill where supported.'
   );
   expect(block).not.toContain('Capture Checkpoints');
-  expect(block).not.toContain('knowledge-mine');
+  expect(block).toContain('never create global knowledge with `knowledge-store` or `knowledge-mine`');
   expect(block).not.toContain('knowledge-maintain');
 }
 

--- a/tests/smoke-safety.test.ts
+++ b/tests/smoke-safety.test.ts
@@ -183,6 +183,25 @@ describe('destructive smoke-test safety', () => {
     expect(script).not.toContain('VAULT_PATH="$HOME/.local/share/open-zk-kb"');
   });
 
+  it('keeps pre-existing vault checks scoped to their explicit project', () => {
+    const script = fs.readFileSync(smokeScript, 'utf8');
+
+    expect(script.split('- project:smoke-test-project')).toHaveLength(3);
+    expect(script).toContain("arguments: { query: 'PostgreSQL database', project: 'smoke-test-project' }");
+    expect(script).toContain("arguments: { project: 'smoke-test-project' }");
+    expect(script).not.toContain("name: 'knowledge-health', arguments: {} });");
+  });
+
+  it('prints captured unit-test output when bun test fails', () => {
+    const script = fs.readFileSync(smokeScript, 'utf8');
+    const failureStart = script.indexOf('FAIL_LINE=$(echo "$TEST_OUTPUT"');
+    const failureEnd = script.indexOf('\nfi', failureStart);
+    const failureBranch = script.slice(failureStart, failureEnd);
+
+    expect(failureStart).toBeGreaterThan(-1);
+    expect(failureBranch).toContain('echo "$TEST_OUTPUT"');
+  });
+
   it('uses the isolated temporary directory for all smoke-suite fixtures', () => {
     for (const relativePath of [
       'docker/model-smoke-test.ts',

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -14,14 +14,14 @@ describe('local tool telemetry', () => {
   });
 
   it('records counter rows with arg_kind and result_count for tool calls', async () => {
-    await handleStore({
+    await handleStore({ project: 'test-project',
       title: 'Alpha Observation',
       content: 'alpha telemetry content',
       kind: 'observation',
       summary: 'Alpha telemetry note',
       guidance: 'Use as telemetry fixture',
     }, ctx.engine, null, ctx.config);
-    handleSearch({ query: 'alpha' }, ctx.engine, null, ctx.config);
+    handleSearch({ project: 'test-project', query: 'alpha' }, ctx.engine, null, ctx.config);
     await handleMaintain({ action: 'review' }, ctx.engine, ctx.config);
     await sleep(0);
 
@@ -37,10 +37,10 @@ describe('local tool telemetry', () => {
   });
 
   it('updates last_accessed_at only for returned search results', async () => {
-    const alpha = ctx.engine.store('alpha returned content', { title: 'Returned', kind: 'reference' });
-    const beta = ctx.engine.store('beta unrelated content', { title: 'Unrelated', kind: 'reference' });
+    const alpha = ctx.engine.store('alpha returned content', { title: 'Returned', kind: 'reference', tags: ['project:test-project'] });
+    const beta = ctx.engine.store('beta unrelated content', { title: 'Unrelated', kind: 'reference', tags: ['project:test-project'] });
 
-    handleSearch({ query: 'alpha' }, ctx.engine, null, ctx.config);
+    handleSearch({ project: 'test-project', query: 'alpha' }, ctx.engine, null, ctx.config);
     await sleep(0);
 
     const accessed = ctx.engine.getById(alpha.id);
@@ -54,9 +54,9 @@ describe('local tool telemetry', () => {
   it('disables telemetry rows and access tracking when opted out', () => {
     cleanupTestHarness(ctx);
     ctx = createTestHarness({ telemetryEnabled: false });
-    const stored = ctx.engine.store('private alpha content', { title: 'Private Alpha', kind: 'reference' });
+    const stored = ctx.engine.store('private alpha content', { title: 'Private Alpha', kind: 'reference', tags: ['project:test-project'] });
 
-    handleSearch({ query: 'private alpha' }, ctx.engine, null, ctx.config);
+    handleSearch({ project: 'test-project', query: 'private alpha' }, ctx.engine, null, ctx.config);
     ctx.engine.recordToolInvocation('store', 'reference', 1);
     ctx.engine.updateLastAccessed([stored.id]);
 
@@ -107,7 +107,7 @@ describe('local tool telemetry', () => {
     ctx.engine.recordToolInvocation('store', 'observation', 1);
     ctx.engine.recordToolInvocation('maintain', 'review');
 
-    const output = await handleHealth({ telemetry: true }, ctx.engine, ctx.config);
+    const output = await handleHealth({ project: 'test-project', telemetry: true }, ctx.engine, ctx.config);
 
     expect(output).toContain('Last 30 days (1 sessions):');
     expect(output).toContain('  Searches: 1 (avg 1 per session)');

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -178,6 +178,7 @@ describe('conformance check in handleStore', () => {
       kind: 'decision',
       summary: 'Chose X',
       guidance: 'Use X',
+      project: 'example-project',
     }, ctx.engine, null, ctx.config);
 
     expect(result).toContain('no headings found');
@@ -191,6 +192,7 @@ describe('conformance check in handleStore', () => {
       kind: 'decision',
       summary: 'Picked A',
       guidance: 'Use A',
+      project: 'example-project',
     }, ctx.engine, null, ctx.config);
 
     expect(result).toContain('Missing:');
@@ -204,6 +206,7 @@ describe('conformance check in handleStore', () => {
       kind: 'decision',
       summary: 'Picked A over B',
       guidance: 'Use A',
+      project: 'example-project',
     }, ctx.engine, null, ctx.config);
 
     expect(result).not.toContain('Conformance:');
@@ -217,6 +220,7 @@ describe('conformance check in handleStore', () => {
       kind: 'personalization',
       summary: 'Prefers dark mode',
       guidance: 'Use dark mode',
+      project: 'example-project',
     }, ctx.engine, null, ctx.config);
 
     expect(result).not.toContain('knowledge-template');
@@ -272,10 +276,11 @@ describe('conformance telemetry', () => {
       kind: 'decision',
       summary: 'Test',
       guidance: 'Test',
+      project: 'example-project',
     }, ctx.engine, null, ctx.config);
     await sleep(0);
 
-    const stats = await handleHealth({ telemetry: true }, ctx.engine, ctx.config);
+    const stats = await handleHealth({ project: 'example-project', telemetry: true }, ctx.engine, ctx.config);
     expect(stats).toContain('Template Conformance');
     expect(stats).toContain('Stores checked:');
   });

--- a/tests/tool-meta.test.ts
+++ b/tests/tool-meta.test.ts
@@ -150,6 +150,7 @@ describe('toZodSchema', () => {
       content: 'Some content',
       summary: 'A test',
       guidance: 'Do this',
+      project: 'example-project',
     })).not.toThrow();
     // Missing required field
     expect(() => schema.parse({

--- a/tests/tool-meta.test.ts
+++ b/tests/tool-meta.test.ts
@@ -59,6 +59,23 @@ describe('tool-meta', () => {
     }
   });
 
+  it('publishing excludes domain while mining exposes an optional client', () => {
+    const maintain = TOOL_DEFINITIONS.find(t => t.name === 'knowledge-maintain')!;
+    const candidate = maintain.params.candidate;
+    expect(candidate.properties?.kind.enum).toContain('reference');
+    expect(candidate.properties?.kind.enum).not.toContain('domain');
+
+    const mine = TOOL_DEFINITIONS.find(t => t.name === 'knowledge-mine')!;
+    expect(mine.params.client.required).toBe(false);
+  });
+
+  it('knowledge-context documents required project visibility with automatic globals', () => {
+    const context = TOOL_DEFINITIONS.find(t => t.name === 'knowledge-context')!;
+    expect(context.params.project.required).toBe(true);
+    expect(context.description).toContain('automatically visible explicit global knowledge');
+    expect(context.description).not.toContain('Without project');
+  });
+
   it('knowledge-store description includes structure hints', () => {
     const store = TOOL_DEFINITIONS.find(t => t.name === 'knowledge-store')!;
     expect(store.description).toContain('Content structure by kind');

--- a/tests/tool-schemas.test.ts
+++ b/tests/tool-schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { TOOL_DEFINITIONS, type ParamDef } from '../src/tool-meta.js';
+import { TOOL_DEFINITIONS, PUBLISH_GLOBAL_CANDIDATE_PROPERTIES, type ParamDef } from '../src/tool-meta.js';
 import { toZodSchema } from '../src/tool-schemas.js';
 import { toTypeBoxSchema } from '../src/pi/tool-schemas.js';
 
@@ -50,5 +50,41 @@ describe('shared tool schemas', () => {
     const mine = TOOL_DEFINITIONS.find(tool => tool.name === 'knowledge-mine')!;
     const schema = toZodSchema(mine.params);
     expect(schema.safeParse({ candidates: [undefined] }).success).toBe(false);
+  });
+
+  it('requires project on knowledge-store', () => {
+    const store = TOOL_DEFINITIONS.find(tool => tool.name === 'knowledge-store')!;
+    const schema = toZodSchema(store.params);
+    expect(schema.safeParse({ title: 't', content: 'c', kind: 'observation', summary: 's', guidance: 'g' }).success).toBe(false);
+    expect(schema.safeParse({ project: 'p', title: 't', content: 'c', kind: 'observation', summary: 's', guidance: 'g' }).success).toBe(true);
+  });
+
+  it('includes publish-global, scope-inventory, and assign-project in maintain actions', () => {
+    const maintain = TOOL_DEFINITIONS.find(tool => tool.name === 'knowledge-maintain')!;
+    const schema = toZodSchema(maintain.params);
+    expect(schema.safeParse({ action: 'publish-global' }).success).toBe(true);
+    expect(schema.safeParse({ action: 'scope-inventory' }).success).toBe(true);
+    expect(schema.safeParse({ action: 'assign-project' }).success).toBe(true);
+    expect(schema.safeParse({ action: 'invalid-action' }).success).toBe(false);
+  });
+
+  it('validates publish-global candidate schema', () => {
+    const candidate = toZodSchema(PUBLISH_GLOBAL_CANDIDATE_PROPERTIES);
+    const valid = candidate.safeParse({
+      title: 'Global Note',
+      content: 'Global content',
+      kind: 'observation',
+      summary: 'Summary',
+      guidance: 'Guidance',
+    });
+    expect(valid.success).toBe(true);
+    const invalid = candidate.safeParse({
+      title: 'Global Note',
+      content: 'Global content',
+      kind: 'invalid-kind',
+      summary: 'Summary',
+      guidance: 'Guidance',
+    });
+    expect(invalid.success).toBe(false);
   });
 });

--- a/tests/tool-schemas.test.ts
+++ b/tests/tool-schemas.test.ts
@@ -86,5 +86,12 @@ describe('shared tool schemas', () => {
       guidance: 'Guidance',
     });
     expect(invalid.success).toBe(false);
+    expect(candidate.safeParse({
+      title: 'Global Domain',
+      content: 'Project domain content',
+      kind: 'domain',
+      summary: 'Summary',
+      guidance: 'Guidance',
+    }).success).toBe(false);
   });
 });

--- a/tests/vault-layout.test.ts
+++ b/tests/vault-layout.test.ts
@@ -10,7 +10,13 @@ import {
 import type { TestContext } from './harness.js';
 import { resolveNotePath, walkMarkdownFiles, extractProjectFromTags } from '../src/storage/path-resolver.js';
 import { handleMaintain, handleStore } from '../src/tool-handlers.js';
-import { buildIndexContent, buildPreferencesIndexContent } from '../src/storage/IndexBuilder.js';
+import {
+  GLOBAL_SCOPE_PREDICATE,
+  buildGeneralIndexContent,
+  buildGeneralKindIndexContent,
+  buildIndexContent,
+  buildPreferencesIndexContent,
+} from '../src/storage/IndexBuilder.js';
 import { buildReviewContent } from '../src/storage/ReviewBuilder.js';
 import type { NoteMetadata } from '../src/storage/NoteRepository.js';
 
@@ -820,6 +826,18 @@ describe('Structured navigation regressions', () => {
  });
 
 describe('Preferences Navigation', () => {
+  it('uses one strict global-scope predicate that excludes conflicted notes', () => {
+    const general = buildGeneralIndexContent([{ kind: 'decision' } as NoteMetadata]);
+    const kind = buildGeneralKindIndexContent('decision', []);
+    const predicate = Function(`return (${GLOBAL_SCOPE_PREDICATE})`)() as (page: unknown) => boolean;
+
+    expect(general).toContain(GLOBAL_SCOPE_PREDICATE);
+    expect(kind).toContain(GLOBAL_SCOPE_PREDICATE);
+    expect(predicate({ file: { tags: ['scope:global'] } })).toBe(true);
+    expect(predicate({ file: { tags: ['#scope:global', '#project:alpha'] } })).toBe(false);
+    expect(predicate({ file: { tags: [{ tag: '#scope:global' }, { name: 'project:alpha' }] } })).toBe(false);
+  });
+
   it('excludes archived notes from all preference sections', () => {
     const content = buildPreferencesIndexContent([]);
     const occurrences = (content.match(/\.where\(p => p\.status !== 'archived'\)/g) || []).length;

--- a/tests/vault-layout.test.ts
+++ b/tests/vault-layout.test.ts
@@ -604,18 +604,11 @@ describe('Global Navigation', () => {
     expect(content).not.toContain('"projects/proj/preferences"');
   });
 
-  it('generates general/general.md for unscoped notes', async () => {
-    await handleStore(
-      { title: 'General Note', content: 'Unscoped content', kind: 'reference', summary: 'General ref', guidance: 'Use it' } as any,
-      context.engine,
-      null,
-      context.config,
-    );
+  it('does not treat explicit global notes as legacy unscoped notes', async () => {
+    context.engine.store('Unscoped content', { title: 'General Note', kind: 'reference', summary: 'General ref', guidance: 'Use it', tags: ['scope:global'] });
 
     const generalIndex = path.join(context.tempDir, 'general', 'general.md');
-    expect(fs.existsSync(generalIndex)).toBe(true);
-    const content = fs.readFileSync(generalIndex, 'utf-8');
-    expect(content).toContain('# `[!!library]` General Knowledge');
+    expect(fs.existsSync(generalIndex)).toBe(false);
   });
 
   it('appends to global log on subsequent stores', async () => {
@@ -790,65 +783,18 @@ describe('Structured navigation regressions', () => {
     expect(content).toContain('[system] Full DB rebuild');
   });
 
-  it('generates preferences/preferences.md when personalization notes exist', async () => {
-    await handleStore(
-      { title: 'Pref', content: 'Pref content', kind: 'personalization', summary: 'User prefers Bun', guidance: 'Use Bun' } as any,
-      context.engine,
-      null,
-      context.config,
-    );
+  it('does not publish global personalization through the legacy unscoped index', async () => {
+    context.engine.store('Pref content', { title: 'Pref', kind: 'personalization', summary: 'User prefers Bun', guidance: 'Use Bun', tags: ['scope:global'] });
 
     const preferencesIndex = path.join(context.tempDir, 'preferences', 'preferences.md');
-    expect(fs.existsSync(preferencesIndex)).toBe(true);
-    const content = fs.readFileSync(preferencesIndex, 'utf-8');
-    expect(content).toContain('# `[!!user-cog]` Preferences');
-    expect(content).toContain('BC-folder-note-field: "up"');
-    expect(content).toContain('up: "[[Home|Home]]"');
-     expect(content).toContain('dv.pages(\'"preferences"\')');
-
-     const globalIndex = fs.readFileSync(path.join(context.tempDir, 'Home.md'), 'utf-8');
-     expect(globalIndex).toContain('[[preferences/preferences\\|Preferences]]');
+    expect(fs.existsSync(preferencesIndex)).toBe(false);
   });
 
-  it('generates general kind subdir folder notes for unscoped notes', async () => {
-    await handleStore(
-      { title: 'General Decision', content: 'Decide', kind: 'decision', summary: 'General summary', guidance: 'Use it' } as any,
-      context.engine,
-      null,
-      context.config,
-    );
+  it('does not generate legacy general kind indexes for explicit global notes', async () => {
+    context.engine.store('Decide', { title: 'General Decision', kind: 'decision', summary: 'General summary', guidance: 'Use it', tags: ['scope:global'] });
 
     const generalKindIndex = path.join(context.tempDir, 'general', 'decisions', 'decisions.md');
-    expect(fs.existsSync(generalKindIndex)).toBe(true);
-    const content = fs.readFileSync(generalKindIndex, 'utf-8');
-    expect(content).toContain('# General — Decisions');
-    expect(content).toContain('[[general/general|General]]');
-     expect(content).toContain('dv.pages(\'"general/decisions"\')');
-   });
-
-   it('groups general kind subdirs by note kind, not by filesystem path (flat-vault safe)', async () => {
-    // Regression: pre-migration flat vaults must not pollute general/ with vault-name dirs.
-    const flatNote = `---
-id: 2026042700000099
-title: Flat Unscoped Decision
-kind: decision
-status: permanent
-lifecycle: snapshot
-type: atomic
-created: 2026-04-27
-updated: 2026-04-27
----
-
-Flat content`;
-    createNoteFile(context, '2026042700000099', flatNote, '2026042700000099-flat-unscoped.md');
-    context.engine.rebuildFromFiles();
-
-    await handleMaintain({ action: 'rebuild' }, context.engine, context.config);
-
-    expect(fs.existsSync(path.join(context.tempDir, 'general', 'decisions', 'decisions.md'))).toBe(true);
-
-    const vaultBasename = path.basename(context.tempDir);
-    expect(fs.existsSync(path.join(context.tempDir, 'general', vaultBasename))).toBe(false);
+    expect(fs.existsSync(generalKindIndex)).toBe(false);
   });
 
   it('creates sub-MOC files for small project kinds below split threshold', async () => {
@@ -890,13 +836,14 @@ describe('Preferences Navigation', () => {
     expect(tableCount).toBe(3);
 
     expect(content).toContain(
-      "p => !tagsFor(p).some(t => t.startsWith('project:') || t.startsWith('#project:') || t.startsWith('client:') || t.startsWith('#client:'))"
+      "p => tagsFor(p).some(t => t === 'scope:global' || t === '#scope:global') && !tagsFor(p).some(t => t.startsWith('project:') || t.startsWith('#project:') || t.startsWith('client:') || t.startsWith('#client:'))"
+    );
+    expect(content).not.toContain('obsidian://quickadd');
+    expect(content).toContain(
+      "p => tagsFor(p).some(t => t.startsWith('client:') || t.startsWith('#client:')) && ((tagsFor(p).some(t => t === 'scope:global' || t === '#scope:global')"
     );
     expect(content).toContain(
-      "p => tagsFor(p).some(t => t.startsWith('client:') || t.startsWith('#client:')))"
-    );
-    expect(content).toContain(
-      "p => tagsFor(p).some(t => t.startsWith('project:') || t.startsWith('#project:')))"
+      "p => !tagsFor(p).some(t => t === 'scope:global' || t === '#scope:global') && tagsFor(p).filter(t => t.startsWith('project:') || t.startsWith('#project:')).length === 1"
     );
   });
 
@@ -931,10 +878,10 @@ describe('Preferences Navigation', () => {
     const projectSection = content.slice(projectIdx);
 
     expect(harnessSection).toContain(
-      "p => tagsFor(p).some(t => t.startsWith('client:') || t.startsWith('#client:')))"
+      "p => tagsFor(p).some(t => t.startsWith('client:') || t.startsWith('#client:')) && ((tagsFor(p).some(t => t === 'scope:global' || t === '#scope:global')"
     );
     expect(projectSection).toContain(
-      "p => tagsFor(p).some(t => t.startsWith('project:') || t.startsWith('#project:')))"
+      "p => !tagsFor(p).some(t => t === 'scope:global' || t === '#scope:global') && tagsFor(p).filter(t => t.startsWith('project:') || t.startsWith('#project:')).length === 1"
     );
   });
 });


### PR DESCRIPTION
## Summary

- enforce current-project plus explicit `scope:global` visibility before ranking, exact-ID lookup, related-note discovery, mining, context, and health aggregation
- add confirmed, stale-safe global derivative publication and rollback-safe legacy project assignment
- prevent reverse project provenance in global notes and navigation, and remove unreviewed global creation paths from Obsidian QuickAdd
- update MCP/Pi contracts, packaged guidance, documentation, OpenSpec artifacts, and migration guidance

## Verification

- `bun run build`
- `bun run typecheck`
- `bun run lint` — 0 errors; 22 existing warnings in `src/mcp-server.ts`
- `bun test` — 1,215 passed, 56 skipped
- `openspec validate "enforce-project-knowledge-boundaries" --type change --strict`
- live temporary-vault generation and `glow` rendering of project/global navigation

## Visual review

The generated Home page labels the shared section **Global Knowledge** and shows only confirmed global derivatives there. Project-local publication provenance remains visible only from the local project side. QuickAdd's project-only choices are covered by scaffold tests; I did not open the full Obsidian GUI.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

