### PR TITLE
Expose scoped link health details

### DIFF
--- a/src/pi/renderers.ts
+++ b/src/pi/renderers.ts
@@ -312,8 +312,9 @@ function healthResult(
     .map(({ kind, count }) => `${count} ${kindLabels[kind] ?? (count === '1' ? kind : `${kind}s`)}`);
   const embedded = sectionBody(sections, 'Embeddings').match(/Embedded:\s*(\d+)\/(\d+)\s+notes?/i);
   const links = sectionBody(sections, 'Link Health');
-  const linkIssue = /Issues:/i.test(links)
-    ? theme.fg('warning', `${ICONS.error} ${links.replace(/^[-*]\s*/, '')}`)
+  const linkIssueLine = links.split('\n').find((line) => /^[-*]\s+Issues:/i.test(line));
+  const linkIssue = linkIssueLine
+    ? theme.fg('warning', `${ICONS.error} ${linkIssueLine.replace(/^[-*]\s*/, '')}`)
     : '';
   const healthySignals = [
     embedded ? `${embedded[1]}/${embedded[2]} embedded` : '',

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -449,7 +449,30 @@ export async function handleHealth(args: HealthArgs, repo: NoteRepository, confi
       if (unlinkedNotes.length > 0) parts.push(`${unlinkedNotes.length} unlinked`);
       if (brokenLinks.length > 0) parts.push(`${brokenLinks.length} broken`);
       if (oneWayLinks.length > 0) parts.push(`${oneWayLinks.length} one-way`);
-      output += `- Issues: ${parts.join(', ')} (run \`knowledge-maintain link-health\` for details)\n`;
+      output += `- Issues: ${parts.join(', ')}\n`;
+
+      const detailLimit = 5;
+      if (unlinkedNotes.length > 0) {
+        output += '- Scoped unlinked notes:\n';
+        for (const note of unlinkedNotes.slice(0, detailLimit)) {
+          output += `  - "${note.title}" [${note.id}]\n`;
+        }
+        if (unlinkedNotes.length > detailLimit) output += `  - …and ${unlinkedNotes.length - detailLimit} more\n`;
+      }
+      if (brokenLinks.length > 0) {
+        output += '- Scoped broken links:\n';
+        for (const link of brokenLinks.slice(0, detailLimit)) {
+          output += `  - "${link.sourceTitle}" [${link.sourceId}] content:${link.line} → [[${link.brokenTarget}]]\n`;
+        }
+        if (brokenLinks.length > detailLimit) output += `  - …and ${brokenLinks.length - detailLimit} more\n`;
+      }
+      if (oneWayLinks.length > 0) {
+        output += '- Scoped one-way links:\n';
+        for (const link of oneWayLinks.slice(0, detailLimit)) {
+          output += `  - "${link.sourceTitle}" [${link.sourceId}] → "${link.targetTitle}" [${link.targetId}]\n`;
+        }
+        if (oneWayLinks.length > detailLimit) output += `  - …and ${oneWayLinks.length - detailLimit} more\n`;
+      }
     } else {
       output += '- All clear ✓\n';
     }

--- a/tests/pi-extension.test.ts
+++ b/tests/pi-extension.test.ts
@@ -275,7 +275,11 @@ Related notes:
 - Embedded: 60/62 notes (2 missing)
 
 ## Link Health
-- Issues: 3 unlinked, 1 broken (run \`knowledge-maintain link-health\` for details)
+- Issues: 3 unlinked, 1 broken
+- Scoped unlinked notes:
+  - "Private orphan" [2026071801234504]
+- Scoped broken links:
+  - "Project source" [2026071801234505] content:12 → [[projects/private/secret]]
 
 ## Staleness
 - 0–7d: 25
@@ -349,10 +353,14 @@ Related notes:
     expect(healthCollapsed).toContain('2 preferences · 3 decisions · 2 observations · 1 reference');
     expect(healthCollapsed).toContain('60/62 embedded');
     expect(healthCollapsed).toContain('Issues: 3 unlinked, 1 broken');
+    expect(healthCollapsed).not.toContain('Private orphan');
+    expect(healthCollapsed).not.toContain('projects/private/secret');
     const healthExpanded = render('knowledge-health', fixtures['knowledge-health'], true);
     for (const section of ['Health (62 notes)', 'Embeddings', 'Link Health', 'Staleness', 'Growth (last 30d)', 'Infrastructure', 'Version']) {
       expect(healthExpanded).toContain(section);
     }
+    expect(healthExpanded).toContain('Private orphan');
+    expect(healthExpanded).toContain('projects/private/secret');
   });
 
   it('renders remaining tools without raw markup in collapsed results', () => {

--- a/tests/project-knowledge-boundaries.test.ts
+++ b/tests/project-knowledge-boundaries.test.ts
@@ -73,6 +73,10 @@ describe('repository project knowledge boundaries', () => {
     const health = await handleHealth({ project: 'alpha' }, context.engine, context.config);
 
     expect(health).toContain('1 broken');
+    expect(health).toContain('Scoped broken links');
+    expect(health).toContain('Alpha source');
+    expect(health).toContain(`[[${targetPath}]]`);
+    expect(health).not.toContain('run `knowledge-maintain link-health` for details');
   });
 
   it('counts incoming global publication relations across project boundaries', () => {


### PR DESCRIPTION
## Summary

- include bounded scoped link-health details directly in `knowledge-health`
- make hidden cross-project link findings actionable without redirecting to the full-vault maintenance report
- add regression coverage for path-style hidden targets

Follow-up to #205 and review comment https://github.com/mrosnerr/open-zk-kb/pull/205#discussion_r3638118812. The initial v1.4.2 publish run was cancelled before publication so this correction can be included.

## Verification

- `bun run build`
- `bun run typecheck`
- `bun run lint` — 0 errors; 22 existing warnings
- `bun test` — 1,245 passed, 56 skipped

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mrosnerr/open-zk-kb/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

